### PR TITLE
Scan private_strategies/ in main.py and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ After this, use `uv run python <script>` to run anything — no manual `source .
 
 ## Writing a Strategy
 
-Create a `.py` file in the `strategies/` directory. It must expose three things at module level:
+Create a `.py` file in `strategies/` (for example strategies) or `private_strategies/` (for strategies you want to keep off git). It must expose three things at module level:
 
 ```python
 NAME = "my_strategy"           # shown in the menu
@@ -89,7 +89,7 @@ For custom strategy logic, subclass `Strategy` and `StrategyConfig` from `nautil
 make backtest
 ```
 
-This starts `main.py`, which scans `strategies/`, shows a numbered menu, and runs the selected strategy. Equivalent to `uv run python main.py`.
+This starts `main.py`, which scans `strategies/` and `private_strategies/`, shows a numbered menu, and runs the selected strategy. Equivalent to `uv run python main.py`.
 
 ## Testing
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Prediction market backtest runner.
 
-Discovers strategies in the strategies/ directory and presents an
-interactive menu. Each strategy file must expose:
+Discovers strategies in the strategies/ and private_strategies/ directories
+and presents an interactive menu. Each strategy file must expose:
 
     NAME        str   — display name shown in the menu
     DESCRIPTION str   — one-line description shown in the menu
@@ -20,7 +20,10 @@ import importlib
 import sys
 from pathlib import Path
 
-STRATEGIES_DIR = Path(__file__).parent / "strategies"
+STRATEGIES_DIRS = [
+    Path(__file__).parent / "strategies",
+    Path(__file__).parent / "private_strategies",
+]
 
 DIM = "\033[2m"
 BOLD = "\033[1m"
@@ -29,26 +32,29 @@ RESET = "\033[0m"
 
 
 def discover() -> list[dict]:
-    """Scan strategies/ for modules that expose NAME, DESCRIPTION, and run()."""
+    """Scan strategies/ and private_strategies/ for modules that expose NAME, DESCRIPTION, and run()."""
     found = []
-    for path in sorted(STRATEGIES_DIR.glob("*.py")):
-        if path.name.startswith("_"):
+    for strats_dir in STRATEGIES_DIRS:
+        if not strats_dir.exists():
             continue
-        mod_name = f"strategies.{path.stem}"
-        try:
-            mod = importlib.import_module(mod_name)
-        except Exception as exc:
-            print(f"{DIM}  Warning: could not import {path.name}: {exc}{RESET}")
-            continue
-        if not hasattr(mod, "run"):
-            continue
-        found.append(
-            {
-                "name": getattr(mod, "NAME", path.stem),
-                "description": getattr(mod, "DESCRIPTION", ""),
-                "run": mod.run,
-            }
-        )
+        for path in sorted(strats_dir.glob("*.py")):
+            if path.name.startswith("_"):
+                continue
+            mod_name = f"{strats_dir.name}.{path.stem}"
+            try:
+                mod = importlib.import_module(mod_name)
+            except Exception as exc:
+                print(f"{DIM}  Warning: could not import {path.name}: {exc}{RESET}")
+                continue
+            if not hasattr(mod, "run"):
+                continue
+            found.append(
+                {
+                    "name": getattr(mod, "NAME", path.stem),
+                    "description": getattr(mod, "DESCRIPTION", ""),
+                    "run": mod.run,
+                }
+            )
     return found
 
 
@@ -85,7 +91,7 @@ def main() -> None:
 
     if not strategies:
         print(
-            f"No strategies found in {STRATEGIES_DIR}/\n"
+            f"No strategies found in {' or '.join(str(d) for d in STRATEGIES_DIRS)}\n"
             "Create a .py file there that exposes NAME, DESCRIPTION, and an async run()."
         )
         sys.exit(1)


### PR DESCRIPTION
## Summary
- `main.py`: `STRATEGIES_DIR` → `STRATEGIES_DIRS` list; `discover()` iterates both `strategies/` and `private_strategies/`, skipping dirs that don't exist
- README: update *Writing a Strategy* and *Running a Backtest* sections to mention `private_strategies/`

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pytest tests/` — 4 passed
- [ ] Drop a `.py` file into `private_strategies/`, run `main.py`, confirm it appears in the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)