### PR TITLE
Fix Ruff formatting drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.5"
           args: check --exclude nautilus_pm
       - uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.5"
           args: format --check --exclude nautilus_pm

--- a/backtests/_kalshi_single_market_runner.py
+++ b/backtests/_kalshi_single_market_runner.py
@@ -128,7 +128,9 @@ async def run_single_market_bar_backtest(
     if closes:
         price_range = max(closes) - min(closes)
         if price_range < min_price_range:
-            print(f"Skip {market_ticker}: price range {price_range:.3f} < {min_price_range:.3f}")
+            print(
+                f"Skip {market_ticker}: price range {price_range:.3f} < {min_price_range:.3f}"
+            )
             return
 
     if not bars:

--- a/backtests/_polymarket_single_market_runner.py
+++ b/backtests/_polymarket_single_market_runner.py
@@ -71,7 +71,9 @@ async def run_single_market_trade_backtest(
     if prices:
         price_range = max(prices) - min(prices)
         if price_range < min_price_range:
-            print(f"Skip {market_slug}: price range {price_range:.3f} < {min_price_range:.3f}")
+            print(
+                f"Skip {market_slug}: price range {price_range:.3f} < {min_price_range:.3f}"
+            )
             return
 
     if not trades:

--- a/backtests/kalshi_ema_bars.py
+++ b/backtests/kalshi_ema_bars.py
@@ -114,7 +114,9 @@ async def fetch_and_catalog() -> None:
     catalog.write_data([loader.instrument])
     catalog.write_data(bars)
 
-    print(f"Wrote instrument {loader.instrument.id} and {len(bars)} bars to {CATALOG_PATH}")
+    print(
+        f"Wrote instrument {loader.instrument.id} and {len(bars)} bars to {CATALOG_PATH}"
+    )
 
 
 def run_backtest() -> None:

--- a/backtests/polymarket_deep_value_resolution_hold.py
+++ b/backtests/polymarket_deep_value_resolution_hold.py
@@ -22,10 +22,18 @@ import pandas as pd
 from nautilus_trader.adapters.polymarket import POLYMARKET_VENUE
 from nautilus_trader.adapters.polymarket import PolymarketDataLoader
 from nautilus_trader.adapters.polymarket.fee_model import PolymarketFeeModel
-from nautilus_trader.adapters.prediction_market.backtest_utils import build_market_prices
-from nautilus_trader.adapters.prediction_market.backtest_utils import extract_price_points
-from nautilus_trader.adapters.prediction_market.backtest_utils import extract_realized_pnl
-from nautilus_trader.adapters.prediction_market.backtest_utils import infer_realized_outcome
+from nautilus_trader.adapters.prediction_market.backtest_utils import (
+    build_market_prices,
+)
+from nautilus_trader.adapters.prediction_market.backtest_utils import (
+    extract_price_points,
+)
+from nautilus_trader.adapters.prediction_market.backtest_utils import (
+    extract_realized_pnl,
+)
+from nautilus_trader.adapters.prediction_market.backtest_utils import (
+    infer_realized_outcome,
+)
 from nautilus_trader.analysis.legacy_plot_adapter import create_legacy_backtest_chart
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
@@ -83,11 +91,19 @@ def _build_probability_frame(
             continue
         rows.append((ts, float(tick.price)))
 
-    frame = pd.DataFrame(rows, columns=["ts", "market_probability"]) if rows else pd.DataFrame()
+    frame = (
+        pd.DataFrame(rows, columns=["ts", "market_probability"])
+        if rows
+        else pd.DataFrame()
+    )
     if frame.empty:
         return frame
 
-    frame = frame.sort_values("ts").drop_duplicates(subset=["ts"], keep="last").set_index("ts")
+    frame = (
+        frame.sort_values("ts")
+        .drop_duplicates(subset=["ts"], keep="last")
+        .set_index("ts")
+    )
     frame["market_probability"] = frame["market_probability"].clip(0.0, 1.0)
 
     signal_mask = frame["market_probability"] <= entry_price_max

--- a/backtests/polymarket_simple_quoter.py
+++ b/backtests/polymarket_simple_quoter.py
@@ -40,7 +40,9 @@ from nautilus_trader.adapters.polymarket.fee_model import PolymarketFeeModel
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
 from nautilus_trader.examples.strategies.ema_cross_long_only import EMACrossLongOnly
-from nautilus_trader.examples.strategies.ema_cross_long_only import EMACrossLongOnlyConfig
+from nautilus_trader.examples.strategies.ema_cross_long_only import (
+    EMACrossLongOnlyConfig,
+)
 from nautilus_trader.model.currencies import USDC_POS
 from nautilus_trader.model.data import BarType
 from nautilus_trader.model.enums import AccountType

--- a/backtests/polymarket_sports_final_period_momentum.py
+++ b/backtests/polymarket_sports_final_period_momentum.py
@@ -23,11 +23,17 @@ from nautilus_trader.adapters.polymarket.common.market_selection import closed_t
 from nautilus_trader.adapters.polymarket.common.market_selection import end_date_utc
 from nautilus_trader.adapters.polymarket.research import analyze_market_trade_window
 from nautilus_trader.adapters.polymarket.research import discover_live_sports_markets
-from nautilus_trader.adapters.polymarket.research import discover_resolved_sports_markets
+from nautilus_trader.adapters.polymarket.research import (
+    discover_resolved_sports_markets,
+)
 from nautilus_trader.adapters.polymarket.research import fetch_market_by_slug
 from nautilus_trader.adapters.prediction_market.research import print_backtest_summary
-from nautilus_trader.adapters.prediction_market.research import save_aggregate_backtest_report
-from nautilus_trader.adapters.prediction_market.research import save_combined_backtest_report
+from nautilus_trader.adapters.prediction_market.research import (
+    save_aggregate_backtest_report,
+)
+from nautilus_trader.adapters.prediction_market.research import (
+    save_combined_backtest_report,
+)
 from nautilus_trader.core import nautilus_pyo3
 from strategies import (
     TradeTickFinalPeriodMomentumConfig,
@@ -180,8 +186,12 @@ async def _select_markets(*, candidate_limit: int) -> list[dict]:
 
 
 async def run() -> None:
-    target_results = min(TARGET_RESULTS, len(MARKET_SLUGS)) if MARKET_SLUGS else TARGET_RESULTS
-    candidate_budget = max(CANDIDATE_LIMIT, target_results * DISCOVERY_CANDIDATE_MULTIPLIER)
+    target_results = (
+        min(TARGET_RESULTS, len(MARKET_SLUGS)) if MARKET_SLUGS else TARGET_RESULTS
+    )
+    candidate_budget = max(
+        CANDIDATE_LIMIT, target_results * DISCOVERY_CANDIDATE_MULTIPLIER
+    )
     if not MARKET_SLUGS:
         candidate_budget = min(candidate_budget, MAX_DISCOVERY_RESULTS)
 
@@ -241,8 +251,16 @@ async def run() -> None:
                 print(f"Skip {slug}: market close time unavailable")
                 continue
 
-            first_text = f"{float(first_activation_price):.2f}" if first_activation_price is not None else "n/a"
-            max_text = f"{float(max_activation_price):.2f}" if max_activation_price is not None else "n/a"
+            first_text = (
+                f"{float(first_activation_price):.2f}"
+                if first_activation_price is not None
+                else "n/a"
+            )
+            max_text = (
+                f"{float(max_activation_price):.2f}"
+                if max_activation_price is not None
+                else "n/a"
+            )
             print(
                 f"Running {slug} on token_index={token_index} "
                 f"outcome={token_outcome or 'n/a'} "
@@ -301,7 +319,9 @@ async def run() -> None:
         candidate_budget = min(candidate_budget + DISCOVERY_STEP, MAX_DISCOVERY_RESULTS)
 
     if not results:
-        print("No Polymarket sports markets had sufficient data for the current filters.")
+        print(
+            "No Polymarket sports markets had sufficient data for the current filters."
+        )
         return
 
     if len(results) < target_results:

--- a/strategies/core.py
+++ b/strategies/core.py
@@ -45,7 +45,9 @@ class LongOnlyPredictionMarketStrategy(Strategy):
     def on_start(self) -> None:
         self._instrument = self.cache.instrument(self.config.instrument_id)
         if self._instrument is None:
-            self.log.error(f"Instrument {self.config.instrument_id} not found - stopping.")
+            self.log.error(
+                f"Instrument {self.config.instrument_id} not found - stopping."
+            )
             self.stop()
             return
         self._subscribe()

--- a/strategies/ema_crossover.py
+++ b/strategies/ema_crossover.py
@@ -68,7 +68,9 @@ class _EMACrossoverBase(LongOnlyPredictionMarketStrategy):
         self._fast_ema: float | None = None
         self._slow_ema: float | None = None
         self._warmup: int = 0
-        self._warmup_needed = max(int(self.config.fast_period), int(self.config.slow_period))
+        self._warmup_needed = max(
+            int(self.config.fast_period), int(self.config.slow_period)
+        )
         self._alpha_fast = 2.0 / (float(self.config.fast_period) + 1.0)
         self._alpha_slow = 2.0 / (float(self.config.slow_period) + 1.0)
 
@@ -79,8 +81,12 @@ class _EMACrossoverBase(LongOnlyPredictionMarketStrategy):
             self._warmup = 1
             return
 
-        self._fast_ema = self._alpha_fast * price + (1.0 - self._alpha_fast) * self._fast_ema
-        self._slow_ema = self._alpha_slow * price + (1.0 - self._alpha_slow) * self._slow_ema
+        self._fast_ema = (
+            self._alpha_fast * price + (1.0 - self._alpha_fast) * self._fast_ema
+        )
+        self._slow_ema = (
+            self._alpha_slow * price + (1.0 - self._alpha_slow) * self._slow_ema
+        )
         self._warmup += 1
 
         if self._warmup < self._warmup_needed or self._pending:

--- a/strategies/final_period_momentum.py
+++ b/strategies/final_period_momentum.py
@@ -96,7 +96,9 @@ class _FinalPeriodMomentumBase(LongOnlyPredictionMarketStrategy):
             self._submit_exit()
             return
 
-        if price >= float(self.config.take_profit_price) or price <= float(self.config.stop_loss_price):
+        if price >= float(self.config.take_profit_price) or price <= float(
+            self.config.stop_loss_price
+        ):
             self._submit_exit()
 
     def on_reset(self) -> None:

--- a/strategies/panic_fade.py
+++ b/strategies/panic_fade.py
@@ -86,7 +86,9 @@ class _PanicFadeBase(LongOnlyPredictionMarketStrategy):
                 return
             peak = max(self._prices)
             drop = peak - price
-            if price <= float(self.config.panic_price) and drop >= float(self.config.min_drop):
+            if price <= float(self.config.panic_price) and drop >= float(
+                self.config.min_drop
+            ):
                 self._submit_entry()
             return
 

--- a/strategies/threshold_momentum.py
+++ b/strategies/threshold_momentum.py
@@ -93,7 +93,9 @@ class _ThresholdMomentumBase(LongOnlyPredictionMarketStrategy):
             self._submit_exit()
             return
 
-        if price >= float(self.config.take_profit_price) or price <= float(self.config.stop_loss_price):
+        if price >= float(self.config.take_profit_price) or price <= float(
+            self.config.stop_loss_price
+        ):
             self._submit_exit()
 
     def on_reset(self) -> None:

--- a/strategies/vwap_reversion.py
+++ b/strategies/vwap_reversion.py
@@ -43,7 +43,9 @@ class TradeTickVWAPReversionStrategy(LongOnlyPredictionMarketStrategy):
 
     def __init__(self, config: TradeTickVWAPReversionConfig) -> None:
         super().__init__(config)
-        self._window: deque[tuple[float, float]] = deque(maxlen=int(self.config.vwap_window))
+        self._window: deque[tuple[float, float]] = deque(
+            maxlen=int(self.config.vwap_window)
+        )
         self._weighted_sum: float = 0.0
         self._size_sum: float = 0.0
 


### PR DESCRIPTION
## Summary
- run Ruff 0.15.5 across the repo (excluding `nautilus_pm`)
- pin CI to Ruff 0.15.5 so formatter behavior stops drifting

## Verification
- `uvx ruff==0.15.5 check --exclude nautilus_pm .`
- `uvx ruff==0.15.5 format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`