### PR TITLE
Expand LGPL notice coverage

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -26,6 +26,7 @@ notices with file-specific change dates:
 - `backtests/_defaults.py`
 - `backtests/_kalshi_single_market_runner.py`
 - `backtests/_kalshi_single_market_trade_runner.py`
+- `backtests/_polymarket_single_market_pmxt_runner.py`
 - `backtests/_polymarket_single_market_runner.py`
 - `backtests/_script_helpers.py`
 - `backtests/kalshi_breakout.py`
@@ -36,10 +37,22 @@ notices with file-specific change dates:
 - `backtests/kalshi_spread_capture.py`
 - `backtests/polymarket_deep_value_resolution_hold.py`
 - `backtests/polymarket_ema_crossover.py`
+- `backtests/polymarket_pmxt_breakout.py`
+- `backtests/polymarket_pmxt_deep_value_hold.py`
+- `backtests/polymarket_pmxt_ema_crossover.py`
+- `backtests/polymarket_pmxt_final_period_momentum.py`
+- `backtests/polymarket_pmxt_late_favorite_limit_hold.py`
+- `backtests/polymarket_pmxt_panic_fade.py`
+- `backtests/polymarket_pmxt_rsi_reversion.py`
+- `backtests/polymarket_pmxt_spread_capture.py`
+- `backtests/polymarket_pmxt_threshold_momentum.py`
+- `backtests/polymarket_pmxt_vwap_reversion.py`
 - `backtests/polymarket_panic_fade.py`
 - `backtests/polymarket_rsi_reversion.py`
 - `backtests/polymarket_simple_quoter.py`
 - `backtests/polymarket_sports_final_period_momentum.py`
+- `backtests/polymarket_sports_late_favorite_limit_hold.py`
+- `backtests/polymarket_sports_vwap_reversion.py`
 - `backtests/polymarket_spread_capture.py`
 - `backtests/polymarket_vwap_reversion.py`
 - `strategies/__init__.py`
@@ -48,34 +61,49 @@ notices with file-specific change dates:
 - `strategies/deep_value.py`
 - `strategies/ema_crossover.py`
 - `strategies/final_period_momentum.py`
+- `strategies/late_favorite_limit_hold.py`
 - `strategies/mean_reversion.py`
 - `strategies/panic_fade.py`
 - `strategies/rsi_reversion.py`
 - `strategies/threshold_momentum.py`
 - `strategies/vwap_reversion.py`
 - `tests/test_backtest_utils.py`
+- `tests/test_legacy_plot_fill_markers.py`
+- `tests/test_quote_tick_strategy_configs.py`
+- `tests/test_legacy_plot_fill_markers.py`
+- `tests/test_quote_tick_strategy_configs.py`
 
-Current modifications to upstream NautilusTrader files
-------------------------------------------------------
+Local modifications inside the vendored NautilusTrader subtree
+--------------------------------------------------------------
 
-The following upstream NautilusTrader files in the vendored subtree were
-modified in this repository and now carry dated modification notices:
+Python files changed in this repository since the original subtree import now
+carry dated file-level notices. That includes modified upstream files and local
+additions under:
+
+- `nautilus_pm/examples/backtest/prediction_markets/`
+- `nautilus_pm/nautilus_trader/adapters/kalshi/`
+- `nautilus_pm/nautilus_trader/adapters/polymarket/`
+- `nautilus_pm/nautilus_trader/adapters/prediction_market/`
+- `nautilus_pm/nautilus_trader/analysis/`
+- `nautilus_pm/nautilus_trader/examples/strategies/prediction_market/`
+- `nautilus_pm/tests/integration_tests/adapters/polymarket/`
+- `nautilus_pm/tests/unit_tests/adapters/kalshi/`
+- `nautilus_pm/tests/unit_tests/adapters/prediction_market/`
+- `nautilus_pm/tests/unit_tests/analysis/`
+- `nautilus_pm/tests/unit_tests/examples/strategies/`
+
+Examples:
 
 - `nautilus_pm/nautilus_trader/adapters/polymarket/__init__.py`
   Modified on 2026-03-11 and 2026-03-15.
-- `nautilus_pm/nautilus_trader/adapters/prediction_market/backtest_utils.py`
-  Modified on 2026-03-11 and 2026-03-15.
+- `nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py`
+  Added locally on 2026-03-15 within the LGPL-covered subtree.
 - `nautilus_pm/nautilus_trader/adapters/prediction_market/research.py`
   Modified on 2026-03-11, 2026-03-15, and 2026-03-16.
-- `nautilus_pm/nautilus_trader/analysis/legacy_plot_adapter.py`
-  Modified on 2026-03-11 and 2026-03-16.
-
-Local additions inside the LGPL-covered subtree
------------------------------------------------
-
-- `nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py`
-  Added locally on 2026-03-15 within the NautilusTrader-derived subtree and
-  distributed under LGPL-3.0-or-later.
+- `nautilus_pm/nautilus_trader/examples/strategies/prediction_market/core.py`
+  Modified on 2026-03-11.
+- `nautilus_pm/examples/backtest/prediction_markets/polymarket_ema_crossover.py`
+  Modified on 2026-03-11.
 
 Upstream lineage
 ----------------

--- a/backtests/_polymarket_single_market_pmxt_runner.py
+++ b/backtests/_polymarket_single_market_pmxt_runner.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11 and 2026-03-15.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Shared runner for single-market Polymarket PMXT L2 backtests.
 """

--- a/backtests/polymarket_pmxt_breakout.py
+++ b/backtests/polymarket_pmxt_breakout.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Breakout strategy on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_deep_value_hold.py
+++ b/backtests/polymarket_pmxt_deep_value_hold.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Deep-value hold strategy on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_ema_crossover.py
+++ b/backtests/polymarket_pmxt_ema_crossover.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 EMA crossover momentum on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_final_period_momentum.py
+++ b/backtests/polymarket_pmxt_final_period_momentum.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Final-period momentum on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_late_favorite_limit_hold.py
+++ b/backtests/polymarket_pmxt_late_favorite_limit_hold.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Late-favorite limit hold on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_panic_fade.py
+++ b/backtests/polymarket_pmxt_panic_fade.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Panic-fade strategy on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_rsi_reversion.py
+++ b/backtests/polymarket_pmxt_rsi_reversion.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 RSI-reversion strategy on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_spread_capture.py
+++ b/backtests/polymarket_pmxt_spread_capture.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Mean-reversion spread capture on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_threshold_momentum.py
+++ b/backtests/polymarket_pmxt_threshold_momentum.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Threshold momentum on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_pmxt_vwap_reversion.py
+++ b/backtests/polymarket_pmxt_vwap_reversion.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11 and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 VWAP-reversion strategy on one Polymarket market using PMXT historical L2 data.
 """

--- a/backtests/polymarket_sports_late_favorite_limit_hold.py
+++ b/backtests/polymarket_sports_late_favorite_limit_hold.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Run a resolved 50-market Polymarket sports basket using a late-favorite limit hold.
 

--- a/backtests/polymarket_sports_vwap_reversion.py
+++ b/backtests/polymarket_sports_vwap_reversion.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11 and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 VWAP reversion on multiple Polymarket sports markets.
 

--- a/nautilus_pm/conftest.py
+++ b/nautilus_pm/conftest.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 # Root-level conftest.py
 #
 # NautilusTrader requires compiled Cython extensions that live in the installed

--- a/nautilus_pm/examples/backtest/prediction_markets/_defaults.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/_defaults.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Shared defaults for prediction-market backtest scripts.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/_kalshi_single_market_runner.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/_kalshi_single_market_runner.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Shared runner for single-market Kalshi bar backtests.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/_kalshi_single_market_trade_runner.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/_kalshi_single_market_trade_runner.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Shared runner for single-market Kalshi trade-tick backtests.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/_polymarket_single_market_runner.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/_polymarket_single_market_runner.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Shared runner for single-market Polymarket trade-tick backtests.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/_script_helpers.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/_script_helpers.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 

--- a/nautilus_pm/examples/backtest/prediction_markets/kalshi_breakout.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/kalshi_breakout.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Breakout strategy on one Kalshi market.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/kalshi_ema_bars.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/kalshi_ema_bars.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 #!/usr/bin/env python3
 # -------------------------------------------------------------------------------------------------
 #  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.

--- a/nautilus_pm/examples/backtest/prediction_markets/kalshi_ema_crossover.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/kalshi_ema_crossover.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 EMA-crossover momentum strategy on one Kalshi market.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/kalshi_panic_fade.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/kalshi_panic_fade.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Panic-fade strategy on one Kalshi market.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/kalshi_rsi_reversion.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/kalshi_rsi_reversion.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 RSI-reversion strategy on one Kalshi market.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/kalshi_spread_capture.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/kalshi_spread_capture.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Bar-based mean-reversion (spread capture) on one Kalshi market.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_deep_value_resolution_hold.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_deep_value_resolution_hold.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Deep-value Polymarket strategy: buy low-priced outcomes and hold.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_ema_crossover.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_ema_crossover.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 EMA-crossover momentum on one Polymarket market.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_panic_fade.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_panic_fade.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Panic-fade strategy on one Polymarket market.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_rsi_reversion.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_rsi_reversion.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 RSI-reversion strategy on one Polymarket market.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_simple_quoter.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_simple_quoter.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 #!/usr/bin/env python3
 # -------------------------------------------------------------------------------------------------
 #  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_sports_final_period_momentum.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_sports_final_period_momentum.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Public multi-market example: run a late-breakout sports strategy across many Polymarket markets.
 

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_spread_capture.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_spread_capture.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Mean-reversion spread capture on one Polymarket market.
 """

--- a/nautilus_pm/examples/backtest/prediction_markets/polymarket_vwap_reversion.py
+++ b/nautilus_pm/examples/backtest/prediction_markets/polymarket_vwap_reversion.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 VWAP-reversion strategy on one Polymarket market.
 """

--- a/nautilus_pm/main.py
+++ b/nautilus_pm/main.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 #!/usr/bin/env python3
 """
 Backtest runner - interactive strategy menu.

--- a/nautilus_pm/nautilus_trader/adapters/kalshi/data.py
+++ b/nautilus_pm/nautilus_trader/adapters/kalshi/data.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/kalshi/fee_model.py
+++ b/nautilus_pm/nautilus_trader/adapters/kalshi/fee_model.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/kalshi/loaders.py
+++ b/nautilus_pm/nautilus_trader/adapters/kalshi/loaders.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 """
 Provides a data loader for historical Kalshi prediction market data.
 """

--- a/nautilus_pm/nautilus_trader/adapters/kalshi/market_selection.py
+++ b/nautilus_pm/nautilus_trader/adapters/kalshi/market_selection.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/kalshi/providers.py
+++ b/nautilus_pm/nautilus_trader/adapters/kalshi/providers.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/kalshi/research.py
+++ b/nautilus_pm/nautilus_trader/adapters/kalshi/research.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/common/gamma_markets.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/common/gamma_markets.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 """
 Thin Gamma Markets API client utilities for Polymarket.
 

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/common/market_selection.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/common/market_selection.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/common/parsing.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/common/parsing.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import time
 from decimal import Decimal

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/execution.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/execution.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import asyncio
 import json

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/fee_model.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/fee_model.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/loaders.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/loaders.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 """
 Provides data loaders for historical Polymarket data from various APIs.
 """

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/research.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/research.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/schemas/trade.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/schemas/trade.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from decimal import Decimal
 from typing import Any

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/schemas/user.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/schemas/user.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from decimal import Decimal
 from typing import Any

--- a/nautilus_pm/nautilus_trader/adapters/prediction_market/__init__.py
+++ b/nautilus_pm/nautilus_trader/adapters/prediction_market/__init__.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """
 Shared prediction-market adapter helpers.

--- a/nautilus_pm/nautilus_trader/adapters/prediction_market/fill_model.py
+++ b/nautilus_pm/nautilus_trader/adapters/prediction_market/fill_model.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/nautilus_pm/nautilus_trader/analysis/__init__.py
+++ b/nautilus_pm/nautilus_trader/analysis/__init__.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 """
 The `analysis` subpackage groups components relating to trading performance statistics
 and analysis.

--- a/nautilus_pm/nautilus_trader/analysis/config.py
+++ b/nautilus_pm/nautilus_trader/analysis/config.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 """
 Configuration for tearsheet generation and visualization.
 """

--- a/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/__init__.py
+++ b/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/__init__.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """
 Vendored legacy prediction-market plotting package.
 """

--- a/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/models.py
+++ b/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/models.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """Unified, platform-agnostic data types for the backtesting engine.
 
 All prices are normalized to float in [0.0, 1.0]. Kalshi cents are divided

--- a/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/plotting.py
+++ b/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/plotting.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """Interactive Bokeh-based plotting for prediction-market backtest results.
 
 Produces a minitrade-style multi-panel interactive chart:

--- a/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/progress.py
+++ b/nautilus_pm/nautilus_trader/analysis/legacy_backtesting/progress.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 """Flicker-free progress bar using ANSI scroll regions.
 
 Reserves the bottom line of the terminal for a pinned status bar.

--- a/nautilus_pm/nautilus_trader/analysis/tearsheet.py
+++ b/nautilus_pm/nautilus_trader/analysis/tearsheet.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 """
 Backtest visualization and tearsheet generation using Plotly.
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/__init__.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/__init__.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """
 Prediction market strategy examples.

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/breakout.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/breakout.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/core.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/core.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/deep_value.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/deep_value.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/ema_crossover.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/ema_crossover.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/final_period_momentum.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/final_period_momentum.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/mean_reversion.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/mean_reversion.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/panic_fade.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/panic_fade.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/rsi_reversion.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/rsi_reversion.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/threshold_momentum.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/threshold_momentum.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/vwap_reversion.py
+++ b/nautilus_pm/nautilus_trader/examples/strategies/prediction_market/vwap_reversion.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/tests/integration_tests/adapters/polymarket/test_loaders.py
+++ b/nautilus_pm/tests/integration_tests/adapters/polymarket/test_loaders.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import pkgutil
 from decimal import Decimal

--- a/nautilus_pm/tests/integration_tests/adapters/polymarket/test_parsing.py
+++ b/nautilus_pm/tests/integration_tests/adapters/polymarket/test_parsing.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import pkgutil
 from decimal import Decimal

--- a/nautilus_pm/tests/unit_tests/adapters/kalshi/test_data.py
+++ b/nautilus_pm/tests/unit_tests/adapters/kalshi/test_data.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/nautilus_pm/tests/unit_tests/adapters/kalshi/test_fee_model.py
+++ b/nautilus_pm/tests/unit_tests/adapters/kalshi/test_fee_model.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """Unit tests for KalshiProportionalFeeModel."""
 

--- a/nautilus_pm/tests/unit_tests/adapters/kalshi/test_loaders.py
+++ b/nautilus_pm/tests/unit_tests/adapters/kalshi/test_loaders.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import decimal
 from unittest.mock import AsyncMock

--- a/nautilus_pm/tests/unit_tests/adapters/kalshi/test_providers.py
+++ b/nautilus_pm/tests/unit_tests/adapters/kalshi/test_providers.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import decimal
 from datetime import UTC

--- a/nautilus_pm/tests/unit_tests/adapters/prediction_market/test_backtest_utils.py
+++ b/nautilus_pm/tests/unit_tests/adapters/prediction_market/test_backtest_utils.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/nautilus_pm/tests/unit_tests/adapters/prediction_market/test_fill_model.py
+++ b/nautilus_pm/tests/unit_tests/adapters/prediction_market/test_fill_model.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 import decimal

--- a/nautilus_pm/tests/unit_tests/adapters/prediction_market/test_research.py
+++ b/nautilus_pm/tests/unit_tests/adapters/prediction_market/test_research.py
@@ -1,3 +1,8 @@
+# Derived from or added to the NautilusTrader subtree in this repository.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/nautilus_pm/tests/unit_tests/analysis/test_legacy_plot_adapter.py
+++ b/nautilus_pm/tests/unit_tests/analysis/test_legacy_plot_adapter.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/nautilus_pm/tests/unit_tests/analysis/test_tearsheet.py
+++ b/nautilus_pm/tests/unit_tests/analysis/test_tearsheet.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import numpy as np
 import pandas as pd

--- a/nautilus_pm/tests/unit_tests/common/test_clock.py
+++ b/nautilus_pm/tests/unit_tests/common/test_clock.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 import re
 import time

--- a/nautilus_pm/tests/unit_tests/examples/strategies/test_kalshi_final_period_momentum.py
+++ b/nautilus_pm/tests/unit_tests/examples/strategies/test_kalshi_final_period_momentum.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """End-to-end tests for the Kalshi final-period momentum strategy."""
 

--- a/nautilus_pm/tests/unit_tests/examples/strategies/test_kalshi_spread_capture.py
+++ b/nautilus_pm/tests/unit_tests/examples/strategies/test_kalshi_spread_capture.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """End-to-end tests for the Kalshi BarMeanReversion spread capture strategy."""
 

--- a/nautilus_pm/tests/unit_tests/examples/strategies/test_kalshi_threshold_momentum.py
+++ b/nautilus_pm/tests/unit_tests/examples/strategies/test_kalshi_threshold_momentum.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """End-to-end tests for the Kalshi threshold momentum strategy."""
 

--- a/nautilus_pm/tests/unit_tests/examples/strategies/test_polymarket_spread_capture.py
+++ b/nautilus_pm/tests/unit_tests/examples/strategies/test_polymarket_spread_capture.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 """End-to-end tests for the Polymarket SpreadCapture strategy."""
 

--- a/nautilus_pm/tests/unit_tests/examples/strategies/test_prediction_market_strategy_configs.py
+++ b/nautilus_pm/tests/unit_tests/examples/strategies/test_prediction_market_strategy_configs.py
@@ -11,6 +11,9 @@
 #  KIND, either express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 # -------------------------------------------------------------------------------------------------
+#  Modified by Evan Kolberg in this repository on 2026-03-11.
+#  See the repository NOTICE file for provenance and licensing scope.
+#
 
 from __future__ import annotations
 

--- a/strategies/late_favorite_limit_hold.py
+++ b/strategies/late_favorite_limit_hold.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-11 and 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/tests/test_legacy_plot_fill_markers.py
+++ b/tests/test_legacy_plot_fill_markers.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market test code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 from datetime import UTC

--- a/tests/test_quote_tick_strategy_configs.py
+++ b/tests/test_quote_tick_strategy_configs.py
@@ -1,3 +1,8 @@
+# Derived from NautilusTrader prediction-market test code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-16.
+# See the repository NOTICE file for provenance and licensing scope.
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary
- add dated notices to the remaining Nautilus-derived root runners and strategy variants
- add dated notices to every Python file changed inside nautilus_pm/ since the original subtree import
- update NOTICE so the subtree coverage is described by the full modified scope instead of a hand-picked subset

## Testing
- uv run pytest tests