### PR TITLE
Improve PMXT loader throughput and cache docs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -95,7 +95,8 @@ Examples:
 - `nautilus_pm/nautilus_trader/adapters/polymarket/__init__.py`
   Modified on 2026-03-11 and 2026-03-15.
 - `nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py`
-  Added locally on 2026-03-15 within the LGPL-covered subtree.
+  Added locally on 2026-03-15 and modified on 2026-03-19 within the
+  LGPL-covered subtree.
 - `nautilus_pm/nautilus_trader/adapters/prediction_market/research.py`
   Modified on 2026-03-11, 2026-03-15, and 2026-03-16.
 - `nautilus_pm/nautilus_trader/examples/strategies/prediction_market/core.py`

--- a/README.md
+++ b/README.md
@@ -203,33 +203,95 @@ data are:
   - `LOOKBACK_HOURS=4` scans 6 hourly files
   - `LOOKBACK_HOURS=24` scans 26 hourly files
   - `LOOKBACK_HOURS=48` scans 50 hourly files
-- The loader filters to one market and one token, then keeps the filtered
-  `OrderBookDeltas` and `QuoteTick` records in memory for the current run.
-- There is no local PMXT cache in this repo yet. Separate PMXT runs re-download
-  and re-decode the same window.
-- Recent 2-hour sample on
+- For each hour, the loader opens the remote parquet file over HTTPS and pushes
+  down filters for:
+  - `market_id == <condition_id>`
+  - `update_type in {"book_snapshot", "price_change"}`
+- Remote HTTPS reads use in-memory readahead by default with `32 MiB` blocks to
+  reduce small-range-request overhead without writing raw PMXT files to disk.
+- The PMXT parquet schema does not expose `token_id` as its own column. The
+  token lives inside the JSON payload in the `data` column, so token filtering
+  happens after the market-level parquet scan.
+- The loader now processes filtered Arrow record batches incrementally instead
+  of materializing full hourly tables before decode, which reduces cold-load
+  Python overhead and peak memory during remote scans.
+- Each surviving JSON payload is decoded into Nautilus
+  `OrderBookDeltas`/`QuoteTick` records, and the backtest waits for that full
+  ingest to finish before strategy execution starts.
+- Local PMXT disk cache is optional. By default the loader remote-scans the
+  hourly parquet files and does not persist PMXT data to disk. If
+  `PMXT_CACHE_DIR` is set, the loader writes the filtered hourly parquet table
+  for one market/token/hour to:
+
+```text
+~/.cache/nautilus_trader/pmxt/<condition_id>/<token_id>/polymarket_orderbook_YYYY-MM-DDTHH.parquet
+```
+
+- Reuse rules:
+  - same market, same token, same hour: cache hit
+  - same market, same token, overlapping window: overlapping cached hours are reused
+  - same hour, different market: no reuse, because the cache key includes `condition_id`
+  - same market, different token/outcome: no reuse, because the cache key includes `token_id`
+- This means repeated runs of the same PMXT market can get much faster after
+  the first pass if disk cache is enabled, but multi-market runs still pay
+  separate remote reads for the same UTC hour because each market builds its
+  own filtered hourly cache.
+- The loader also prefetches multiple hours in parallel while still yielding
+  them back in chronological order. Configure that with
+  `PMXT_PREFETCH_WORKERS` (default `4`).
+- Cache controls:
+  - `PMXT_CACHE_DIR=1` enables disk cache at `~/.cache/nautilus_trader/pmxt`
+  - `PMXT_CACHE_DIR=/custom/path` enables disk cache at a custom root
+  - `PMXT_DISABLE_CACHE=1` disables local PMXT disk cache entirely
+  - `PMXT_PREFETCH_WORKERS=8` increases hourly prefetch parallelism
+  - `PMXT_HTTP_BLOCK_SIZE_MB=64` increases the in-memory HTTP readahead block size
+  - `PMXT_HTTP_CACHE_TYPE=bytes` switches the HTTP file cache strategy
+- Cache size is currently unbounded. There is no eviction policy or size cap.
+  If disk cache is enabled, it grows with the number of unique
+  `(condition_id, token_id, hour)` tuples you backtest. Very active markets and
+  long lookbacks will produce larger cached parquet files than quiet markets
+  and short windows. Check current size with:
+
+```bash
+du -sh ~/.cache/nautilus_trader/pmxt
+```
+
+- Example: turn on disk cache for a PMXT backtest and use the default cache
+  location:
+
+```bash
+PMXT_CACHE_DIR=1 END_TIME=2026-03-16T13:00:00Z LOOKBACK_HOURS=2 MIN_PRICE_RANGE=0 TRADE_SIZE=10 \
+  uv run python backtests/polymarket_pmxt_ema_crossover.py
+```
+
+- Validation on 2026-03-19 using the OpenAI hardware market
   `will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026`
-  (`END_TIME=2026-03-16T13:00:00Z`, `TRADE_SIZE=10`, HTML enabled):
-  - loader-only scan: `1286` quotes + `1286` delta batches in about `86s`
-  - end-to-end runs:
-    `ema_crossover` `176.214s`,
-    `rsi_reversion` `183.718s`,
-    `spread_capture` `173.466s`
-- Fixed quote-breakout sanity sample on the same market over 4 hours
-  (`2026-03-16T09:00:00Z` to `2026-03-16T13:00:00Z`, `TRADE_SIZE=10`,
-  `MIN_PRICE_RANGE=0`): `2484` quotes, `2` fills, `PnL -0.0350`
-- 48-hour sample on the same market
-  (`2026-03-14T13:00:00Z` to `2026-03-16T13:00:00Z`, `TRADE_SIZE=1`, HTML enabled):
-  - loader-only ingest: `1954.49s` (`32.57m`)
-  - files read: `50` unique hourly parquet files, `100` opens total
-  - ingress measured at the file-read layer: `18.277 GiB`
-  - filtered dataset size: `32819` quotes + `32819` delta batches
-  - strategy runtime after the data is already in memory:
-    `ema_crossover` `3.360s`,
-    `rsi_reversion` `3.325s`,
-    `spread_capture` `3.394s`
-  - if you run those PMXT modules separately today, each run still pays the
-    ~`32.6m` loader cost because the window is not cached locally
+  with `END_TIME=2026-03-16T13:00:00Z`, `LOOKBACK_HOURS=2`,
+  `MIN_PRICE_RANGE=0`, `TRADE_SIZE=10`, and `PMXT_CACHE_DIR=1`:
+  - the first `polymarket_pmxt_ema_crossover.py` run populated `4` cached
+    hourly parquet files in about `17.0s`
+  - the warmed cache footprint for that slice was about `116 KB`
+  - all `backtests/polymarket_pmxt_*.py` entrypoints then exited `0` on the
+    same cached slice
+  - warm cached end-to-end runtimes ranged from about `2.0s` to `3.1s`
+  - each validated PMXT backtest loaded `1286` quotes on that slice
+- Validation on 2026-03-19 using the same market over 48 hours
+  (`END_TIME=2026-03-16T13:00:00Z`, `LOOKBACK_HOURS=48`,
+  `MIN_PRICE_RANGE=0`, `TRADE_SIZE=1`, `PMXT_CACHE_DIR=1`):
+  - the first `polymarket_pmxt_ema_crossover.py` run populated `50` cached
+    hourly parquet files in about `12m 50s` end to end
+  - the warmed cache footprint for that full 48-hour slice was about `1.6 MB`
+  - fresh warm cached end-to-end reruns on the same slice:
+    `ema_crossover` about `1.1s` with `32819` quotes, `26` fills, `PnL -0.0880`
+    `rsi_reversion` about `2.1s` with `32819` quotes, `198` fills, `PnL -0.3610`
+    `spread_capture` about `1.0s` with `32819` quotes, `50` fills, `PnL -0.1808`
+  - repeated runs of that same market/token/window can now reuse overlapping
+    cached hours from local disk instead of re-downloading them
+  - different markets covering the same UTC hours still do not share cache
+    entries, because the cache is market/token scoped
+- Cold uncached PMXT runs still have to remote-scan every unique hour in the
+  requested window, so first-run load time remains dominated by PMXT archive
+  access even after the batch-streaming and HTTP readahead improvements.
 - Short windows can still fail if the selected range never includes usable L2
   book state for that instrument.
 
@@ -303,7 +365,7 @@ Unlike git submodules, subtrees copy upstream code directly into this repo — t
 ## Known Issues
 
 - [ ] APIs rate-limit a lot. Kalshi seems worse. (for trade tick config)
-- [ ] Pulling L2 data from PMXT archives takes an insane amount of time (and data)
+- [ ] Cold PMXT L2 loads still take a long time; multi-market runs do not yet share a raw per-hour cache, and optional filtered-disk-cache growth is currently unbounded
 
 ## License
 

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py
@@ -1,16 +1,27 @@
 # Added by Evan Kolberg to the NautilusTrader-derived subtree on 2026-03-15.
+# Modified in this repository on 2026-03-19.
 # Distributed under the GNU Lesser General Public License Version 3.0 or later.
 # See the repository NOTICE file for provenance and licensing scope.
 
 from __future__ import annotations
 
+import os
+import re
+from collections.abc import Iterator
+from concurrent.futures import Future
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from datetime import UTC
+from pathlib import Path
 
 import fsspec
 import msgspec
 import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.dataset as ds
 import pyarrow.fs as pafs
+import pyarrow.parquet as pq
 
 from nautilus_trader.adapters.polymarket.common.enums import PolymarketOrderSide
 from nautilus_trader.adapters.polymarket.loaders import PolymarketDataLoader
@@ -18,7 +29,6 @@ from nautilus_trader.adapters.polymarket.schemas.book import PolymarketBookLevel
 from nautilus_trader.adapters.polymarket.schemas.book import PolymarketBookSnapshot
 from nautilus_trader.adapters.polymarket.schemas.book import PolymarketQuote
 from nautilus_trader.adapters.polymarket.schemas.book import PolymarketQuotes
-from nautilus_trader.core.datetime import nanos_to_secs
 from nautilus_trader.model.book import OrderBook
 from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import QuoteTick
@@ -50,6 +60,10 @@ class _PMXTPriceChangePayload(msgspec.Struct, frozen=True):
     change_side: str
 
 
+_PMXT_BOOK_SNAPSHOT_DECODER = msgspec.json.Decoder(type=_PMXTBookSnapshotPayload)
+_PMXT_PRICE_CHANGE_DECODER = msgspec.json.Decoder(type=_PMXTPriceChangePayload)
+
+
 class PolymarketPMXTDataLoader(PolymarketDataLoader):
     """
     Historical Polymarket L2 loader backed by the PMXT hourly archive.
@@ -62,18 +76,31 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
     """
 
     _PMXT_BASE_URL = "https://r2.pmxt.dev"
-    _PMXT_COLUMNS = [
-        "timestamp_received",
+    _PMXT_REMOTE_COLUMNS = [
         "market_id",
         "update_type",
         "data",
     ]
+    _PMXT_COLUMNS = [
+        "update_type",
+        "data",
+    ]
+    _PMXT_CACHE_DIR_ENV = "PMXT_CACHE_DIR"
+    _PMXT_DISABLE_CACHE_ENV = "PMXT_DISABLE_CACHE"
+    _PMXT_PREFETCH_WORKERS_ENV = "PMXT_PREFETCH_WORKERS"
+    _PMXT_HTTP_BLOCK_SIZE_MB_ENV = "PMXT_HTTP_BLOCK_SIZE_MB"
+    _PMXT_HTTP_CACHE_TYPE_ENV = "PMXT_HTTP_CACHE_TYPE"
+    _PMXT_DEFAULT_PREFETCH_WORKERS = 4
+    _PMXT_DEFAULT_HTTP_BLOCK_SIZE = 32 * 1024 * 1024
+    _PMXT_DEFAULT_HTTP_CACHE_TYPE = "readahead"
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
-        self._pmxt_fs = pafs.PyFileSystem(
-            pafs.FSSpecHandler(fsspec.filesystem("https")),
-        )
+        self._pmxt_cache_dir = self._resolve_cache_dir()
+        self._pmxt_prefetch_workers = self._resolve_prefetch_workers()
+        self._pmxt_http_block_size = self._resolve_http_block_size()
+        self._pmxt_http_cache_type = self._resolve_http_cache_type()
+        self._reset_http_filesystem()
 
     @staticmethod
     def _normalize_timestamp(value: pd.Timestamp | str | None) -> pd.Timestamp | None:
@@ -98,12 +125,365 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         return hours
 
     @classmethod
-    def _archive_url_for_hour(cls, hour: pd.Timestamp) -> str:
+    def _archive_filename_for_hour(cls, hour: pd.Timestamp) -> str:
         ts = hour.tz_convert(UTC)
-        return (
-            f"{cls._PMXT_BASE_URL}/polymarket_orderbook_"
-            f"{ts.strftime('%Y-%m-%dT%H')}.parquet"
+        return f"polymarket_orderbook_{ts.strftime('%Y-%m-%dT%H')}.parquet"
+
+    @classmethod
+    def _archive_url_for_hour(cls, hour: pd.Timestamp) -> str:
+        return f"{cls._PMXT_BASE_URL}/{cls._archive_filename_for_hour(hour)}"
+
+    @staticmethod
+    def _env_flag_enabled(value: str | None) -> bool:
+        if value is None:
+            return False
+        return value.strip().casefold() in {"1", "true", "yes", "on"}
+
+    @classmethod
+    def _default_cache_dir(cls) -> Path:
+        xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+        base_dir = Path(xdg_cache_home).expanduser() if xdg_cache_home else Path.home() / ".cache"
+        return base_dir / "nautilus_trader" / "pmxt"
+
+    @classmethod
+    def _resolve_cache_dir(cls) -> Path | None:
+        if cls._env_flag_enabled(os.getenv(cls._PMXT_DISABLE_CACHE_ENV)):
+            return None
+
+        configured = os.getenv(cls._PMXT_CACHE_DIR_ENV)
+        if configured is None:
+            return None
+
+        value = configured.strip()
+        if not value or value.casefold() in {"0", "false", "no", "off", "none", "disabled"}:
+            return None
+        if value.casefold() in {"1", "true", "yes", "on", "default"}:
+            return cls._default_cache_dir()
+        return Path(value).expanduser()
+
+    @classmethod
+    def _resolve_prefetch_workers(cls) -> int:
+        configured = os.getenv(cls._PMXT_PREFETCH_WORKERS_ENV)
+        if configured is None:
+            return cls._PMXT_DEFAULT_PREFETCH_WORKERS
+
+        value = configured.strip()
+        if not value:
+            return cls._PMXT_DEFAULT_PREFETCH_WORKERS
+
+        try:
+            return max(1, int(value))
+        except ValueError:
+            return cls._PMXT_DEFAULT_PREFETCH_WORKERS
+
+    @classmethod
+    def _resolve_http_block_size(cls) -> int:
+        configured = os.getenv(cls._PMXT_HTTP_BLOCK_SIZE_MB_ENV)
+        if configured is None:
+            return cls._PMXT_DEFAULT_HTTP_BLOCK_SIZE
+
+        value = configured.strip()
+        if not value:
+            return cls._PMXT_DEFAULT_HTTP_BLOCK_SIZE
+
+        try:
+            return max(1, int(value)) * 1024 * 1024
+        except ValueError:
+            return cls._PMXT_DEFAULT_HTTP_BLOCK_SIZE
+
+    @classmethod
+    def _resolve_http_cache_type(cls) -> str:
+        configured = os.getenv(cls._PMXT_HTTP_CACHE_TYPE_ENV)
+        if configured is None:
+            return cls._PMXT_DEFAULT_HTTP_CACHE_TYPE
+
+        value = configured.strip()
+        return value or cls._PMXT_DEFAULT_HTTP_CACHE_TYPE
+
+    def _reset_http_filesystem(self) -> None:
+        self._pmxt_http_fs = fsspec.filesystem(
+            "https",
+            block_size=self._pmxt_http_block_size,
+            cache_type=self._pmxt_http_cache_type,
         )
+        self._pmxt_fs = pafs.PyFileSystem(
+            pafs.FSSpecHandler(self._pmxt_http_fs),
+        )
+
+    @classmethod
+    def _market_cache_path_for_hour(
+        cls,
+        cache_dir: Path,
+        condition_id: str,
+        token_id: str,
+        hour: pd.Timestamp,
+    ) -> Path:
+        return cache_dir / condition_id / token_id / cls._archive_filename_for_hour(hour)
+
+    def _cache_path_for_hour(self, hour: pd.Timestamp) -> Path | None:
+        if self._pmxt_cache_dir is None or self.condition_id is None or self.token_id is None:
+            return None
+
+        return self._market_cache_path_for_hour(
+            self._pmxt_cache_dir,
+            self.condition_id,
+            self.token_id,
+            hour,
+        )
+
+    def _market_filter(self):
+        return (ds.field("market_id") == self.condition_id) & (
+            (ds.field("update_type") == "book_snapshot")
+            | (ds.field("update_type") == "price_change")
+        )
+
+    @classmethod
+    def _empty_market_table(cls) -> pa.Table:
+        return pa.table(
+            {
+                "update_type": pa.array([], type=pa.string()),
+                "data": pa.array([], type=pa.string()),
+            },
+        )
+
+    @classmethod
+    def _to_market_batch(cls, batch: pa.RecordBatch) -> pa.RecordBatch:
+        if batch.schema.names == cls._PMXT_COLUMNS:
+            return batch
+        return pa.RecordBatch.from_arrays(
+            [
+                batch.column("update_type"),
+                batch.column("data"),
+            ],
+            names=cls._PMXT_COLUMNS,
+        )
+
+    def _filter_batch_to_token(self, batch: pa.RecordBatch) -> pa.RecordBatch:
+        if self.token_id is None or batch.num_rows == 0:
+            return self._to_market_batch(batch)
+
+        token_mask = pc.match_substring_regex(
+            batch.column("data"),
+            rf'"token_id"\s*:\s*"{re.escape(self.token_id)}"',
+        )
+        token_mask = pc.fill_null(token_mask, False)
+        return self._to_market_batch(batch.filter(token_mask))
+
+    def _load_cached_market_table(self, hour: pd.Timestamp) -> pa.Table | None:
+        cache_path = self._cache_path_for_hour(hour)
+        if cache_path is None or not cache_path.exists():
+            return None
+
+        try:
+            dataset = ds.dataset(str(cache_path), format="parquet")
+            return dataset.scanner(columns=self._PMXT_COLUMNS).to_table()
+        except (OSError, ValueError, pa.ArrowException):
+            cache_path.unlink(missing_ok=True)
+            return None
+
+    def _load_cached_market_batches(
+        self,
+        hour: pd.Timestamp,
+    ) -> list[pa.RecordBatch] | None:
+        cache_path = self._cache_path_for_hour(hour)
+        if cache_path is None or not cache_path.exists():
+            return None
+
+        try:
+            dataset = ds.dataset(str(cache_path), format="parquet")
+            scanner = dataset.scanner(columns=self._PMXT_COLUMNS)
+            return list(scanner.to_batches())
+        except (OSError, ValueError, pa.ArrowException):
+            cache_path.unlink(missing_ok=True)
+            return None
+
+    def _write_market_cache(self, hour: pd.Timestamp, table: pa.Table) -> None:
+        cache_path = self._cache_path_for_hour(hour)
+        if cache_path is None:
+            return
+
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = cache_path.with_name(f"{cache_path.name}.tmp.{os.getpid()}")
+        try:
+            pq.write_table(table, tmp_path)
+            os.replace(tmp_path, cache_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def _load_remote_market_table(
+        self,
+        hour: pd.Timestamp,
+        *,
+        batch_size: int,
+    ) -> pa.Table | None:
+        batches = self._load_remote_market_batches(hour, batch_size=batch_size)
+        if batches is None:
+            return None
+        if not batches:
+            return self._empty_market_table()
+        return pa.Table.from_batches(batches)
+
+    def _load_remote_market_batches(
+        self,
+        hour: pd.Timestamp,
+        *,
+        batch_size: int,
+    ) -> list[pa.RecordBatch] | None:
+        archive_url = self._archive_url_for_hour(hour)
+        try:
+            dataset = ds.dataset(
+                archive_url,
+                filesystem=self._pmxt_fs,
+                format="parquet",
+            )
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            if "404" in str(exc):
+                return None
+            raise
+
+        scanner = dataset.scanner(
+            columns=self._PMXT_REMOTE_COLUMNS,
+            filter=self._market_filter(),
+            batch_size=batch_size,
+        )
+        batches: list[pa.RecordBatch] = []
+        for batch in scanner.to_batches():
+            filtered_batch = self._filter_batch_to_token(batch)
+            if filtered_batch.num_rows:
+                batches.append(filtered_batch)
+
+        return batches
+
+    def _filter_table_to_token(self, table: pa.Table) -> pa.Table:
+        if self.token_id is None or table.num_rows == 0:
+            return table
+
+        token_mask = pc.match_substring_regex(
+            table.column("data"),
+            rf'"token_id"\s*:\s*"{re.escape(self.token_id)}"',
+        )
+        token_mask = pc.fill_null(token_mask, False)
+        return table.filter(token_mask)
+
+    def _load_market_table(
+        self,
+        hour: pd.Timestamp,
+        *,
+        batch_size: int,
+    ) -> pa.Table | None:
+        table = self._load_cached_market_table(hour)
+        if table is not None:
+            return table
+
+        table = self._load_remote_market_table(hour, batch_size=batch_size)
+        if table is None:
+            return table
+
+        table = self._filter_table_to_token(table)
+        if self._pmxt_cache_dir is None:
+            return table
+
+        with suppress(OSError, pa.ArrowException):
+            self._write_market_cache(hour, table)
+
+        return table
+
+    def _load_market_batches(
+        self,
+        hour: pd.Timestamp,
+        *,
+        batch_size: int,
+    ) -> list[pa.RecordBatch] | None:
+        batches = self._load_cached_market_batches(hour)
+        if batches is not None:
+            return batches
+
+        batches = self._load_remote_market_batches(hour, batch_size=batch_size)
+        if batches is None:
+            return None
+
+        if self._pmxt_cache_dir is None:
+            return batches
+
+        table = pa.Table.from_batches(batches) if batches else self._empty_market_table()
+        with suppress(OSError, pa.ArrowException):
+            self._write_market_cache(hour, table)
+
+        return batches
+
+    def _iter_market_tables(
+        self,
+        hours: list[pd.Timestamp],
+        *,
+        batch_size: int,
+    ) -> Iterator[tuple[pd.Timestamp, pa.Table | None]]:
+        max_workers = min(self._pmxt_prefetch_workers, len(hours))
+        if max_workers <= 1:
+            for hour in hours:
+                yield hour, self._load_market_table(hour, batch_size=batch_size)
+            return
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures: dict[pd.Timestamp, Future[pa.Table | None]] = {}
+            next_index = 0
+
+            def _submit_next() -> None:
+                nonlocal next_index
+                if next_index >= len(hours):
+                    return
+                hour = hours[next_index]
+                next_index += 1
+                futures[hour] = executor.submit(
+                    self._load_market_table,
+                    hour,
+                    batch_size=batch_size,
+                )
+
+            for _ in range(max_workers):
+                _submit_next()
+
+            for hour in hours:
+                table = futures.pop(hour).result()
+                _submit_next()
+                yield hour, table
+
+    def _iter_market_batches(
+        self,
+        hours: list[pd.Timestamp],
+        *,
+        batch_size: int,
+    ) -> Iterator[tuple[pd.Timestamp, list[pa.RecordBatch] | None]]:
+        max_workers = min(self._pmxt_prefetch_workers, len(hours))
+        if max_workers <= 1:
+            for hour in hours:
+                yield hour, self._load_market_batches(hour, batch_size=batch_size)
+            return
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures: dict[pd.Timestamp, Future[list[pa.RecordBatch] | None]] = {}
+            next_index = 0
+
+            def _submit_next() -> None:
+                nonlocal next_index
+                if next_index >= len(hours):
+                    return
+                hour = hours[next_index]
+                next_index += 1
+                futures[hour] = executor.submit(
+                    self._load_market_batches,
+                    hour,
+                    batch_size=batch_size,
+                )
+
+            for _ in range(max_workers):
+                _submit_next()
+
+            for hour in hours:
+                batches = futures.pop(hour).result()
+                _submit_next()
+                yield hour, batches
 
     @staticmethod
     def _timestamp_to_ms_string(timestamp_secs: float) -> str:
@@ -136,31 +516,19 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
 
     @staticmethod
     def _decode_book_snapshot(payload_text: str) -> _PMXTBookSnapshotPayload:
-        return msgspec.json.decode(
-            payload_text.encode("utf-8"),
-            type=_PMXTBookSnapshotPayload,
-        )
+        return _PMXT_BOOK_SNAPSHOT_DECODER.decode(payload_text)
 
     @staticmethod
     def _decode_price_change(payload_text: str) -> _PMXTPriceChangePayload:
-        return msgspec.json.decode(
-            payload_text.encode("utf-8"),
-            type=_PMXTPriceChangePayload,
-        )
+        return _PMXT_PRICE_CHANGE_DECODER.decode(payload_text)
 
     @staticmethod
     def _to_book_snapshot(payload: _PMXTBookSnapshotPayload) -> PolymarketBookSnapshot:
         return PolymarketBookSnapshot(
             market=payload.market_id,
             asset_id=payload.token_id,
-            bids=[
-                PolymarketBookLevel(price=price, size=size)
-                for price, size in payload.bids
-            ],
-            asks=[
-                PolymarketBookLevel(price=price, size=size)
-                for price, size in payload.asks
-            ],
+            bids=[PolymarketBookLevel(price=price, size=size) for price, size in payload.bids],
+            asks=[PolymarketBookLevel(price=price, size=size) for price, size in payload.asks],
             timestamp=PolymarketPMXTDataLoader._timestamp_to_ms_string(payload.timestamp),
         )
 
@@ -185,6 +553,96 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             ],
             timestamp=PolymarketPMXTDataLoader._timestamp_to_ms_string(payload.timestamp),
         )
+
+    def _process_book_snapshot(
+        self,
+        payload_text: str,
+        *,
+        token_id: str,
+        instrument,
+        local_book: OrderBook,
+        has_snapshot: bool,
+        events: list[OrderBookDeltas | QuoteTick],
+        start_ns: int,
+        end_ns: int,
+        include_order_book: bool,
+        include_quotes: bool,
+    ) -> tuple[OrderBook, bool]:
+        payload = self._decode_book_snapshot(payload_text)
+        if payload.token_id != token_id:
+            return local_book, has_snapshot
+
+        snapshot = self._to_book_snapshot(payload)
+        deltas = snapshot.parse_to_snapshot(
+            instrument=instrument,
+            ts_init=int(payload.timestamp * 1_000_000_000),
+        )
+        if deltas is None:
+            return local_book, has_snapshot
+
+        event_ns = deltas.ts_event
+        local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
+        local_book.apply_deltas(deltas)
+        has_snapshot = True
+        if event_ns < start_ns or event_ns > end_ns:
+            return local_book, has_snapshot
+
+        if include_order_book:
+            events.append(deltas)
+        if include_quotes:
+            quote = snapshot.parse_to_quote(
+                instrument=instrument,
+                ts_init=deltas.ts_event + 1,
+            )
+            if quote is not None:
+                events.append(quote)
+
+        return local_book, has_snapshot
+
+    def _process_price_change(
+        self,
+        payload_text: str,
+        *,
+        token_id: str,
+        instrument,
+        local_book: OrderBook,
+        has_snapshot: bool,
+        events: list[OrderBookDeltas | QuoteTick],
+        start_ns: int,
+        end_ns: int,
+        include_order_book: bool,
+        include_quotes: bool,
+    ) -> OrderBook:
+        if not has_snapshot:
+            return local_book
+
+        payload = self._decode_price_change(payload_text)
+        if payload.token_id != token_id:
+            return local_book
+
+        quotes = self._to_price_change(payload)
+        deltas = quotes.parse_to_deltas(
+            instrument=instrument,
+            ts_init=int(payload.timestamp * 1_000_000_000),
+        )
+        local_book.apply_deltas(deltas)
+
+        event_ns = deltas.ts_event
+        if event_ns < start_ns or event_ns > end_ns:
+            return local_book
+
+        if include_order_book:
+            events.append(deltas)
+        if include_quotes:
+            quote = self._quote_from_book(
+                instrument=instrument,
+                local_book=local_book,
+                ts_event_ns=deltas.ts_event,
+            )
+            if quote is not None:
+                events.append(quote)
+
+        return local_book
 
     def load_order_book_and_quotes(
         self,
@@ -211,101 +669,53 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         if start_ts is None or end_ts is None or end_ts <= start_ts:
             return []
 
+        start_ns = start_ts.value
+        end_ns = end_ts.value
         token_id = self.token_id
         instrument = self.instrument
         local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
         has_snapshot = False
         events: list[OrderBookDeltas | QuoteTick] = []
+        hours = self._archive_hours(start_ts, end_ts)
 
-        for hour in self._archive_hours(start_ts, end_ts):
-            archive_url = self._archive_url_for_hour(hour)
-            try:
-                dataset = ds.dataset(
-                    archive_url,
-                    filesystem=self._pmxt_fs,
-                    format="parquet",
-                )
-            except FileNotFoundError:
+        for _hour, batches in self._iter_market_batches(hours, batch_size=batch_size):
+            if not batches:
                 continue
-            except OSError as exc:
-                if "404" in str(exc):
-                    continue
-                raise
 
-            scanner = dataset.scanner(
-                columns=self._PMXT_COLUMNS,
-                filter=ds.field("market_id") == self.condition_id,
-                batch_size=batch_size,
-            )
-
-            for batch in scanner.to_batches():
-                for row in batch.to_pylist():
-                    payload_text = str(row["data"])
-                    update_type = str(row["update_type"])
-
+            for batch in batches:
+                update_types = batch.column("update_type").to_pylist()
+                payload_texts = batch.column("data").to_pylist()
+                for update_type, payload_text in zip(update_types, payload_texts, strict=False):
                     if update_type == "book_snapshot":
-                        payload = self._decode_book_snapshot(payload_text)
-                        if payload.token_id != token_id:
-                            continue
-
-                        snapshot = self._to_book_snapshot(payload)
-                        deltas = snapshot.parse_to_snapshot(
-                            instrument=instrument,
-                            ts_init=int(payload.timestamp * 1_000_000_000),
-                        )
-                        if deltas is None:
-                            continue
-
-                        local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
-                        local_book.apply_deltas(deltas)
-                        has_snapshot = True
-                        event_ts = pd.Timestamp(
-                            nanos_to_secs(deltas.ts_event),
-                            unit="s",
-                            tz=UTC,
-                        )
-                        if event_ts < start_ts or event_ts > end_ts:
-                            continue
-
-                        if include_order_book:
-                            events.append(deltas)
-                        if include_quotes:
-                            quote = snapshot.parse_to_quote(
-                                instrument=instrument,
-                                ts_init=deltas.ts_event + 1,
-                            )
-                            if quote is not None:
-                                events.append(quote)
-                        continue
-
-                    if update_type != "price_change" or not has_snapshot:
-                        continue
-
-                    payload = self._decode_price_change(payload_text)
-                    if payload.token_id != token_id:
-                        continue
-
-                    quotes = self._to_price_change(payload)
-                    deltas = quotes.parse_to_deltas(
-                        instrument=instrument,
-                        ts_init=int(payload.timestamp * 1_000_000_000),
-                    )
-                    local_book.apply_deltas(deltas)
-
-                    event_ts = pd.Timestamp(payload.timestamp, unit="s", tz=UTC)
-                    if event_ts < start_ts or event_ts > end_ts:
-                        continue
-
-                    if include_order_book:
-                        events.append(deltas)
-                    if include_quotes:
-                        quote = self._quote_from_book(
+                        local_book, has_snapshot = self._process_book_snapshot(
+                            payload_text,
+                            token_id=token_id,
                             instrument=instrument,
                             local_book=local_book,
-                            ts_event_ns=deltas.ts_event,
+                            has_snapshot=has_snapshot,
+                            events=events,
+                            start_ns=start_ns,
+                            end_ns=end_ns,
+                            include_order_book=include_order_book,
+                            include_quotes=include_quotes,
                         )
-                        if quote is not None:
-                            events.append(quote)
+                        continue
 
-        events.sort(key=lambda record: int(getattr(record, "ts_init", getattr(record, "ts_event", 0))))
+                    if update_type == "price_change":
+                        local_book = self._process_price_change(
+                            payload_text,
+                            token_id=token_id,
+                            instrument=instrument,
+                            local_book=local_book,
+                            has_snapshot=has_snapshot,
+                            events=events,
+                            start_ns=start_ns,
+                            end_ns=end_ns,
+                            include_order_book=include_order_book,
+                            include_quotes=include_quotes,
+                        )
+
+        events.sort(
+            key=lambda record: int(getattr(record, "ts_init", getattr(record, "ts_event", 0)))
+        )
         return events

--- a/nautilus_pm/tests/unit_tests/analysis/test_legacy_plot_adapter.py
+++ b/nautilus_pm/tests/unit_tests/analysis/test_legacy_plot_adapter.py
@@ -368,7 +368,11 @@ def test_create_legacy_backtest_chart_saves_final_layout_without_requiring_brier
     )
     monkeypatch.setattr(adapter, "_build_metrics", lambda *args, **kwargs: {})
     monkeypatch.setattr(adapter, "_platform_enum", lambda *args, **kwargs: "KALSHI")
-    monkeypatch.setattr(adapter, "_apply_layout_overrides", lambda layout, initial_cash: layout)
+    monkeypatch.setattr(
+        adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
     monkeypatch.setattr(
         adapter,
         "prepare_cumulative_brier_advantage",
@@ -448,7 +452,11 @@ def test_create_legacy_backtest_chart_saves_placeholder_brier_panel_when_outcome
     )
     monkeypatch.setattr(adapter, "_build_metrics", lambda *args, **kwargs: {})
     monkeypatch.setattr(adapter, "_platform_enum", lambda *args, **kwargs: "KALSHI")
-    monkeypatch.setattr(adapter, "_apply_layout_overrides", lambda layout, initial_cash: layout)
+    monkeypatch.setattr(
+        adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
     monkeypatch.setattr(
         adapter,
         "prepare_cumulative_brier_advantage",

--- a/tests/test_polymarket_pmxt_cache.py
+++ b/tests/test_polymarket_pmxt_cache.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+
+from nautilus_trader.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
+
+
+def _make_loader(cache_dir: Path | None) -> PolymarketPMXTDataLoader:
+    loader = object.__new__(PolymarketPMXTDataLoader)
+    loader._pmxt_cache_dir = cache_dir
+    loader._condition_id = "condition-123"
+    loader._token_id = "token-yes-123"
+    loader._pmxt_prefetch_workers = 2
+    return loader
+
+
+def test_resolve_cache_dir_is_opt_in(monkeypatch, tmp_path):
+    monkeypatch.delenv(PolymarketPMXTDataLoader._PMXT_CACHE_DIR_ENV, raising=False)
+    monkeypatch.delenv(PolymarketPMXTDataLoader._PMXT_DISABLE_CACHE_ENV, raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    assert PolymarketPMXTDataLoader._resolve_cache_dir() is None
+
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_CACHE_DIR_ENV, "1")
+    assert PolymarketPMXTDataLoader._resolve_cache_dir() == (
+        tmp_path / "xdg-cache" / "nautilus_trader" / "pmxt"
+    )
+
+
+def test_resolve_prefetch_workers_parses_env(monkeypatch):
+    monkeypatch.delenv(PolymarketPMXTDataLoader._PMXT_PREFETCH_WORKERS_ENV, raising=False)
+    assert PolymarketPMXTDataLoader._resolve_prefetch_workers() == 4
+
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_PREFETCH_WORKERS_ENV, "8")
+    assert PolymarketPMXTDataLoader._resolve_prefetch_workers() == 8
+
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_PREFETCH_WORKERS_ENV, "invalid")
+    assert PolymarketPMXTDataLoader._resolve_prefetch_workers() == 4
+
+
+def test_resolve_http_tuning_parses_env(monkeypatch):
+    monkeypatch.delenv(PolymarketPMXTDataLoader._PMXT_HTTP_BLOCK_SIZE_MB_ENV, raising=False)
+    monkeypatch.delenv(PolymarketPMXTDataLoader._PMXT_HTTP_CACHE_TYPE_ENV, raising=False)
+
+    assert PolymarketPMXTDataLoader._resolve_http_block_size() == 32 * 1024 * 1024
+    assert PolymarketPMXTDataLoader._resolve_http_cache_type() == "readahead"
+
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_HTTP_BLOCK_SIZE_MB_ENV, "64")
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_HTTP_CACHE_TYPE_ENV, "bytes")
+
+    assert PolymarketPMXTDataLoader._resolve_http_block_size() == 64 * 1024 * 1024
+    assert PolymarketPMXTDataLoader._resolve_http_cache_type() == "bytes"
+
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_HTTP_BLOCK_SIZE_MB_ENV, "invalid")
+    monkeypatch.setenv(PolymarketPMXTDataLoader._PMXT_HTTP_CACHE_TYPE_ENV, "")
+
+    assert PolymarketPMXTDataLoader._resolve_http_block_size() == 32 * 1024 * 1024
+    assert PolymarketPMXTDataLoader._resolve_http_cache_type() == "readahead"
+
+
+def test_load_market_table_writes_token_filtered_cache(tmp_path):
+    loader = _make_loader(tmp_path)
+    hour = pd.Timestamp("2026-03-16T12:00:00Z")
+    remote_table = pa.table(
+        {
+            "update_type": ["book_snapshot", "price_change", "price_change"],
+            "data": [
+                '{"token_id":"token-yes-123","payload":"keep-1"}',
+                '{"token_id":"token-no-456","payload":"drop"}',
+                '{"token_id":"token-yes-123","payload":"keep-2"}',
+            ],
+        },
+    )
+
+    loader._load_remote_market_table = lambda _hour, *, batch_size: remote_table  # type: ignore[method-assign]
+
+    loaded = loader._load_market_table(hour, batch_size=1_000)
+
+    assert loaded is not None
+    assert loaded.to_pylist() == [
+        {"update_type": "book_snapshot", "data": '{"token_id":"token-yes-123","payload":"keep-1"}'},
+        {"update_type": "price_change", "data": '{"token_id":"token-yes-123","payload":"keep-2"}'},
+    ]
+    assert loader._cache_path_for_hour(hour) == (
+        tmp_path / "condition-123" / "token-yes-123" / "polymarket_orderbook_2026-03-16T12.parquet"
+    )
+
+    cached = loader._load_cached_market_table(hour)
+    assert cached is not None
+    assert cached.to_pylist() == loaded.to_pylist()
+
+
+def test_load_market_table_prefers_cached_table(tmp_path):
+    loader = _make_loader(tmp_path)
+    hour = pd.Timestamp("2026-03-16T13:00:00Z")
+    cached_table = pa.table(
+        {
+            "update_type": ["book_snapshot"],
+            "data": ['{"token_id":"token-yes-123","payload":"cached"}'],
+        },
+    )
+    loader._write_market_cache(hour, cached_table)
+
+    def _fail_remote(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("remote load should not run when cache exists")
+
+    loader._load_remote_market_table = _fail_remote  # type: ignore[method-assign]
+
+    loaded = loader._load_market_table(hour, batch_size=1_000)
+
+    assert loaded is not None
+    assert loaded.to_pylist() == cached_table.to_pylist()
+
+
+def test_iter_market_tables_preserves_hour_order(tmp_path):
+    loader = _make_loader(tmp_path)
+    hours = [
+        pd.Timestamp("2026-03-16T12:00:00Z"),
+        pd.Timestamp("2026-03-16T13:00:00Z"),
+        pd.Timestamp("2026-03-16T14:00:00Z"),
+    ]
+    delays = {
+        hours[0]: 0.05,
+        hours[1]: 0.0,
+        hours[2]: 0.01,
+    }
+
+    def _load(hour, *, batch_size):  # type: ignore[no-untyped-def]
+        time.sleep(delays[hour])
+        return pa.table(
+            {
+                "update_type": ["book_snapshot"],
+                "data": [hour.isoformat()],
+            },
+        )
+
+    loader._load_market_table = _load  # type: ignore[method-assign]
+
+    yielded = list(loader._iter_market_tables(hours, batch_size=1_000))
+
+    assert [hour for hour, _ in yielded] == hours
+    assert [table.to_pylist()[0]["data"] for _, table in yielded] == [
+        hour.isoformat() for hour in hours
+    ]
+
+
+def test_iter_market_batches_preserves_hour_order(tmp_path):
+    loader = _make_loader(tmp_path)
+    hours = [
+        pd.Timestamp("2026-03-16T12:00:00Z"),
+        pd.Timestamp("2026-03-16T13:00:00Z"),
+        pd.Timestamp("2026-03-16T14:00:00Z"),
+    ]
+    delays = {
+        hours[0]: 0.05,
+        hours[1]: 0.0,
+        hours[2]: 0.01,
+    }
+
+    def _load(hour, *, batch_size):  # type: ignore[no-untyped-def]
+        time.sleep(delays[hour])
+        return [
+            pa.record_batch(
+                [
+                    pa.array(["book_snapshot"]),
+                    pa.array([hour.isoformat()]),
+                ],
+                names=["update_type", "data"],
+            ),
+        ]
+
+    loader._load_market_batches = _load  # type: ignore[method-assign]
+
+    yielded = list(loader._iter_market_batches(hours, batch_size=1_000))
+
+    assert [hour for hour, _ in yielded] == hours
+    assert [batches[0].column("data")[0].as_py() for _, batches in yielded] == [
+        hour.isoformat() for hour in hours
+    ]


### PR DESCRIPTION
## Summary
- stream PMXT remote parquet scans as filtered record batches and add HTTP readahead tuning
- make PMXT disk cache opt-in, add cache coverage, and document cache location and enablement
- refresh README with current 2h and 48h PMXT validation data, and fix vendored legacy plot tests for the current adapter signature

## Testing
- uv run pytest -q tests/test_polymarket_pmxt_*.py tests/test_backtest_utils.py tests/test_legacy_plot_fill_markers.py tests/test_quote_tick_strategy_configs.py tests/test_polymarket_ema_crossover.py
- (cd nautilus_pm && uv run pytest -q tests/unit_tests/adapters/prediction_market/test_backtest_utils.py tests/unit_tests/analysis/test_legacy_plot_adapter.py)
- PMXT backtest validation with PMXT_CACHE_DIR=1 on 2h and 48h historical windows via backtests/polymarket_pmxt_*.py