### PR TITLE
Fix relay OOM kills, CPU badge, and worker/prebuild separation

### DIFF
--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -260,7 +260,7 @@ On a 6 GB VPS the safe configuration is:
 | Service  | `MemoryMax` | `MemorySwapMax` | Notes                            |
 |----------|-------------|-----------------|----------------------------------|
 | Worker   | 2500M       | 512M            | Mirror + shard only, no prebuild |
-| Prebuild | 4G          | 486M            | One hour at a time               |
+| Prebuild | 4500M       | 486M            | One hour at a time               |
 
 Key env vars that control memory:
 

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -10,7 +10,6 @@ import json
 import os
 from pathlib import Path
 import shutil
-import time as time_module
 from xml.sax.saxutils import escape
 
 from aiohttp import web
@@ -114,23 +113,10 @@ def _usage_color(percent: float) -> str:
     return "brightgreen"
 
 
-def _read_cpu_totals() -> tuple[int, int]:
-    with Path("/proc/stat").open() as handle:
-        parts = handle.readline().split()
-    values = [int(value) for value in parts[1:]]
-    idle = values[3] + (values[4] if len(values) > 4 else 0)
-    total = sum(values)
-    return idle, total
-
-
-def _sample_cpu_percent(interval_secs: float = 0.1) -> float:
-    idle_before, total_before = _read_cpu_totals()
-    time_module.sleep(interval_secs)
-    idle_after, total_after = _read_cpu_totals()
-    total_delta = max(1, total_after - total_before)
-    idle_delta = max(0, idle_after - idle_before)
-    used_fraction = 1.0 - min(1.0, idle_delta / total_delta)
-    return max(0.0, min(100.0, used_fraction * 100.0))
+def _cpu_percent_from_loadavg() -> float:
+    cpu_count = os.cpu_count() or 1
+    load_1min = os.getloadavg()[0]
+    return max(0.0, min(100.0, (load_1min / cpu_count) * 100.0))
 
 
 def _memory_percent() -> float:
@@ -152,7 +138,7 @@ def _disk_percent(path: Path) -> float:
 
 def _system_metrics_snapshot(config: RelayConfig) -> dict[str, float]:
     return {
-        "cpu_percent": round(_sample_cpu_percent(), 1),
+        "cpu_percent": round(_cpu_percent_from_loadavg(), 1),
         "mem_percent": round(_memory_percent(), 1),
         "disk_percent": round(_disk_percent(config.data_dir), 1),
     }
@@ -385,6 +371,10 @@ class RequestRateLimiter:
             return False
 
         bucket.append(current)
+        if len(self._requests) > 10000:
+            stale = [k for k, v in self._requests.items() if not v]
+            for k in stale:
+                del self._requests[k]
         return True
 
     def bucket_size(self, client_id: str, *, now: float | None = None) -> int:

--- a/pmxt_relay/cli.py
+++ b/pmxt_relay/cli.py
@@ -55,11 +55,13 @@ def main(argv: list[str] | None = None) -> int:
             RelayWorker(
                 config,
                 reset_prebuild_inflight=False,
+                skip_prebuild=True,
             ).run_once()
         else:
             worker = RelayWorker(
                 config,
                 reset_prebuild_inflight=False,
+                skip_prebuild=True,
             )
             discovered = worker._discover_archive_hours()  # noqa: SLF001
             mirrored = worker._mirror_pending_hours()  # noqa: SLF001
@@ -85,8 +87,11 @@ def main(argv: list[str] | None = None) -> int:
             reset_process_inflight=False,
             reset_prebuild_inflight=True,
         )
-        count = worker._prebuild_filtered_hours(limit=args.limit)  # noqa: SLF001
-        print(json.dumps({"prebuilt_hours": count}, indent=2, sort_keys=True))
+        if args.limit is not None:
+            count = worker._prebuild_filtered_hours(limit=args.limit)  # noqa: SLF001
+            print(json.dumps({"prebuilt_hours": count}, indent=2, sort_keys=True))
+        else:
+            worker.run_prebuild_forever()
         return 0
 
     if args.command == "stats":

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -65,7 +65,8 @@ class RelayIndex:
                 mirrored_at TEXT,
                 processed_at TEXT,
                 prebuilt_at TEXT,
-                last_error TEXT
+                last_error TEXT,
+                error_count INTEGER NOT NULL DEFAULT 0
             );
 
             CREATE TABLE IF NOT EXISTS filtered_hours (
@@ -111,6 +112,10 @@ class RelayIndex:
         self._ensure_archive_hours_column(
             "prebuilt_at",
             "TEXT",
+        )
+        self._ensure_archive_hours_column(
+            "error_count",
+            "INTEGER NOT NULL DEFAULT 0",
         )
         self._conn.execute(
             """
@@ -252,6 +257,7 @@ class RelayIndex:
             SELECT *
             FROM archive_hours
             WHERE mirror_status IN ('pending', 'error')
+              AND error_count < 3
             ORDER BY hour
             """
         )
@@ -282,7 +288,8 @@ class RelayIndex:
                     mirrored_at = ?,
                     processed_at = NULL,
                     prebuilt_at = NULL,
-                    last_error = NULL
+                    last_error = NULL,
+                    error_count = 0
                 WHERE filename = ?
                 """,
                 (
@@ -311,7 +318,9 @@ class RelayIndex:
             self._conn.execute(
                 """
                 UPDATE archive_hours
-                SET mirror_status = 'error', last_error = ?
+                SET mirror_status = 'error',
+                    last_error = ?,
+                    error_count = error_count + 1
                 WHERE filename = ?
                 """,
                 (error, filename),
@@ -329,6 +338,7 @@ class RelayIndex:
             SELECT *
             FROM archive_hours
             WHERE mirror_status = 'ready' AND process_status IN ({placeholders})
+              AND error_count < 3
             ORDER BY hour
             """,
             statuses,
@@ -351,7 +361,9 @@ class RelayIndex:
             self._conn.execute(
                 """
                 UPDATE archive_hours
-                SET process_status = 'error', last_error = ?
+                SET process_status = 'error',
+                    last_error = ?,
+                    error_count = error_count + 1
                 WHERE filename = ?
                 """,
                 (error, filename),
@@ -402,7 +414,8 @@ class RelayIndex:
                     processed_at = ?,
                     prebuilt_at = ?,
                     filtered_artifact_count = ?,
-                    last_error = NULL
+                    last_error = NULL,
+                    error_count = 0
                 WHERE filename = ?
                 """,
                 (_utc_now(), _utc_now(), len(artifacts), filename),
@@ -418,7 +431,8 @@ class RelayIndex:
                 UPDATE archive_hours
                 SET process_status = 'ready',
                     processed_at = ?,
-                    last_error = NULL
+                    last_error = NULL,
+                    error_count = 0
                 WHERE filename = ?
                 """,
                 (_utc_now(), filename),
@@ -442,7 +456,8 @@ class RelayIndex:
                 """
                 UPDATE archive_hours
                 SET prebuild_status = 'error',
-                    last_error = ?
+                    last_error = ?,
+                    error_count = error_count + 1
                 WHERE filename = ?
                 """,
                 (error, filename),
@@ -488,7 +503,8 @@ class RelayIndex:
                 SET prebuild_status = 'ready',
                     prebuilt_at = ?,
                     filtered_artifact_count = ?,
-                    last_error = NULL
+                    last_error = NULL,
+                    error_count = 0
                 WHERE filename = ?
                 """,
                 (_utc_now(), filtered_artifact_count, filename),
@@ -502,6 +518,7 @@ class RelayIndex:
             WHERE mirror_status = 'ready'
               AND process_status = 'ready'
               AND prebuild_status IN ('pending', 'error')
+              AND error_count < 3
               AND local_path IS NOT NULL
             ORDER BY hour DESC
             """

--- a/pmxt_relay/processor.py
+++ b/pmxt_relay/processor.py
@@ -147,6 +147,7 @@ class RelayHourProcessor:
         raw_path: Path,
         *,
         progress_callback: Callable[[int, int], None] | None = None,
+        skip_filtered: bool = False,
     ) -> ProcessedHourResult:
         hour = parse_archive_hour(filename).isoformat()
         temp_root = self._config.tmp_root / f"{filename}.filtered"
@@ -155,7 +156,8 @@ class RelayHourProcessor:
         final_path = self._config.processed_root / processed_relative_path(filename)
         shutil.rmtree(temp_root, ignore_errors=True)
         temp_root.mkdir(parents=True, exist_ok=True)
-        partition_root.mkdir(parents=True, exist_ok=True)
+        if not skip_filtered:
+            partition_root.mkdir(parents=True, exist_ok=True)
         final_path.parent.mkdir(parents=True, exist_ok=True)
 
         parquet_file = pq.ParquetFile(raw_path)
@@ -190,12 +192,13 @@ class RelayHourProcessor:
                             schema=PROCESSED_SCHEMA,
                         )
                     )
-                    self._write_partition_batch(
-                        batch,
-                        partition_root,
-                        basename_template=f"part-{partition_counter}-{{i}}.parquet",
-                    )
-                    partition_counter += 1
+                    if not skip_filtered:
+                        self._write_partition_batch(
+                            batch,
+                            partition_root,
+                            basename_template=f"part-{partition_counter}-{{i}}.parquet",
+                        )
+                        partition_counter += 1
                     wrote_any = True
                 if progress_callback is not None:
                     progress_callback(processed_rows, total_rows)
@@ -209,11 +212,14 @@ class RelayHourProcessor:
                 return ProcessedHourResult(artifacts=[], total_filtered_rows=0)
 
             os.replace(temp_path, final_path)
-            artifacts = self._materialize_partition_tree(
-                filename,
-                hour,
-                partition_root,
-            )
+            if skip_filtered:
+                artifacts: list[FilteredHourArtifact] = []
+            else:
+                artifacts = self._materialize_partition_tree(
+                    filename,
+                    hour,
+                    partition_root,
+                )
             return ProcessedHourResult(
                 artifacts=artifacts,
                 total_filtered_rows=total_filtered_rows,
@@ -236,12 +242,12 @@ class RelayHourProcessor:
         shutil.rmtree(temp_root, ignore_errors=True)
         partition_root.mkdir(parents=True, exist_ok=True)
 
-        dataset = ds.dataset(processed_path, format="parquet")
         total_rows = pq.ParquetFile(processed_path).metadata.num_rows
         row_offset = 0
         partition_counter = 0
 
         try:
+            dataset = ds.dataset(processed_path, format="parquet")
             for batch in dataset.to_batches(
                 columns=["market_id", "token_id", "update_type", "data"],
                 batch_size=PARQUET_BATCH_SIZE,
@@ -272,6 +278,7 @@ class RelayHourProcessor:
                 partition_counter += 1
                 if progress_callback is not None:
                     progress_callback(row_offset, total_rows)
+            del dataset
 
             if progress_callback is not None:
                 progress_callback(total_rows, total_rows)

--- a/pmxt_relay/systemd/pmxt-relay-prebuild.service
+++ b/pmxt_relay/systemd/pmxt-relay-prebuild.service
@@ -35,7 +35,7 @@ AmbientCapabilities=
 SystemCallArchitectures=native
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 ReadWritePaths=/srv/pmxt-relay
-MemoryMax=4G
+MemoryMax=4500M
 MemorySwapMax=486M
 
 [Install]

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import logging
 import os
 import shutil
@@ -108,6 +109,16 @@ class RelayWorker:
             prebuilt,
         )
         return total
+
+    def run_prebuild_forever(self) -> None:
+        while True:
+            prebuilt = self._prebuild_filtered_hours(limit=1)
+            if prebuilt == 0:
+                LOG.info(
+                    "No prebuild work pending, sleeping for %ss",
+                    self._config.poll_interval_secs,
+                )
+                time.sleep(self._config.poll_interval_secs)
 
     def _discover_archive_hours(self) -> int:
         discovered = 0
@@ -364,13 +375,12 @@ class RelayWorker:
                 message=f"Processing {filename}",
                 payload={"raw_path": str(raw_path)},
             )
-            existing_rows = self._index.list_filtered_for_filename(filename)
-
             try:
                 result = self._processor.process_hour(
                     filename,
                     raw_path,
                     progress_callback=report_progress,
+                    skip_filtered=self._skip_prebuild,
                 )
             except Exception as exc:  # noqa: BLE001
                 self._index.mark_process_error(filename, str(exc))
@@ -384,40 +394,52 @@ class RelayWorker:
                 LOG.exception("Failed to process %s", filename)
                 continue
 
-            artifacts = result.artifacts
-            keep_paths = {artifact.local_path for artifact in artifacts}
-            for existing in existing_rows:
-                cached_path = self._config.filtered_root / filtered_relative_path(
-                    existing["condition_id"],
-                    existing["token_id"],
-                    existing["filename"],
-                )
-                cached_path.unlink(missing_ok=True)
-                if existing["local_path"] in keep_paths:
-                    continue
-                existing_path = Path(existing["local_path"])
-                if existing_path.is_dir():
-                    shutil.rmtree(existing_path, ignore_errors=True)
-                elif existing_path.is_relative_to(self._config.filtered_root):
-                    existing_path.unlink(missing_ok=True)
-
             self._index.mark_sharded(filename)
-            self._index.mark_prebuilt(
-                filename,
-                filtered_artifact_count=len(artifacts),
-                artifacts=artifacts,
-            )
-            self._record_event(
-                level="INFO",
-                event_type="process_complete",
-                filename=filename,
-                message=f"Processed {filename}",
-                payload={
-                    "filtered_files": len(artifacts),
-                    "filtered_rows": result.total_filtered_rows,
-                },
-            )
-            LOG.info("Processed %s into %s filtered files", filename, len(artifacts))
+            if self._skip_prebuild:
+                self._record_event(
+                    level="INFO",
+                    event_type="process_complete",
+                    filename=filename,
+                    message=f"Sharded {filename} (prebuild deferred)",
+                    payload={
+                        "filtered_rows": result.total_filtered_rows,
+                    },
+                )
+                LOG.info("Sharded %s (prebuild deferred)", filename)
+            else:
+                artifacts = result.artifacts
+                existing_rows = self._index.list_filtered_for_filename(filename)
+                keep_paths = {artifact.local_path for artifact in artifacts}
+                for existing in existing_rows:
+                    cached_path = self._config.filtered_root / filtered_relative_path(
+                        existing["condition_id"],
+                        existing["token_id"],
+                        existing["filename"],
+                    )
+                    cached_path.unlink(missing_ok=True)
+                    if existing["local_path"] in keep_paths:
+                        continue
+                    existing_path = Path(existing["local_path"])
+                    if existing_path.is_dir():
+                        shutil.rmtree(existing_path, ignore_errors=True)
+                    elif existing_path.is_relative_to(self._config.filtered_root):
+                        existing_path.unlink(missing_ok=True)
+                self._index.mark_prebuilt(
+                    filename,
+                    filtered_artifact_count=len(artifacts),
+                    artifacts=artifacts,
+                )
+                self._record_event(
+                    level="INFO",
+                    event_type="process_complete",
+                    filename=filename,
+                    message=f"Processed {filename}",
+                    payload={
+                        "filtered_files": len(artifacts),
+                        "filtered_rows": result.total_filtered_rows,
+                    },
+                )
+                LOG.info("Processed %s into %s filtered files", filename, len(artifacts))
             processed += 1
             if limit is not None and processed >= limit:
                 break
@@ -502,6 +524,8 @@ class RelayWorker:
                 filename,
                 len(artifacts),
             )
+            del artifacts
+            gc.collect()
             prebuilt += 1
             if limit is not None and prebuilt >= limit:
                 break

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -14,6 +14,7 @@ from pmxt_relay.api import (
     INDEX_APP_KEY,
     RequestRateLimiter,
     _collect_inflight_processes,
+    _cpu_percent_from_loadavg,
     _resolve_filtered_path,
     _resolve_raw_path,
     create_app,
@@ -41,6 +42,21 @@ def _make_config(tmp_path: Path) -> RelayConfig:
         api_rate_limit_per_minute=2400,
         api_list_max_hours=2000,
     )
+
+
+def test_cpu_percent_uses_load_average():
+    with patch("pmxt_relay.api.os.cpu_count", return_value=4):
+        with patch("pmxt_relay.api.os.getloadavg", return_value=(3.5, 3.0, 2.5)):
+            result = _cpu_percent_from_loadavg()
+            assert result == 87.5  # 3.5 / 4 * 100
+
+        with patch("pmxt_relay.api.os.getloadavg", return_value=(0.0, 0.0, 0.0)):
+            result = _cpu_percent_from_loadavg()
+            assert result == 0.0
+
+        with patch("pmxt_relay.api.os.getloadavg", return_value=(5.0, 4.0, 3.0)):
+            result = _cpu_percent_from_loadavg()
+            assert result == 100.0  # capped at 100
 
 
 def test_rate_limiter_enforces_sliding_window():

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pmxt_relay.index_db import RelayIndex
+from pmxt_relay.index_db import FilteredHourArtifact, RelayIndex
 
 
 def test_relay_index_events_and_queue_summary(tmp_path: Path):
@@ -233,3 +233,111 @@ def test_mark_prebuilt_tracks_filtered_artifact_count(tmp_path: Path):
     assert stats["ready_to_prebuild_hours"] == 0
     assert stats["filtered_hours"] == 42
     assert index.list_hours_needing_filtered_prebuild() == []
+
+
+def test_error_count_exhausts_retries_after_three_failures(tmp_path: Path):
+    index = RelayIndex(tmp_path / "relay.sqlite3")
+    index.initialize()
+    filename = "polymarket_orderbook_2026-03-21T12.parquet"
+    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
+
+    # Mirror errors: first 2 retries still appear in the queue
+    index.mark_mirror_error(filename, "timeout 1")
+    assert len(index.list_hours_needing_mirror()) == 1
+    index.mark_mirror_error(filename, "timeout 2")
+    assert len(index.list_hours_needing_mirror()) == 1
+    # Third error exhausts retries
+    index.mark_mirror_error(filename, "timeout 3")
+    assert len(index.list_hours_needing_mirror()) == 0
+
+    # Success resets error_count
+    index.mark_mirrored(
+        filename, local_path="/tmp/a", etag=None,
+        content_length=None, last_modified=None,
+    )
+    index.mark_process_error(filename, "corrupt 1")
+    assert len(index.list_hours_needing_process()) == 1
+    index.mark_process_error(filename, "corrupt 2")
+    index.mark_process_error(filename, "corrupt 3")
+    assert len(index.list_hours_needing_process()) == 0
+
+    # Prebuild errors
+    index.mark_sharded(filename)  # resets error_count
+    index.mark_prebuild_error(filename, "oom 1")
+    assert len(index.list_hours_needing_filtered_prebuild()) == 1
+    index.mark_prebuild_error(filename, "oom 2")
+    index.mark_prebuild_error(filename, "oom 3")
+    assert len(index.list_hours_needing_filtered_prebuild()) == 0
+
+
+def test_mark_prebuilt_registers_artifacts_in_filtered_hours(tmp_path: Path):
+    index = RelayIndex(tmp_path / "relay.sqlite3")
+    index.initialize()
+    filename = "polymarket_orderbook_2026-03-21T12.parquet"
+    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
+    index.mark_mirrored(
+        filename, local_path="/tmp/a", etag=None,
+        content_length=None, last_modified=None,
+    )
+    index.mark_sharded(filename)
+
+    artifacts = [
+        FilteredHourArtifact(
+            filename=filename,
+            hour="2026-03-21T12:00:00+00:00",
+            condition_id="0x" + "ab" * 32,
+            token_id="123",
+            local_path="/srv/filtered/0xab/123/" + filename,
+            row_count=100,
+            byte_size=5000,
+        ),
+        FilteredHourArtifact(
+            filename=filename,
+            hour="2026-03-21T12:00:00+00:00",
+            condition_id="0x" + "cd" * 32,
+            token_id="456",
+            local_path="/srv/filtered/0xcd/456/" + filename,
+            row_count=50,
+            byte_size=2500,
+        ),
+    ]
+    index.mark_prebuilt(filename, filtered_artifact_count=2, artifacts=artifacts)
+
+    # Verify filtered_hours table
+    rows = index.list_filtered_for_filename(filename)
+    assert len(rows) == 2
+    assert rows[0]["condition_id"] == "0x" + "ab" * 32
+    assert rows[0]["row_count"] == 100
+    assert rows[1]["condition_id"] == "0x" + "cd" * 32
+
+    # Verify the listing API works
+    listed = index.list_filtered_hours("0x" + "ab" * 32, "123")
+    assert len(listed) == 1
+    assert listed[0]["filename"] == filename
+
+    # Re-prebuilt replaces old artifacts
+    new_artifacts = [artifacts[0]]
+    index.mark_prebuilt(filename, filtered_artifact_count=1, artifacts=new_artifacts)
+    rows = index.list_filtered_for_filename(filename)
+    assert len(rows) == 1
+
+
+def test_mark_prebuilt_without_artifacts_does_not_touch_filtered_hours(tmp_path: Path):
+    index = RelayIndex(tmp_path / "relay.sqlite3")
+    index.initialize()
+    filename = "polymarket_orderbook_2026-03-21T12.parquet"
+    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
+    index.mark_mirrored(
+        filename, local_path="/tmp/a", etag=None,
+        content_length=None, last_modified=None,
+    )
+    index.mark_sharded(filename)
+
+    # mark_prebuilt without artifacts should NOT insert into filtered_hours
+    index.mark_prebuilt(filename, filtered_artifact_count=42)
+    rows = index.list_filtered_for_filename(filename)
+    assert len(rows) == 0
+
+    # But archive_hours should still show ready
+    stats = index.stats()
+    assert stats["processed_hours"] == 1


### PR DESCRIPTION
## Summary
- **CPU badge fix**: Replaced broken `/proc/stat` 100ms sampling (showed 0.0% under load) with `os.getloadavg()` for accurate readings
- **Worker/prebuild separation**: Worker now passes `skip_filtered=True` to `process_hour()`, avoiding heavy partition materialization that belongs to the prebuild service. Eliminates memory contention on the VPS.
- **Prebuild loop**: `prebuild-filtered` command now loops internally when no `--limit` flag, instead of relying on systemd `Restart=always` which missed newly-sharded hours
- **OOM prevention**: Increased prebuild `MemoryMax` from 4G to 4500M, added `gc.collect()` after each prebuild, added `del dataset` for earlier memory release
- **Error retry limits**: Added `error_count` column to `archive_hours` — errors increment count, success resets it, listing queries skip rows with `error_count >= 3`
- **Rate limiter hardening**: Evict stale buckets when map exceeds 10k entries

## Test plan
- [x] 24 relay tests pass (including 3 new tests for CPU badge, error exhaustion, artifact registration)
- [ ] Deploy to VPS and verify prebuild service stops OOM-killing
- [ ] Verify CPU badge shows non-zero values under load
- [ ] Verify worker no longer produces filtered files inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)