### PR TITLE
Fix prebuild OOM, SQLite lock timeout, and restart-loop guard

### DIFF
--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -28,7 +28,7 @@ class FilteredHourArtifact:
 class RelayIndex:
     def __init__(self, db_path: Path, *, event_retention: int = 50000) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(db_path, timeout=30, check_same_thread=False)
+        self._conn = sqlite3.connect(db_path, timeout=60, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._event_retention = event_retention
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -187,7 +187,8 @@ class RelayIndex:
                     """
                     UPDATE archive_hours
                     SET mirror_status = 'pending',
-                        last_error = COALESCE(last_error, 'mirror interrupted by restart')
+                        last_error = COALESCE(last_error, 'mirror interrupted by restart'),
+                        error_count = error_count + 1
                     WHERE mirror_status = 'processing'
                     """
                 )
@@ -199,7 +200,8 @@ class RelayIndex:
                     """
                     UPDATE archive_hours
                     SET process_status = 'pending',
-                        last_error = COALESCE(last_error, 'processing interrupted by restart')
+                        last_error = COALESCE(last_error, 'processing interrupted by restart'),
+                        error_count = error_count + 1
                     WHERE process_status = 'processing'
                     """
                 )
@@ -211,7 +213,8 @@ class RelayIndex:
                     """
                     UPDATE archive_hours
                     SET prebuild_status = 'pending',
-                        last_error = COALESCE(last_error, 'prebuild interrupted by restart')
+                        last_error = COALESCE(last_error, 'prebuild interrupted by restart'),
+                        error_count = error_count + 1
                     WHERE prebuild_status = 'processing'
                     """
                 )

--- a/pmxt_relay/processor.py
+++ b/pmxt_relay/processor.py
@@ -258,6 +258,7 @@ class RelayHourProcessor:
             con.execute(f"SET threads = {self._config.duckdb_threads}")
             con.execute(f"SET memory_limit = '{self._config.duckdb_memory_limit}'")
             con.execute(f"SET temp_directory = '{temp_root}'")
+            con.execute("SET preserve_insertion_order = false")
 
             # Get unique keys (lightweight metadata scan).
             keys = con.execute(


### PR DESCRIPTION
## Summary
- **DuckDB OOM**: disable `preserve_insertion_order` during `COPY PARTITION_BY` — row order is irrelevant for per-market filtered slices, and this significantly reduces DuckDB's memory footprint (swap usage dropped from 485MB to 33MB after deploy)
- **SQLite locking**: increase busy timeout from 30s to 60s to handle I/O-bound contention between the worker and prebuild services
- **Restart-loop protection**: increment `error_count` when `reset_inflight_work` demotes `processing` → `pending`, so hours that crash-loop (e.g., OOM-killed before the exception handler runs) eventually hit the `error_count < 3` guard instead of retrying forever

## Test plan
- [x] `test_pmxt_relay_index_db.py` — 15 passed
- [x] `test_pmxt_relay_processor.py` — 3 passed
- [x] Deployed to VPS, restarted all 3 services, confirmed:
  - Zero errors post-restart
  - Prebuild actively processing (`2026-03-24T01`)
  - Restart correctly incremented `error_count` on the one inflight hour
  - Swap usage dropped from 485MB → 33MB (preserve_insertion_order=false effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)