### PR TITLE
Fix relay SQLite lock contention and discovery page walking

### DIFF
--- a/pmxt_relay/config.py
+++ b/pmxt_relay/config.py
@@ -68,7 +68,7 @@ class RelayConfig:
             ).rstrip("/"),
             poll_interval_secs=max(60, _env_int("PMXT_RELAY_POLL_INTERVAL_SECS", 900)),
             http_timeout_secs=max(5, _env_int("PMXT_RELAY_HTTP_TIMEOUT_SECS", 60)),
-            archive_stale_pages=max(1, _env_int("PMXT_RELAY_ARCHIVE_STALE_PAGES", 3)),
+            archive_stale_pages=max(1, _env_int("PMXT_RELAY_ARCHIVE_STALE_PAGES", 1)),
             archive_max_pages=archive_max_pages or None,
             duckdb_threads=max(1, _env_int("PMXT_RELAY_DUCKDB_THREADS", 4)),
             duckdb_memory_limit=os.getenv("PMXT_RELAY_DUCKDB_MEMORY_LIMIT", "4GB"),

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -464,6 +464,8 @@ class RelayIndex:
                 (error, filename),
             )
 
+    _PREBUILT_BATCH_SIZE = 5000
+
     def mark_prebuilt(
         self,
         filename: str,
@@ -471,33 +473,37 @@ class RelayIndex:
         filtered_artifact_count: int,
         artifacts: list[FilteredHourArtifact] | None = None,
     ) -> None:
-        with self._conn:
-            if artifacts:
+        if artifacts:
+            with self._conn:
                 self._conn.execute(
                     "DELETE FROM filtered_hours WHERE filename = ?",
                     (filename,),
                 )
-                self._conn.executemany(
-                    """
-                    INSERT INTO filtered_hours (
-                        filename, hour, condition_id, token_id,
-                        local_path, row_count, byte_size, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    [
-                        (
-                            a.filename,
-                            a.hour,
-                            a.condition_id,
-                            a.token_id,
-                            a.local_path,
-                            a.row_count,
-                            a.byte_size,
-                            _utc_now(),
-                        )
-                        for a in artifacts
-                    ],
-                )
+            for offset in range(0, len(artifacts), self._PREBUILT_BATCH_SIZE):
+                batch = artifacts[offset : offset + self._PREBUILT_BATCH_SIZE]
+                with self._conn:
+                    self._conn.executemany(
+                        """
+                        INSERT INTO filtered_hours (
+                            filename, hour, condition_id, token_id,
+                            local_path, row_count, byte_size, created_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        [
+                            (
+                                a.filename,
+                                a.hour,
+                                a.condition_id,
+                                a.token_id,
+                                a.local_path,
+                                a.row_count,
+                                a.byte_size,
+                                _utc_now(),
+                            )
+                            for a in batch
+                        ],
+                    )
+        with self._conn:
             self._conn.execute(
                 """
                 UPDATE archive_hours


### PR DESCRIPTION
## Summary
- **Batch `mark_prebuilt` inserts**: splits the single large transaction (up to 40k rows) into batches of 5k, releasing the SQLite write lock between batches. This was causing the worker process to crash with `database is locked` after exhausting the 60s busy timeout (~115 restarts observed on the VPS).
- **Lower default `archive_stale_pages`** from 3 to 1: discovery now stops as soon as it hits a page where everything is already known, instead of walking additional stale pages unnecessarily.

## Test plan
- [x] All 81 tests pass (including `test_mark_prebuilt_registers_artifacts_in_filtered_hours` which exercises the batched path)
- [ ] Deploy to VPS and verify worker restart counter stops climbing
- [ ] Verify discovery cycles complete faster with `ARCHIVE_STALE_PAGES=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)