### PR TITLE
Fix PMXT backtest ordering and direct script entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ Unlike git submodules, subtrees copy upstream code directly into this repo — t
 - [x] PMXT relay misses or raw-fallback PMXT L2 loads can still take a long time -- relay now returns 404 for non-prebuilt hours (no more server-side scanning), client falls back to r2.pmxt.dev [PR#22](https://github.com/evan-kolberg/prediction-market-backtesting/pull/22)
 - [x] Public relay rate-limiting previously collapsed proxied clients into one shared bucket behind Caddy; relay now trusts forwarded client IPs only from configured local proxies [PR#25](https://github.com/evan-kolberg/prediction-market-backtesting/pull/25)
 - [x] Relay request-rate buckets could accumulate stale one-off clients forever; expired buckets are now pruned instead of lingering in memory [PR#25](https://github.com/evan-kolberg/prediction-market-backtesting/pull/25)
+- [x] PMXT L2 backtests could fail with `No order book data found` on longer windows because quote ticks could be replayed ahead of their first book snapshot; PMXT events are now ordered by event time with book updates before quotes [PR#26](https://github.com/evan-kolberg/prediction-market-backtesting/pull/26)
+- [x] `polymarket_simple_quoter.py` could fail when run directly because the repo-root bootstrap happened too late for `_defaults`; direct-script imports now initialize the repo root first [PR#26](https://github.com/evan-kolberg/prediction-market-backtesting/pull/26)
 - [ ] multi-market runs do not yet share a universal raw per-hour cache, and optional local filtered-disk-cache growth is currently unbounded
 
 ## License

--- a/backtests/polymarket_trade_tick/polymarket_simple_quoter.py
+++ b/backtests/polymarket_trade_tick/polymarket_simple_quoter.py
@@ -31,6 +31,8 @@ Data sources:
 
 """
 
+# ruff: noqa: E402
+
 import asyncio
 import os
 import sys
@@ -38,6 +40,13 @@ from decimal import Decimal
 from pathlib import Path
 
 import pandas as pd
+
+try:
+    from ._script_helpers import ensure_repo_root
+except ImportError:
+    from _script_helpers import ensure_repo_root
+
+ensure_repo_root(__file__)
 
 from nautilus_trader.adapters.polymarket import POLYMARKET_VENUE
 from nautilus_trader.adapters.polymarket import PolymarketDataLoader

--- a/nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py
+++ b/nautilus_pm/nautilus_trader/adapters/polymarket/pmxt.py
@@ -632,6 +632,18 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             timestamp=PolymarketPMXTDataLoader._timestamp_to_ms_string(payload.timestamp),
         )
 
+    @staticmethod
+    def _event_sort_key(record: OrderBookDeltas | QuoteTick) -> tuple[int, int, int]:
+        ts_event = int(getattr(record, "ts_event", getattr(record, "ts_init", 0)))
+        ts_init = int(getattr(record, "ts_init", ts_event))
+        if isinstance(record, OrderBookDeltas):
+            priority = 0
+        elif isinstance(record, QuoteTick):
+            priority = 1
+        else:
+            priority = 2
+        return (ts_event, priority, ts_init)
+
     def _process_book_snapshot(
         self,
         payload_text: str,
@@ -793,7 +805,5 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
                             include_quotes=include_quotes,
                         )
 
-        events.sort(
-            key=lambda record: int(getattr(record, "ts_init", getattr(record, "ts_event", 0)))
-        )
+        events.sort(key=self._event_sort_key)
         return events

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -14,6 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
     "relative_path",
     [
         Path("backtests/kalshi_trade_tick/kalshi_breakout.py"),
+        Path("backtests/polymarket_trade_tick/polymarket_simple_quoter.py"),
         Path("backtests/polymarket_trade_tick/polymarket_vwap_reversion.py"),
     ],
 )

--- a/tests/test_polymarket_pmxt_cache.py
+++ b/tests/test_polymarket_pmxt_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pyarrow as pa
@@ -265,6 +266,108 @@ def test_iter_market_tables_preserves_hour_order(tmp_path):
     assert [hour for hour, _ in yielded] == hours
     assert [table.to_pylist()[0]["data"] for _, table in yielded] == [
         hour.isoformat() for hour in hours
+    ]
+
+
+def test_event_sort_key_orders_book_updates_before_quotes(monkeypatch):
+    class _FakeOrderBookDeltas:
+        def __init__(self, ts_event: int, ts_init: int) -> None:
+            self.ts_event = ts_event
+            self.ts_init = ts_init
+
+    class _FakeQuoteTick:
+        def __init__(self, ts_event: int, ts_init: int) -> None:
+            self.ts_event = ts_event
+            self.ts_init = ts_init
+
+    monkeypatch.setattr(pmxt_module, "OrderBookDeltas", _FakeOrderBookDeltas)
+    monkeypatch.setattr(pmxt_module, "QuoteTick", _FakeQuoteTick)
+
+    quote = _FakeQuoteTick(ts_event=10, ts_init=11)
+    delta = _FakeOrderBookDeltas(ts_event=10, ts_init=20)
+
+    ordered = sorted(
+        [quote, delta],
+        key=PolymarketPMXTDataLoader._event_sort_key,
+    )
+
+    assert ordered == [delta, quote]
+
+
+def test_load_order_book_and_quotes_keeps_snapshot_before_quote(monkeypatch, tmp_path):
+    loader = _make_loader(tmp_path)
+    loader._instrument = SimpleNamespace(id="POLYMARKET.TEST")
+    hour = pd.Timestamp("2026-03-16T12:00:00Z")
+
+    class _FakeOrderBook:
+        def __init__(self, instrument_id, book_type):  # type: ignore[no-untyped-def]
+            self.instrument_id = instrument_id
+            self.book_type = book_type
+
+    class _FakeOrderBookDeltas:
+        def __init__(self, ts_event: int, ts_init: int) -> None:
+            self.ts_event = ts_event
+            self.ts_init = ts_init
+
+    class _FakeQuoteTick:
+        def __init__(self, ts_event: int, ts_init: int) -> None:
+            self.ts_event = ts_event
+            self.ts_init = ts_init
+
+    monkeypatch.setattr(pmxt_module, "OrderBook", _FakeOrderBook)
+    monkeypatch.setattr(pmxt_module, "OrderBookDeltas", _FakeOrderBookDeltas)
+    monkeypatch.setattr(pmxt_module, "QuoteTick", _FakeQuoteTick)
+
+    loader._archive_hours = lambda _start, _end: [hour]  # type: ignore[method-assign]
+    loader._iter_market_batches = (  # type: ignore[method-assign]
+        lambda hours, *, batch_size: iter(
+            [
+                (
+                    hour,
+                    [
+                        pa.record_batch(
+                            [
+                                pa.array(["book_snapshot"]),
+                                pa.array(['{"token_id":"token-yes-123"}']),
+                            ],
+                            names=["update_type", "data"],
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+    def _process_book_snapshot(  # type: ignore[no-untyped-def]
+        payload_text,
+        *,
+        token_id,
+        instrument,
+        local_book,
+        has_snapshot,
+        events,
+        start_ns,
+        end_ns,
+        include_order_book,
+        include_quotes,
+    ):
+        del payload_text, token_id, instrument, has_snapshot, start_ns, end_ns
+        if include_order_book:
+            events.append(_FakeOrderBookDeltas(ts_event=10, ts_init=20))
+        if include_quotes:
+            events.append(_FakeQuoteTick(ts_event=10, ts_init=11))
+        return local_book, True
+
+    monkeypatch.setattr(loader, "_process_book_snapshot", _process_book_snapshot)
+
+    data = loader.load_order_book_and_quotes(
+        hour,
+        hour + pd.Timedelta(hours=1),
+    )
+
+    assert [type(record).__name__ for record in data] == [
+        "_FakeOrderBookDeltas",
+        "_FakeQuoteTick",
     ]
 
 


### PR DESCRIPTION
## Summary
- fix PMXT L2 event ordering so long-window backtests do not replay quotes ahead of the first book snapshot
- fix direct execution of `polymarket_simple_quoter.py` and add direct-entrypoint regression coverage
- document the fixed issues under `Known Issues` with `PR#26`

## Verification
- executed all 25 backtest entrypoints successfully on the current tree
- `printf '15\\n' | make backtest`
- `uv run pytest tests/ -q` (`94 passed, 1 skipped`)
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`