### PR TITLE
Tighten README issue list and agent testing rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,20 @@ When reviewing behavior, separate:
 
 The latter is not automatically a code bug.
 
+## End-To-End Claims
+
+- If the user says `test everything`, `end-to-end`, `all backtests`, or asks whether `everything works`, verify the current worktree, not just `HEAD` or the PR diff.
+- Do not claim `all backtests passed` until every runnable entrypoint under `backtests/` has returned `0` on the current tree.
+- If the worktree is dirty, explicitly separate:
+  - current-worktree verification
+  - what is actually included in the PR/commit
+- If the user reports a specific failing command, rerun that exact command first. Do not substitute a nearby script and call it equivalent.
+- When touching PMXT loader behavior, runner bootstrap, `main.py`, or default backtest selection/parameters, verify both:
+  - the direct script path for the affected runner
+  - the interactive/menu path, e.g. `make backtest`
+- Do not merge a backtest-affecting PR after only partial smokes if the user asked for full end-to-end validation.
+- Clean up temporary sweep artifacts and long-running background verification processes before finishing.
+
 ## Backtest Runner Conventions
 
 - Timing/progress output should stay enabled by default in `main.py`.
@@ -179,6 +193,7 @@ Good default test mix for this repo:
 - at least one direct-script backtest smoke
 - at least one menu/default PMXT smoke when touching `main.py`, timing, or PMXT loader behavior
 - live relay verification when touching deployed relay code
+- full runnable `backtests/` sweep when the user explicitly asks for all backtests or when answering whether everything works end-to-end
 
 If the user asks whether “everything works,” the answer should be based on:
 

--- a/README.md
+++ b/README.md
@@ -473,13 +473,15 @@ Unlike git submodules, subtrees copy upstream code directly into this repo — t
 
 ## Known Issues
 
-- [ ] Poly/Kalshi APIs rate-limit a lot. Kalshi seems worse. (for trade tick config)
+No outstanding repo-level issues are currently tracked here.
+
+Recently fixed:
+
 - [x] PMXT relay misses or raw-fallback PMXT L2 loads can still take a long time -- relay now returns 404 for non-prebuilt hours (no more server-side scanning), client falls back to r2.pmxt.dev [PR#22](https://github.com/evan-kolberg/prediction-market-backtesting/pull/22)
 - [x] Public relay rate-limiting previously collapsed proxied clients into one shared bucket behind Caddy; relay now trusts forwarded client IPs only from configured local proxies [PR#25](https://github.com/evan-kolberg/prediction-market-backtesting/pull/25)
 - [x] Relay request-rate buckets could accumulate stale one-off clients forever; expired buckets are now pruned instead of lingering in memory [PR#25](https://github.com/evan-kolberg/prediction-market-backtesting/pull/25)
 - [x] PMXT L2 backtests could fail with `No order book data found` on longer windows because quote ticks could be replayed ahead of their first book snapshot; PMXT events are now ordered by event time with book updates before quotes [PR#26](https://github.com/evan-kolberg/prediction-market-backtesting/pull/26)
 - [x] `polymarket_simple_quoter.py` could fail when run directly because the repo-root bootstrap happened too late for `_defaults`; direct-script imports now initialize the repo root first [PR#26](https://github.com/evan-kolberg/prediction-market-backtesting/pull/26)
-- [ ] multi-market runs do not yet share a universal raw per-hour cache, and optional local filtered-disk-cache growth is currently unbounded
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove two README items that are not actually current repo issues
- clarify that there are no currently tracked open repo-level issues and keep the fixed-issue history
- strengthen `AGENTS.md` so future agents must verify the current worktree end-to-end before claiming everything works

## Notes
- leaves the local uncommitted `backtests/polymarket_pmxt_relay_vwap_reversion.py` tweak out of the PR
- docs/process-only change; no code behavior changes