### PR TITLE
Add multi-market Polymarket PMXT quote runner

### DIFF
--- a/backtests/polymarket_quote_tick/polymarket_pmxt_relay_sports_vwap_reversion.py
+++ b/backtests/polymarket_quote_tick/polymarket_pmxt_relay_sports_vwap_reversion.py
@@ -1,0 +1,367 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-03-29.
+# See the repository NOTICE file for provenance and licensing scope.
+
+"""
+Public multi-market example: run a quote-tick VWAP-reversion strategy across many
+Polymarket sports markets using PMXT historical L2 data.
+
+This script defaults to a resolved sports-market sample so people can inspect:
+- market discovery,
+- token-side selection,
+- repeated quote-tick PMXT backtests,
+- per-market legacy charts, and
+- one legacy multi-market summary chart.
+"""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+from datetime import UTC
+from datetime import datetime
+from decimal import Decimal
+
+try:
+    from ._script_helpers import ensure_repo_root
+except ImportError:
+    from _script_helpers import ensure_repo_root
+
+ensure_repo_root(__file__)
+
+from nautilus_trader.adapters.polymarket.common.market_selection import closed_time_utc
+from nautilus_trader.adapters.polymarket.common.market_selection import end_date_utc
+from nautilus_trader.adapters.polymarket.research import analyze_market_trade_window
+from nautilus_trader.adapters.polymarket.research import discover_live_sports_markets
+from nautilus_trader.adapters.polymarket.research import (
+    discover_resolved_sports_markets,
+)
+from nautilus_trader.adapters.polymarket.research import fetch_market_by_slug
+from nautilus_trader.adapters.prediction_market.research import print_backtest_summary
+from nautilus_trader.adapters.prediction_market.research import (
+    save_aggregate_backtest_report,
+)
+from nautilus_trader.adapters.prediction_market.research import (
+    save_combined_backtest_report,
+)
+from nautilus_trader.core import nautilus_pyo3
+from strategies import QuoteTickVWAPReversionConfig
+from strategies import QuoteTickVWAPReversionStrategy
+
+
+try:
+    from ._defaults import DEFAULT_INITIAL_CASH
+    from ._polymarket_single_market_pmxt_runner import run_single_market_pmxt_backtest
+    from ._script_helpers import parse_bool_env
+    from ._script_helpers import parse_csv_env
+except ImportError:
+    from backtests.polymarket_quote_tick._defaults import DEFAULT_INITIAL_CASH
+    from backtests.polymarket_quote_tick._polymarket_single_market_pmxt_runner import (
+        run_single_market_pmxt_backtest,
+    )
+    from backtests.polymarket_quote_tick._script_helpers import parse_bool_env
+    from backtests.polymarket_quote_tick._script_helpers import parse_csv_env
+
+
+NAME = "polymarket_pmxt_relay_sports_vwap_reversion"
+DESCRIPTION = "VWAP reversion on multiple Polymarket sports markets using PMXT L2 data"
+
+LOOKBACK_HOURS = float(os.getenv("LOOKBACK_HOURS", "168"))
+SELECTION_LOOKBACK_DAYS = max(1, math.ceil(LOOKBACK_HOURS / 24.0))
+CANDIDATE_LIMIT = int(os.getenv("CANDIDATE_LIMIT", "100"))
+TARGET_RESULTS = int(os.getenv("TARGET_RESULTS", "20"))
+MARKET_MODE = os.getenv("MARKET_MODE", "resolved").strip().lower() or "resolved"
+ACTIVE_WINDOW_HOURS = float(os.getenv("ACTIVE_WINDOW_HOURS", "3"))
+DISCOVERY_MAX_HOURS_TO_CLOSE = float(
+    os.getenv(
+        "DISCOVERY_MAX_HOURS_TO_CLOSE",
+        os.getenv("MAX_HOURS_TO_CLOSE", "4320"),
+    ),
+)
+MAX_DAYS_SINCE_CLOSE = float(os.getenv("MAX_DAYS_SINCE_CLOSE", "365"))
+DISCOVERY_STEP = int(os.getenv("DISCOVERY_STEP", "250"))
+MAX_DISCOVERY_RESULTS = int(os.getenv("MAX_DISCOVERY_RESULTS", "10000"))
+DISCOVERY_CANDIDATE_MULTIPLIER = int(
+    os.getenv("DISCOVERY_CANDIDATE_MULTIPLIER", "4"),
+)
+DISCOVERY_SCAN_MULTIPLIER = int(os.getenv("DISCOVERY_SCAN_MULTIPLIER", "50"))
+GAMES_ONLY = parse_bool_env(os.getenv("GAMES_ONLY", "true"))
+MIN_VOLUME_24H = float(os.getenv("MIN_VOLUME_24H", "0"))
+MIN_QUOTES = int(os.getenv("MIN_QUOTES", "500"))
+MIN_PRICE_RANGE = float(os.getenv("MIN_PRICE_RANGE", "0.005"))
+SELECTION_ENTRY_PRICE = float(os.getenv("SELECTION_ENTRY_PRICE", "0.80"))
+
+VWAP_WINDOW = int(os.getenv("VWAP_WINDOW", "30"))
+ENTRY_THRESHOLD = float(os.getenv("ENTRY_THRESHOLD", "0.0015"))
+EXIT_THRESHOLD = float(os.getenv("EXIT_THRESHOLD", "0.0003"))
+MIN_TICK_SIZE = float(os.getenv("MIN_TICK_SIZE", "0.0"))
+TAKE_PROFIT = float(os.getenv("TAKE_PROFIT", "0.004"))
+STOP_LOSS = float(os.getenv("STOP_LOSS", "0.004"))
+
+TRADE_SIZE = Decimal(os.getenv("TRADE_SIZE", "100"))
+INITIAL_CASH = float(os.getenv("INITIAL_CASH", str(DEFAULT_INITIAL_CASH)))
+CHART_RESAMPLE_RULE = os.getenv("CHART_RESAMPLE_RULE") or None
+EMIT_HTML = parse_bool_env(os.getenv("EMIT_HTML", "true"))
+COMBINED_REPORT = parse_bool_env(os.getenv("COMBINED_REPORT", "false"))
+COMBINED_REPORT_PATH = os.getenv(
+    "COMBINED_REPORT_PATH",
+    f"output/{NAME}_combined_legacy.html",
+)
+SUMMARY_REPORT = parse_bool_env(os.getenv("SUMMARY_REPORT", "true"))
+SUMMARY_REPORT_PATH = os.getenv(
+    "SUMMARY_REPORT_PATH",
+    f"output/{NAME}_multi_market.html",
+)
+MARKET_SLUGS = parse_csv_env(os.getenv("MARKET_SLUGS", ""))
+
+
+def _market_window_end(market: dict) -> datetime | None:
+    if MARKET_MODE != "resolved":
+        return None
+    return closed_time_utc(market)
+
+
+def _market_close_timestamp(market: dict) -> float:
+    close_dt = closed_time_utc(market) or end_date_utc(market)
+    return close_dt.timestamp() if close_dt is not None else 0.0
+
+
+def _market_volume(market: dict) -> float:
+    return float(market.get("volume24hr") or market.get("volume") or 0.0)
+
+
+def _sort_markets(markets: list[dict]) -> list[dict]:
+    if MARKET_MODE == "resolved":
+        markets.sort(
+            key=lambda market: (
+                -_market_volume(market),
+                -_market_close_timestamp(market),
+            ),
+        )
+    else:
+        markets.sort(
+            key=lambda market: (
+                end_date_utc(market) or datetime.max.replace(tzinfo=UTC),
+                -_market_volume(market),
+            ),
+        )
+    return markets
+
+
+async def _select_markets(*, candidate_limit: int) -> list[dict]:
+    if MARKET_SLUGS:
+        client = nautilus_pyo3.HttpClient(
+            default_quota=nautilus_pyo3.Quota.rate_per_second(10),
+        )
+        selected: list[dict] = []
+        for slug in MARKET_SLUGS:
+            try:
+                market = await fetch_market_by_slug(slug, http_client=client)
+            except Exception as exc:
+                print(f"Skip {slug}: {exc}")
+                continue
+            selected.append(market)
+        return selected
+
+    max_results = min(
+        MAX_DISCOVERY_RESULTS,
+        max(candidate_limit * DISCOVERY_SCAN_MULTIPLIER, candidate_limit, 1000),
+    )
+
+    if MARKET_MODE == "live":
+        markets = await discover_live_sports_markets(
+            candidate_limit=candidate_limit,
+            max_results=max_results,
+            quota_rate_per_second=20,
+            min_volume_24h=MIN_VOLUME_24H,
+            max_hours_to_close=DISCOVERY_MAX_HOURS_TO_CLOSE,
+            games_only=GAMES_ONLY,
+        )
+    else:
+        markets = await discover_resolved_sports_markets(
+            candidate_limit=candidate_limit,
+            max_results=max_results,
+            quota_rate_per_second=20,
+            min_volume_24h=MIN_VOLUME_24H,
+            max_days_since_close=MAX_DAYS_SINCE_CLOSE,
+            games_only=GAMES_ONLY,
+        )
+
+    return _sort_markets(markets)
+
+
+async def run() -> None:
+    target_results = (
+        min(TARGET_RESULTS, len(MARKET_SLUGS)) if MARKET_SLUGS else TARGET_RESULTS
+    )
+    candidate_budget = max(
+        CANDIDATE_LIMIT,
+        target_results * DISCOVERY_CANDIDATE_MULTIPLIER,
+    )
+    if not MARKET_SLUGS:
+        candidate_budget = min(candidate_budget, MAX_DISCOVERY_RESULTS)
+
+    seen_slugs: set[str] = set()
+    results: list[dict] = []
+    attempted = 0
+
+    while len(results) < target_results:
+        markets = await _select_markets(candidate_limit=candidate_budget)
+        if not markets:
+            break
+
+        fresh_markets = []
+        for market in markets:
+            slug = str(market.get("slug") or market.get("market_slug") or "")
+            if not slug or slug in seen_slugs:
+                continue
+            fresh_markets.append(market)
+            seen_slugs.add(slug)
+
+        if not fresh_markets:
+            break
+
+        print(
+            f"Loaded {len(fresh_markets)} new Polymarket candidates "
+            f"(mode={MARKET_MODE}, target_results={target_results}, "
+            f"completed={len(results)}, attempted={attempted})."
+        )
+
+        for market in fresh_markets:
+            if len(results) >= target_results:
+                break
+
+            slug = str(market.get("slug") or market.get("market_slug") or "")
+            analysis = await analyze_market_trade_window(
+                market=market,
+                lookback_days=SELECTION_LOOKBACK_DAYS,
+                entry_price=SELECTION_ENTRY_PRICE,
+                active_window_hours=ACTIVE_WINDOW_HOURS,
+            )
+            if analysis is None:
+                print(f"Skip {slug}: unable to analyze market trade window")
+                attempted += 1
+                continue
+
+            token_index = int(analysis.get("token_index") or 0)
+            token_outcome = str(analysis.get("token_outcome") or "")
+            activation_trades = int(analysis.get("activation_trades") or 0)
+            first_activation_price = analysis.get("first_activation_price")
+            max_activation_price = analysis.get("max_activation_price")
+            crossed_entry = bool(analysis.get("crossed_entry"))
+            window_end = _market_window_end(analysis)
+            attempted += 1
+
+            first_text = (
+                f"{float(first_activation_price):.2f}"
+                if first_activation_price is not None
+                else "n/a"
+            )
+            max_text = (
+                f"{float(max_activation_price):.2f}"
+                if max_activation_price is not None
+                else "n/a"
+            )
+            print(
+                f"Running {slug} on token_index={token_index} "
+                f"outcome={token_outcome or 'n/a'} "
+                f"first_active={first_text} max_active={max_text} "
+                f"active_trades={activation_trades} crossed_entry={crossed_entry}"
+            )
+
+            result = await run_single_market_pmxt_backtest(
+                name=NAME,
+                market_slug=slug,
+                token_index=token_index,
+                lookback_hours=LOOKBACK_HOURS,
+                min_quotes=MIN_QUOTES,
+                min_price_range=MIN_PRICE_RANGE,
+                initial_cash=INITIAL_CASH,
+                probability_window=VWAP_WINDOW,
+                chart_resample_rule=CHART_RESAMPLE_RULE,
+                emit_summary=False,
+                emit_html=EMIT_HTML,
+                return_chart_layout=False,
+                return_summary_series=SUMMARY_REPORT,
+                end_time=window_end,
+                strategy_factory=lambda instrument_id: QuoteTickVWAPReversionStrategy(
+                    config=QuoteTickVWAPReversionConfig(
+                        instrument_id=instrument_id,
+                        trade_size=TRADE_SIZE,
+                        vwap_window=VWAP_WINDOW,
+                        entry_threshold=ENTRY_THRESHOLD,
+                        exit_threshold=EXIT_THRESHOLD,
+                        min_tick_size=MIN_TICK_SIZE,
+                        take_profit=TAKE_PROFIT,
+                        stop_loss=STOP_LOSS,
+                    ),
+                ),
+            )
+            if result is None:
+                continue
+
+            result["outcome"] = token_outcome
+            result["activation_trades"] = activation_trades
+            result["crossed_entry"] = crossed_entry
+            results.append(result)
+            print(
+                f"Completed {len(results)}/{target_results}: {slug} "
+                f"pnl={float(result['pnl']):+.4f} "
+                f"fills={int(result['fills'])} "
+                f"quotes={int(result['quotes'])} "
+                f"attempted={attempted}"
+            )
+
+        if MARKET_SLUGS or candidate_budget >= MAX_DISCOVERY_RESULTS:
+            break
+        candidate_budget = min(candidate_budget + DISCOVERY_STEP, MAX_DISCOVERY_RESULTS)
+
+    if not results:
+        print(
+            "No Polymarket sports markets had sufficient PMXT quote data for the current filters."
+        )
+        return
+
+    if len(results) < target_results:
+        print(
+            f"Completed {len(results)} Polymarket quote-tick backtests "
+            f"after attempting {attempted} markets. Target was {target_results}."
+        )
+
+    print_backtest_summary(
+        results=results,
+        market_key="slug",
+        count_key="quotes",
+        count_label="Quotes",
+        pnl_label="PnL (USDC)",
+    )
+
+    if COMBINED_REPORT:
+        combined_path = save_combined_backtest_report(
+            results=results,
+            output_path=COMBINED_REPORT_PATH,
+            title=f"{NAME} combined legacy chart",
+            market_key="slug",
+            pnl_label="PnL (USDC)",
+        )
+        if combined_path is not None:
+            print(f"\nCombined legacy chart saved to {combined_path}")
+
+    if SUMMARY_REPORT:
+        summary_path = save_aggregate_backtest_report(
+            results=results,
+            output_path=SUMMARY_REPORT_PATH,
+            title=f"{NAME} legacy multi-market chart",
+            market_key="slug",
+            pnl_label="PnL (USDC)",
+        )
+        if summary_path is not None:
+            print(f"\nLegacy multi-market chart saved to {summary_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add a multi-market PMXT quote-tick sports runner for Polymarket
- reuse the single-market PMXT runner and existing sports market discovery/token-side selection flow
- emit aggregate multi-market legacy plotting alongside the per-market runs

## Verification
- uv run ruff check --exclude nautilus_pm .
- uv run ruff format --check --exclude nautilus_pm .
- uv run pytest tests/ -q
- MARKET_MODE=live MARKET_SLUGS=will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026 TARGET_RESULTS=1 LOOKBACK_HOURS=24 MIN_QUOTES=1 MIN_PRICE_RANGE=0 EMIT_HTML=0 SUMMARY_REPORT=0 COMBINED_REPORT=0 timeout 120 uv run python -u backtests/polymarket_quote_tick/polymarket_pmxt_relay_sports_vwap_reversion.py