### PR TITLE
Fix NOTICE coverage for LGPL root files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -43,6 +43,7 @@ notices with file-specific change dates:
 - `backtests/polymarket_quote_tick/polymarket_pmxt_relay_late_favorite_limit_hold.py`
 - `backtests/polymarket_quote_tick/polymarket_pmxt_relay_panic_fade.py`
 - `backtests/polymarket_quote_tick/polymarket_pmxt_relay_rsi_reversion.py`
+- `backtests/polymarket_quote_tick/polymarket_pmxt_relay_sports_vwap_reversion.py`
 - `backtests/polymarket_quote_tick/polymarket_pmxt_relay_spread_capture.py`
 - `backtests/polymarket_quote_tick/polymarket_pmxt_relay_threshold_momentum.py`
 - `backtests/polymarket_quote_tick/polymarket_pmxt_relay_vwap_reversion.py`

--- a/tests/test_notice_license_coverage.py
+++ b/tests/test_notice_license_coverage.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTICE_PATH = REPO_ROOT / "NOTICE"
+ROOT_NOTICE_SPLIT = "Local modifications inside the vendored NautilusTrader subtree"
+LGPL_HEADER_MARKERS = (
+    "Derived from NautilusTrader",
+    "Modified by Evan Kolberg in this repository",
+    "Distributed under the GNU Lesser General Public License Version 3.0 or later.",
+)
+
+
+def _tracked_files() -> list[str]:
+    output = subprocess.check_output(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    return output.splitlines()
+
+
+def _has_root_lgpl_header(relative_path: str) -> bool:
+    if relative_path.startswith("nautilus_pm/"):
+        return False
+
+    path = REPO_ROOT / relative_path
+    try:
+        header_lines = path.read_text(errors="ignore").splitlines()[:30]
+    except OSError:
+        return False
+
+    for line in header_lines:
+        stripped = line.lstrip()
+        if not stripped.startswith("#"):
+            continue
+        if any(marker in stripped for marker in LGPL_HEADER_MARKERS):
+            return True
+    return False
+
+
+def _root_notice_paths() -> set[str]:
+    notice_text = NOTICE_PATH.read_text()
+    root_section = notice_text.split(ROOT_NOTICE_SPLIT, maxsplit=1)[0]
+    return {
+        path
+        for path in re.findall(r"- `([^`]+)`", root_section)
+        if not path.endswith("/") and not path.startswith("nautilus_pm/")
+    }
+
+
+def test_notice_lists_all_root_lgpl_files() -> None:
+    root_lgpl_files = {
+        relative_path
+        for relative_path in _tracked_files()
+        if _has_root_lgpl_header(relative_path)
+    }
+    notice_paths = _root_notice_paths()
+
+    assert root_lgpl_files == notice_paths


### PR DESCRIPTION
## Summary
- add the missing LGPL-covered multi-market runner to `NOTICE`
- add a test that compares root-level Nautilus-derived file headers against `NOTICE`

## Verification
- `uv run pytest tests/test_notice_license_coverage.py -q`
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`