### PR TITLE
[codex] add modular PMXT BYOD sources and under-construction relay docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@
 ![GitHub top language](https://img.shields.io/github/languages/top/evan-kolberg/prediction-market-backtesting)
 ![GitHub open issues](https://img.shields.io/github/issues/evan-kolberg/prediction-market-backtesting)
 
-Relay VPS statistics:
+> UNDER CONSTRUCTION: the public PMXT relay/VPS is being reworked. Expect
+> processed/prebuilt coverage and VPS stats to be unstable while the old
+> processed layer is purged and a ClickHouse-backed replacement is planned. In
+> the meantime, the PMXT L2 runners support BYOD/local sources. See
+> [`docs/pmxt-byod.md`](docs/pmxt-byod.md).
+
+Relay VPS statistics (may be stale while the relay is under construction):
 
 [![PMXT relay](https://209-209-10-83.sslip.io/v1/badge/status.svg)](https://209-209-10-83.sslip.io/v1/stats)
 [![Relay CPU](https://209-209-10-83.sslip.io/v1/badge/cpu.svg)](https://209-209-10-83.sslip.io/v1/system)
@@ -158,8 +164,8 @@ MARKET_SLUG=<polymarket-market-slug> uv run python backtests/polymarket_trade_ti
 ```
 
 If you omit the market env vars, the public runners fall back to the defaults
-bundled in each module. The PMXT single-market relay runners are intentionally
-pinned to one relay-backed historical slice in code, and the PMXT sports
+bundled in each module. The PMXT single-market L2 runners are intentionally
+pinned to one known-good historical slice in code, and the PMXT sports
 multi-market example is pinned to a small fixed set of recent March 2026 sports
 futures with explicit multi-day windows, so those examples still replay cleanly
 without the latest upstream PMXT hours.
@@ -170,12 +176,19 @@ Most runners are configured through environment variables. Common ones:
 - `MARKET_SLUG` for Polymarket trade-tick single-market runners
 - `TOKEN_INDEX` to choose which Polymarket outcome token to backtest
 - `LOOKBACK_DAYS` for data window size
+- `PMXT_DATA_SOURCE` for PMXT L2 runner source selection:
+  `auto`, `relay`, `raw-remote`, `raw-local`, or `filtered-local`
+- `PMXT_LOCAL_MIRROR_DIR` for `PMXT_DATA_SOURCE=raw-local`
+- `PMXT_LOCAL_FILTERED_DIR` for `PMXT_DATA_SOURCE=filtered-local`
 - `PMXT_RELAY_BASE_URL` to override the default public relay or disable it
   with `PMXT_RELAY_BASE_URL=0`
 - `PMXT_CACHE_DIR` / `PMXT_DISABLE_CACHE` to control the local PMXT filtered
   parquet cache
 - `TRADE_SIZE` and `INITIAL_CASH` for sizing
 - `TARGET_RESULTS` for multi-market runners
+
+For exact PMXT BYOD layouts and the expected L2 payload shape, see
+[`docs/pmxt-byod.md`](docs/pmxt-byod.md).
 
 The interactive menu always prints total wall time. PMXT fetch timing
 instrumentation is enabled by default in `make backtest` / `uv run python
@@ -228,6 +241,17 @@ data are:
 
 ### PMXT Polymarket L2
 
+- The public relay is currently under construction. If it is slow, unavailable,
+  or still catching up, use BYOD/local PMXT sources instead of waiting on the
+  VPS.
+- PMXT quote-tick runners now support explicit source selection:
+  - `PMXT_DATA_SOURCE=auto` keeps the current cache -> relay -> raw remote chain
+  - `PMXT_DATA_SOURCE=relay` forces relay-first mode
+  - `PMXT_DATA_SOURCE=raw-remote` skips the relay
+  - `PMXT_DATA_SOURCE=raw-local PMXT_LOCAL_MIRROR_DIR=/path/to/raw` replays a local raw PMXT mirror
+  - `PMXT_DATA_SOURCE=filtered-local PMXT_LOCAL_FILTERED_DIR=/path/to/filtered` replays local prefiltered parquet only
+- The exact BYOD directory layout and required L2 payload shape are documented
+  in [`docs/pmxt-byod.md`](docs/pmxt-byod.md).
 - Public Polymarket PMXT runners now default to the public relay at
   `https://209-209-10-83.sslip.io`.
 - For each required hour, the loader tries the relay first:
@@ -323,6 +347,22 @@ make clear-pmxt-cache
   market/window and the default local cache:
 
 ```bash
+uv run python backtests/polymarket_quote_tick/polymarket_pmxt_relay_ema_crossover.py
+```
+
+- Example: run the same PMXT backtest against a local raw mirror:
+
+```bash
+PMXT_DATA_SOURCE=raw-local \
+PMXT_LOCAL_MIRROR_DIR=/data/pmxt/raw \
+uv run python backtests/polymarket_quote_tick/polymarket_pmxt_relay_ema_crossover.py
+```
+
+- Example: run it against local prefiltered parquet only:
+
+```bash
+PMXT_DATA_SOURCE=filtered-local \
+PMXT_LOCAL_FILTERED_DIR=/data/pmxt/filtered \
 uv run python backtests/polymarket_quote_tick/polymarket_pmxt_relay_ema_crossover.py
 ```
 

--- a/backtests/_shared/_timing_test.py
+++ b/backtests/_shared/_timing_test.py
@@ -34,74 +34,103 @@ def install_timing() -> None:
     from tqdm import tqdm
     from nautilus_trader.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
 
+    try:
+        from backtests._shared.data_sources.pmxt import (
+            RunnerPolymarketPMXTDataLoader,
+        )
+    except ImportError:
+        RunnerPolymarketPMXTDataLoader = None
+
     source_local = threading.local()
     pbar_state: dict = {"bar": None}
     pbar_lock = threading.Lock()
 
-    orig_load = PolymarketPMXTDataLoader._load_market_batches
-    orig_cached = PolymarketPMXTDataLoader._load_cached_market_batches
-    orig_relay = PolymarketPMXTDataLoader._load_relay_market_batches
-    orig_remote = PolymarketPMXTDataLoader._load_remote_market_batches
-    orig_iter = PolymarketPMXTDataLoader._iter_market_batches
+    def _install_full_timing(loader_cls) -> None:  # type: ignore[no-untyped-def]
+        orig_load = loader_cls._load_market_batches
+        orig_cached = loader_cls._load_cached_market_batches
+        orig_relay = loader_cls._load_relay_market_batches
+        orig_remote = loader_cls._load_remote_market_batches
+        orig_iter = loader_cls._iter_market_batches
 
-    def patched_cached(self, hour):
-        result = orig_cached(self, hour)
-        if result is not None:
-            cache_path = self._cache_path_for_hour(hour)
-            source_local.source = str(cache_path)
-        return result
+        def patched_cached(self, hour):
+            result = orig_cached(self, hour)
+            if result is not None:
+                cache_path = self._cache_path_for_hour(hour)
+                source_local.source = str(cache_path)
+            return result
 
-    def patched_relay(self, hour, *, batch_size):
-        result = orig_relay(self, hour, batch_size=batch_size)
-        if result is not None:
-            source_local.source = self._pmxt_relay_base_url or "relay"
-        return result
+        def patched_relay(self, hour, *, batch_size):
+            result = orig_relay(self, hour, batch_size=batch_size)
+            if result is not None:
+                source_local.source = self._pmxt_relay_base_url or "relay"
+            return result
 
-    def patched_remote(self, hour, *, batch_size):
-        result = orig_remote(self, hour, batch_size=batch_size)
-        if result is not None:
-            source_local.source = self._PMXT_BASE_URL
-        return result
-
-    def timed_load(self, hour, *, batch_size):
-        source_local.source = "none"
-        t0 = time.perf_counter()
-        result = orig_load(self, hour, batch_size=batch_size)
-        elapsed = time.perf_counter() - t0
-        rows = sum(b.num_rows for b in result) if result else 0
-        source = getattr(source_local, "source", "unknown")
-
-        with pbar_lock:
-            bar = pbar_state["bar"]
-            if bar is not None:
-                bar.write(
-                    f"  {hour.isoformat():>25s}  {elapsed:6.3f}s  {rows:>6} rows  {source}"
+        def patched_remote(self, hour, *, batch_size):
+            result = orig_remote(self, hour, batch_size=batch_size)
+            if result is not None:
+                raw_root = getattr(self, "_pmxt_raw_root", None)
+                source_local.source = (
+                    str(raw_root) if raw_root is not None else self._PMXT_BASE_URL
                 )
-                bar.update(1)
-        return result
+            return result
 
-    def patched_iter(self, hours, *, batch_size):
-        with pbar_lock:
-            pbar_state["bar"] = tqdm(
-                total=len(hours),
-                desc="Fetching hours",
-                unit="hr",
-                bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]",
-            )
-        try:
-            yield from orig_iter(self, hours, batch_size=batch_size)
-        finally:
+        def timed_load(self, hour, *, batch_size):
+            source_local.source = "none"
+            t0 = time.perf_counter()
+            result = orig_load(self, hour, batch_size=batch_size)
+            elapsed = time.perf_counter() - t0
+            rows = sum(b.num_rows for b in result) if result else 0
+            source = getattr(source_local, "source", "unknown")
+
             with pbar_lock:
                 bar = pbar_state["bar"]
                 if bar is not None:
-                    bar.close()
-                    pbar_state["bar"] = None
+                    bar.write(
+                        f"  {hour.isoformat():>25s}  {elapsed:6.3f}s  {rows:>6} rows  {source}"
+                    )
+                    bar.update(1)
+            return result
 
-    PolymarketPMXTDataLoader._load_cached_market_batches = patched_cached
-    PolymarketPMXTDataLoader._load_relay_market_batches = patched_relay
-    PolymarketPMXTDataLoader._load_remote_market_batches = patched_remote
-    PolymarketPMXTDataLoader._load_market_batches = timed_load
-    PolymarketPMXTDataLoader._iter_market_batches = patched_iter
+        def patched_iter(self, hours, *, batch_size):
+            with pbar_lock:
+                pbar_state["bar"] = tqdm(
+                    total=len(hours),
+                    desc="Fetching hours",
+                    unit="hr",
+                    bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]",
+                )
+            try:
+                yield from orig_iter(self, hours, batch_size=batch_size)
+            finally:
+                with pbar_lock:
+                    bar = pbar_state["bar"]
+                    if bar is not None:
+                        bar.close()
+                        pbar_state["bar"] = None
+
+        loader_cls._load_cached_market_batches = patched_cached
+        loader_cls._load_relay_market_batches = patched_relay
+        loader_cls._load_remote_market_batches = patched_remote
+        loader_cls._load_market_batches = timed_load
+        loader_cls._iter_market_batches = patched_iter
+
+    def _install_remote_source_only(loader_cls) -> None:  # type: ignore[no-untyped-def]
+        orig_remote = loader_cls._load_remote_market_batches
+
+        def patched_remote(self, hour, *, batch_size):
+            result = orig_remote(self, hour, batch_size=batch_size)
+            if result is not None:
+                raw_root = getattr(self, "_pmxt_raw_root", None)
+                source_local.source = (
+                    str(raw_root) if raw_root is not None else self._PMXT_BASE_URL
+                )
+            return result
+
+        loader_cls._load_remote_market_batches = patched_remote
+
+    _install_full_timing(PolymarketPMXTDataLoader)
+    if RunnerPolymarketPMXTDataLoader is not None:
+        _install_remote_source_only(RunnerPolymarketPMXTDataLoader)
 
 
 def _load_backtest_module(path_str: str):

--- a/backtests/_shared/data_sources/__init__.py
+++ b/backtests/_shared/data_sources/__init__.py
@@ -1,0 +1,27 @@
+"""Shared backtest data-source helpers."""
+
+from backtests._shared.data_sources.pmxt import PMXT_CACHE_DIR_ENV
+from backtests._shared.data_sources.pmxt import PMXT_DATA_SOURCE_ENV
+from backtests._shared.data_sources.pmxt import PMXT_DISABLE_REMOTE_ARCHIVE_ENV
+from backtests._shared.data_sources.pmxt import PMXT_LOCAL_FILTERED_DIR_ENV
+from backtests._shared.data_sources.pmxt import PMXT_LOCAL_MIRROR_DIR_ENV
+from backtests._shared.data_sources.pmxt import PMXT_RAW_ROOT_ENV
+from backtests._shared.data_sources.pmxt import PMXT_RELAY_BASE_URL_ENV
+from backtests._shared.data_sources.pmxt import PMXTDataSourceSelection
+from backtests._shared.data_sources.pmxt import RunnerPolymarketPMXTDataLoader
+from backtests._shared.data_sources.pmxt import configured_pmxt_data_source
+from backtests._shared.data_sources.pmxt import resolve_pmxt_data_source_selection
+
+__all__ = [
+    "PMXT_CACHE_DIR_ENV",
+    "PMXT_DATA_SOURCE_ENV",
+    "PMXT_DISABLE_REMOTE_ARCHIVE_ENV",
+    "PMXT_LOCAL_FILTERED_DIR_ENV",
+    "PMXT_LOCAL_MIRROR_DIR_ENV",
+    "PMXT_RAW_ROOT_ENV",
+    "PMXT_RELAY_BASE_URL_ENV",
+    "PMXTDataSourceSelection",
+    "RunnerPolymarketPMXTDataLoader",
+    "configured_pmxt_data_source",
+    "resolve_pmxt_data_source_selection",
+]

--- a/backtests/_shared/data_sources/pmxt.py
+++ b/backtests/_shared/data_sources/pmxt.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import pyarrow.dataset as ds
+
+from nautilus_trader.adapters.polymarket import PolymarketPMXTDataLoader
+
+
+PMXT_DATA_SOURCE_ENV = "PMXT_DATA_SOURCE"
+PMXT_LOCAL_MIRROR_DIR_ENV = "PMXT_LOCAL_MIRROR_DIR"
+PMXT_LOCAL_FILTERED_DIR_ENV = "PMXT_LOCAL_FILTERED_DIR"
+PMXT_RAW_ROOT_ENV = "PMXT_RAW_ROOT"
+PMXT_DISABLE_REMOTE_ARCHIVE_ENV = "PMXT_DISABLE_REMOTE_ARCHIVE"
+PMXT_RELAY_BASE_URL_ENV = "PMXT_RELAY_BASE_URL"
+PMXT_CACHE_DIR_ENV = "PMXT_CACHE_DIR"
+PMXT_DEFAULT_RELAY_BASE_URL = "https://209-209-10-83.sslip.io"
+
+_DISABLED_ENV_VALUES = {"", "0", "false", "no", "off", "none", "disabled"}
+_MODE_ALIASES = {
+    "": "auto",
+    "auto": "auto",
+    "default": "auto",
+    "relay": "relay",
+    "relay-first": "relay",
+    "raw": "raw-remote",
+    "raw-remote": "raw-remote",
+    "remote-raw": "raw-remote",
+    "raw-local": "raw-local",
+    "local-raw": "raw-local",
+    "mirror": "raw-local",
+    "filtered-local": "filtered-local",
+    "local-filtered": "filtered-local",
+    "cache-local": "filtered-local",
+}
+_VALID_MODES = ("auto", "relay", "raw-remote", "raw-local", "filtered-local")
+
+
+class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
+    """
+    Repo-layer PMXT loader extensions used by the backtest runners.
+
+    This keeps BYOD/local-mirror behavior out of the vendored Nautilus subtree.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        self._pmxt_raw_root = self._resolve_raw_root()
+        self._pmxt_disable_remote_archive = self._env_flag_enabled(
+            os.getenv(PMXT_DISABLE_REMOTE_ARCHIVE_ENV)
+        )
+
+    @classmethod
+    def _resolve_raw_root(cls) -> Path | None:
+        configured = os.getenv(PMXT_RAW_ROOT_ENV)
+        if configured is None:
+            return None
+
+        value = configured.strip()
+        if value.casefold() in _DISABLED_ENV_VALUES:
+            return None
+
+        return Path(value).expanduser()
+
+    def _raw_path_for_hour(self, hour) -> Path | None:  # type: ignore[no-untyped-def]
+        if self._pmxt_raw_root is None:
+            return None
+
+        ts = hour.tz_convert("UTC")
+        return (
+            self._pmxt_raw_root
+            / str(ts.year)
+            / f"{ts.month:02d}"
+            / f"{ts.day:02d}"
+            / self._archive_filename_for_hour(hour)
+        )
+
+    def _load_local_raw_market_batches(
+        self,
+        hour,
+        *,
+        batch_size: int,
+    ):  # type: ignore[no-untyped-def]
+        raw_path = self._raw_path_for_hour(hour)
+        if raw_path is None or not raw_path.exists():
+            return None
+
+        dataset = ds.dataset(str(raw_path), format="parquet")
+        scanner = dataset.scanner(
+            columns=self._PMXT_REMOTE_COLUMNS,
+            filter=self._market_filter(),
+            batch_size=batch_size,
+        )
+        batches = []
+        for batch in scanner.to_batches():
+            filtered_batch = self._filter_batch_to_token(batch)
+            if filtered_batch.num_rows:
+                batches.append(filtered_batch)
+        return batches
+
+    def _load_remote_market_batches(
+        self,
+        hour,
+        *,
+        batch_size: int,
+    ):  # type: ignore[no-untyped-def]
+        if self._pmxt_raw_root is not None:
+            return self._load_local_raw_market_batches(hour, batch_size=batch_size)
+
+        if self._pmxt_disable_remote_archive:
+            return None
+
+        return super()._load_remote_market_batches(hour, batch_size=batch_size)
+
+
+@dataclass(frozen=True)
+class PMXTDataSourceSelection:
+    mode: str
+    summary: str
+
+
+def _normalize_mode(value: str | None) -> str:
+    if value is None:
+        return "auto"
+
+    normalized = value.strip().casefold().replace("_", "-")
+    try:
+        return _MODE_ALIASES[normalized]
+    except KeyError as exc:
+        valid_modes = ", ".join(_VALID_MODES)
+        raise ValueError(
+            f"Unsupported {PMXT_DATA_SOURCE_ENV}={value!r}. Use one of: {valid_modes}."
+        ) from exc
+
+
+def _env_value(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _env_enabled(name: str) -> bool:
+    value = _env_value(name)
+    if value is None:
+        return False
+    return value.casefold() not in _DISABLED_ENV_VALUES
+
+
+def _resolve_existing_relay_url() -> str:
+    configured = os.getenv(PMXT_RELAY_BASE_URL_ENV)
+    if configured is None:
+        return PMXT_DEFAULT_RELAY_BASE_URL
+
+    value = configured.strip().rstrip("/")
+    if value.casefold() in _DISABLED_ENV_VALUES:
+        return PMXT_DEFAULT_RELAY_BASE_URL
+    return value or PMXT_DEFAULT_RELAY_BASE_URL
+
+
+def _resolve_required_directory(env_name: str, *, label: str) -> Path:
+    configured = os.getenv(env_name)
+    if configured is None or configured.strip().casefold() in _DISABLED_ENV_VALUES:
+        raise ValueError(f"{env_name} is required when using {label}.")
+
+    path = Path(configured).expanduser()
+    if not path.exists():
+        raise ValueError(f"{label} path does not exist: {path}")
+    if not path.is_dir():
+        raise ValueError(f"{label} path is not a directory: {path}")
+    return path
+
+
+def resolve_pmxt_data_source_selection() -> tuple[
+    PMXTDataSourceSelection,
+    dict[str, str | None],
+]:
+    configured_mode = os.getenv(PMXT_DATA_SOURCE_ENV)
+    mode = _normalize_mode(configured_mode)
+
+    if configured_mode is None:
+        raw_root = _env_value(PMXT_RAW_ROOT_ENV)
+        relay_base_url = _env_value(PMXT_RELAY_BASE_URL_ENV)
+        cache_dir = _env_value(PMXT_CACHE_DIR_ENV)
+        disable_remote_archive = _env_enabled(PMXT_DISABLE_REMOTE_ARCHIVE_ENV)
+
+        if raw_root is not None and raw_root.casefold() not in _DISABLED_ENV_VALUES:
+            return (
+                PMXTDataSourceSelection(
+                    mode="raw-local",
+                    summary=f"PMXT source: local raw mirror ({Path(raw_root).expanduser()})",
+                ),
+                {},
+            )
+
+        if disable_remote_archive and cache_dir is not None:
+            return (
+                PMXTDataSourceSelection(
+                    mode="filtered-local",
+                    summary=f"PMXT source: local filtered parquet ({Path(cache_dir).expanduser()})",
+                ),
+                {},
+            )
+
+        if (
+            relay_base_url is not None
+            and relay_base_url.casefold() in _DISABLED_ENV_VALUES
+        ):
+            return (
+                PMXTDataSourceSelection(
+                    mode="raw-remote",
+                    summary="PMXT source: raw remote archive (relay disabled)",
+                ),
+                {},
+            )
+
+        return (
+            PMXTDataSourceSelection(
+                mode="auto",
+                summary="PMXT source: auto (cache -> relay -> raw remote)",
+            ),
+            {},
+        )
+
+    if mode == "auto":
+        return (
+            PMXTDataSourceSelection(
+                mode=mode,
+                summary="PMXT source: auto (cache -> relay -> raw remote)",
+            ),
+            {
+                PMXT_RELAY_BASE_URL_ENV: _resolve_existing_relay_url(),
+                PMXT_RAW_ROOT_ENV: None,
+                PMXT_DISABLE_REMOTE_ARCHIVE_ENV: None,
+            },
+        )
+
+    if mode == "relay":
+        relay_url = _resolve_existing_relay_url()
+        return (
+            PMXTDataSourceSelection(
+                mode=mode,
+                summary=f"PMXT source: relay-first ({relay_url})",
+            ),
+            {
+                PMXT_RELAY_BASE_URL_ENV: relay_url,
+                PMXT_RAW_ROOT_ENV: None,
+                PMXT_DISABLE_REMOTE_ARCHIVE_ENV: None,
+            },
+        )
+
+    if mode == "raw-remote":
+        return (
+            PMXTDataSourceSelection(
+                mode=mode,
+                summary="PMXT source: raw remote archive (relay disabled)",
+            ),
+            {
+                PMXT_RELAY_BASE_URL_ENV: "0",
+                PMXT_RAW_ROOT_ENV: None,
+                PMXT_DISABLE_REMOTE_ARCHIVE_ENV: None,
+            },
+        )
+
+    if mode == "raw-local":
+        raw_root = _resolve_required_directory(
+            PMXT_LOCAL_MIRROR_DIR_ENV,
+            label="local raw PMXT mirror",
+        )
+        return (
+            PMXTDataSourceSelection(
+                mode=mode,
+                summary=f"PMXT source: local raw mirror ({raw_root})",
+            ),
+            {
+                PMXT_RELAY_BASE_URL_ENV: "0",
+                PMXT_RAW_ROOT_ENV: str(raw_root),
+                PMXT_DISABLE_REMOTE_ARCHIVE_ENV: None,
+            },
+        )
+
+    filtered_root = _resolve_required_directory(
+        PMXT_LOCAL_FILTERED_DIR_ENV,
+        label="local filtered PMXT root",
+    )
+    return (
+        PMXTDataSourceSelection(
+            mode=mode,
+            summary=f"PMXT source: local filtered parquet ({filtered_root})",
+        ),
+        {
+            PMXT_RELAY_BASE_URL_ENV: "0",
+            PMXT_CACHE_DIR_ENV: str(filtered_root),
+            PMXT_RAW_ROOT_ENV: None,
+            PMXT_DISABLE_REMOTE_ARCHIVE_ENV: "1",
+        },
+    )
+
+
+@contextmanager
+def configured_pmxt_data_source() -> Iterator[PMXTDataSourceSelection]:
+    selection, updates = resolve_pmxt_data_source_selection()
+    originals = {name: os.environ.get(name) for name in updates}
+
+    try:
+        for name, value in updates.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        yield selection
+    finally:
+        for name, value in originals.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/backtests/polymarket_quote_tick/_polymarket_single_market_pmxt_runner.py
+++ b/backtests/polymarket_quote_tick/_polymarket_single_market_pmxt_runner.py
@@ -17,7 +17,6 @@ from typing import Any
 import pandas as pd
 
 from nautilus_trader.adapters.polymarket import POLYMARKET_VENUE
-from nautilus_trader.adapters.polymarket import PolymarketPMXTDataLoader
 from nautilus_trader.adapters.polymarket.fee_model import PolymarketFeeModel
 from nautilus_trader.adapters.prediction_market.backtest_utils import (
     infer_realized_outcome,
@@ -29,6 +28,11 @@ from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.enums import BookType
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import Strategy
+
+from backtests._shared.data_sources.pmxt import configured_pmxt_data_source
+from backtests._shared.data_sources.pmxt import (
+    RunnerPolymarketPMXTDataLoader as PolymarketPMXTDataLoader,
+)
 
 
 type StrategyFactory = Callable[[InstrumentId], Strategy]
@@ -89,11 +93,13 @@ async def run_single_market_pmxt_backtest(
     )
 
     try:
-        loader = await PolymarketPMXTDataLoader.from_market_slug(
-            market_slug,
-            token_index=token_index,
-        )
-        data = loader.load_order_book_and_quotes(start, end)
+        with configured_pmxt_data_source() as data_source:
+            print(data_source.summary)
+            loader = await PolymarketPMXTDataLoader.from_market_slug(
+                market_slug,
+                token_index=token_index,
+            )
+            data = loader.load_order_book_and_quotes(start, end)
     except Exception as exc:
         print(f"Unable to load PMXT Polymarket market {market_slug}: {exc}")
         return

--- a/docs/pmxt-byod.md
+++ b/docs/pmxt-byod.md
@@ -1,0 +1,129 @@
+# PMXT BYOD and Data Sources
+
+The PMXT L2 runners can now be pointed at different historical data sources
+without changing code inside the runner files.
+
+## Source Modes
+
+Set `PMXT_DATA_SOURCE` before running any PMXT quote-tick backtest:
+
+- `auto`: existing behavior. Use local cache first, then the relay, then the remote raw PMXT archive.
+- `relay`: force relay-first behavior even if `PMXT_RELAY_BASE_URL` was disabled earlier in your shell.
+- `raw-remote`: skip the relay and scan the raw PMXT archive directly.
+- `raw-local`: scan a local raw PMXT mirror instead of `r2.pmxt.dev`.
+- `filtered-local`: read already-filtered local parquet files only.
+
+Examples:
+
+```bash
+PMXT_DATA_SOURCE=raw-remote \
+uv run python backtests/polymarket_quote_tick/polymarket_pmxt_relay_ema_crossover.py
+```
+
+```bash
+PMXT_DATA_SOURCE=raw-local \
+PMXT_LOCAL_MIRROR_DIR=/data/pmxt/raw \
+uv run python backtests/polymarket_quote_tick/polymarket_pmxt_relay_ema_crossover.py
+```
+
+```bash
+PMXT_DATA_SOURCE=filtered-local \
+PMXT_LOCAL_FILTERED_DIR=/data/pmxt/filtered \
+uv run python backtests/polymarket_quote_tick/polymarket_pmxt_relay_ema_crossover.py
+```
+
+If you already set lower-level loader env vars such as `PMXT_RAW_ROOT`,
+`PMXT_RELAY_BASE_URL`, or `PMXT_CACHE_DIR` manually, the runner leaves those in
+place unless you explicitly set `PMXT_DATA_SOURCE`.
+
+## Local Raw Mirror Layout
+
+`PMXT_DATA_SOURCE=raw-local` expects the same hourly directory layout used by
+the relay's `raw/` tree:
+
+```text
+/data/pmxt/raw/
+  2026/03/21/polymarket_orderbook_2026-03-21T12.parquet
+  2026/03/21/polymarket_orderbook_2026-03-21T13.parquet
+  ...
+```
+
+Each raw hourly parquet file must keep these columns:
+
+- `market_id`
+- `update_type`
+- `data`
+
+The runner filters by `market_id` at parquet scan time, then filters the JSON
+payload in `data` down to the selected `token_id`.
+
+## Local Filtered Layout
+
+`PMXT_DATA_SOURCE=filtered-local` expects the same per-market/token/hour layout
+as the runner cache and relay prebuilt output:
+
+```text
+/data/pmxt/filtered/
+  <condition_id>/<token_id>/polymarket_orderbook_YYYY-MM-DDTHH.parquet
+```
+
+Each filtered parquet file must contain only:
+
+- `update_type`
+- `data`
+
+This mode is strict local BYOD. If a required hour is missing from that root,
+the runner will not fall back to the public relay or remote PMXT archive.
+
+## L2 JSON Payload Requirements
+
+The loader currently understands two PMXT update types:
+
+- `book_snapshot`
+- `price_change`
+
+For `book_snapshot`, the JSON string in `data` must decode into fields with this
+shape:
+
+```json
+{
+  "update_type": "book_snapshot",
+  "market_id": "0x...",
+  "token_id": "123...",
+  "side": "BUY",
+  "best_bid": "0.42",
+  "best_ask": "0.43",
+  "timestamp": 1771767624.001295,
+  "bids": [["0.42", "150"], ["0.41", "80"]],
+  "asks": [["0.43", "120"], ["0.44", "95"]]
+}
+```
+
+For `price_change`, the JSON string in `data` must decode into fields with this
+shape:
+
+```json
+{
+  "update_type": "price_change",
+  "market_id": "0x...",
+  "token_id": "123...",
+  "side": "BUY",
+  "best_bid": "0.42",
+  "best_ask": "0.43",
+  "timestamp": 1771767624.101295,
+  "change_price": "0.43",
+  "change_size": "25",
+  "change_side": "SELL"
+}
+```
+
+Notes:
+
+- `timestamp` is a UTC Unix timestamp in seconds.
+- Price and size values are strings because that is what the current PMXT
+  decoder expects.
+- `best_bid` and `best_ask` may be `null`.
+- Rows within each hourly file must stay in original event order. The loader
+  rebuilds the order book by replaying those rows sequentially.
+- The loader needs at least one earlier snapshot hour before the requested
+  window so it can reconstruct initial L2 state.

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -3,6 +3,11 @@
 `pmxt_relay/` is a self-hosted PMXT acceleration layer for the backtests in this
 repo.
 
+> UNDER CONSTRUCTION: the current public VPS relay is being reworked. The
+> existing processed parquet layer is temporary and a ClickHouse-backed
+> replacement is planned, so expect public coverage and stats to be unstable for
+> a while.
+
 What it does:
 
 - mirrors every hourly raw PMXT Polymarket archive parquet file

--- a/tests/test_pmxt_data_source.py
+++ b/tests/test_pmxt_data_source.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from backtests._shared.data_sources.pmxt import PMXT_CACHE_DIR_ENV
+from backtests._shared.data_sources.pmxt import PMXT_DATA_SOURCE_ENV
+from backtests._shared.data_sources.pmxt import PMXT_DISABLE_REMOTE_ARCHIVE_ENV
+from backtests._shared.data_sources.pmxt import PMXT_LOCAL_FILTERED_DIR_ENV
+from backtests._shared.data_sources.pmxt import PMXT_LOCAL_MIRROR_DIR_ENV
+from backtests._shared.data_sources.pmxt import PMXT_RAW_ROOT_ENV
+from backtests._shared.data_sources.pmxt import PMXT_RELAY_BASE_URL_ENV
+from backtests._shared.data_sources.pmxt import RunnerPolymarketPMXTDataLoader
+from backtests._shared.data_sources.pmxt import configured_pmxt_data_source
+
+
+def _make_loader(
+    *,
+    cache_dir: Path | None = None,
+    raw_root: Path | None = None,
+    disable_remote_archive: bool = False,
+) -> RunnerPolymarketPMXTDataLoader:
+    loader = object.__new__(RunnerPolymarketPMXTDataLoader)
+    loader._pmxt_cache_dir = cache_dir
+    loader._pmxt_relay_base_url = None
+    loader._condition_id = "condition-123"
+    loader._token_id = "token-yes-123"
+    loader._pmxt_prefetch_workers = 2
+    loader._pmxt_http_block_size = 32 * 1024 * 1024
+    loader._pmxt_http_cache_type = "readahead"
+    loader._pmxt_raw_root = raw_root
+    loader._pmxt_disable_remote_archive = disable_remote_archive
+    loader._reset_http_filesystem()
+    return loader
+
+
+def test_configured_pmxt_data_source_sets_raw_local_overrides(monkeypatch, tmp_path):
+    mirror_root = tmp_path / "mirror"
+    mirror_root.mkdir()
+    monkeypatch.setenv(PMXT_DATA_SOURCE_ENV, "raw-local")
+    monkeypatch.setenv(PMXT_LOCAL_MIRROR_DIR_ENV, str(mirror_root))
+
+    with configured_pmxt_data_source() as selection:
+        assert selection.mode == "raw-local"
+        assert str(mirror_root) in selection.summary
+        assert os.environ[PMXT_RELAY_BASE_URL_ENV] == "0"
+        assert os.environ[PMXT_RAW_ROOT_ENV] == str(mirror_root)
+        assert PMXT_DISABLE_REMOTE_ARCHIVE_ENV not in os.environ
+
+    assert os.getenv(PMXT_RAW_ROOT_ENV) is None
+    assert os.getenv(PMXT_RELAY_BASE_URL_ENV) is None
+
+
+def test_configured_pmxt_data_source_sets_filtered_local_overrides(
+    monkeypatch,
+    tmp_path,
+):
+    filtered_root = tmp_path / "filtered"
+    filtered_root.mkdir()
+    monkeypatch.setenv(PMXT_DATA_SOURCE_ENV, "filtered-local")
+    monkeypatch.setenv(PMXT_LOCAL_FILTERED_DIR_ENV, str(filtered_root))
+
+    with configured_pmxt_data_source() as selection:
+        assert selection.mode == "filtered-local"
+        assert str(filtered_root) in selection.summary
+        assert os.environ[PMXT_RELAY_BASE_URL_ENV] == "0"
+        assert os.environ[PMXT_CACHE_DIR_ENV] == str(filtered_root)
+        assert os.environ[PMXT_DISABLE_REMOTE_ARCHIVE_ENV] == "1"
+
+
+def test_configured_pmxt_data_source_preserves_manual_low_level_env(
+    monkeypatch,
+    tmp_path,
+):
+    mirror_root = tmp_path / "manual-mirror"
+    mirror_root.mkdir()
+    monkeypatch.delenv(PMXT_DATA_SOURCE_ENV, raising=False)
+    monkeypatch.setenv(PMXT_RAW_ROOT_ENV, str(mirror_root))
+
+    with configured_pmxt_data_source() as selection:
+        assert selection.mode == "raw-local"
+        assert os.environ[PMXT_RAW_ROOT_ENV] == str(mirror_root)
+
+
+def test_configured_pmxt_data_source_requires_local_mirror(monkeypatch):
+    monkeypatch.setenv(PMXT_DATA_SOURCE_ENV, "raw-local")
+    monkeypatch.delenv(PMXT_LOCAL_MIRROR_DIR_ENV, raising=False)
+
+    with pytest.raises(ValueError, match=PMXT_LOCAL_MIRROR_DIR_ENV):
+        with configured_pmxt_data_source():
+            pass
+
+
+def test_runner_loader_reads_market_rows_from_local_raw_mirror(tmp_path):
+    loader = _make_loader(raw_root=tmp_path)
+    hour = pd.Timestamp("2026-03-21T12:00:00Z")
+    raw_path = (
+        tmp_path / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T12.parquet"
+    )
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.table(
+            {
+                "market_id": [
+                    "condition-123",
+                    "condition-123",
+                    "condition-456",
+                ],
+                "update_type": [
+                    "book_snapshot",
+                    "price_change",
+                    "price_change",
+                ],
+                "data": [
+                    '{"token_id":"token-yes-123","seq":1}',
+                    '{"token_id":"token-no-999","seq":2}',
+                    '{"token_id":"token-yes-123","seq":3}',
+                ],
+            }
+        ),
+        raw_path,
+    )
+
+    batches = loader._load_remote_market_batches(hour, batch_size=1_000)
+
+    assert batches is not None
+    assert pa.Table.from_batches(batches).to_pylist() == [
+        {
+            "update_type": "book_snapshot",
+            "data": '{"token_id":"token-yes-123","seq":1}',
+        },
+    ]


### PR DESCRIPTION
## What changed
- added a shared `backtests/_shared/data_sources/` package so PMXT runner source selection lives in a reusable runner-side layer instead of a one-off helper
- added explicit PMXT BYOD modes for quote-tick backtests: `auto`, `relay`, `raw-remote`, `raw-local`, and `filtered-local`
- added local raw-mirror support plus strict local filtered-parquet mode for PMXT L2 backtests
- updated the timing harness so source reporting still works with the runner-side PMXT source adapter
- documented the repo and relay as under construction, and added a dedicated BYOD/L2 format guide in `docs/pmxt-byod.md`

## Why this changed
- users are very likely to want their own historical data sources, so the runners should stay modular instead of assuming one public VPS-backed path
- the public relay is no longer keeping up with incoming PMXT hours, so the README now points users toward BYOD/local alternatives while the relay is reworked

## User impact
- PMXT L2 example runners can now replay from a local raw PMXT mirror or local prefiltered parquet without editing runner code
- the relay-facing docs now clearly say the public VPS is under construction
- the VPS relay was operationally reset outside this PR: worker and prebuild were disabled, processed/filtered/state/tmp were swapped to empty directories, and the API now reports an empty relay state while the old purge continues in the background

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
