### PR TITLE
[codex] Slim PMXT relay to mirror-only state

### DIFF
--- a/pmxt_local/processor.py
+++ b/pmxt_local/processor.py
@@ -14,9 +14,8 @@ import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 
 from pmxt_local.config import LocalProcessingConfig
-from pmxt_relay.index_db import FilteredHourArtifact
-from pmxt_relay.storage import parse_archive_hour
 from pmxt_local.paths import filtered_relative_path
+from pmxt_relay.storage import parse_archive_hour
 
 
 TOKEN_ID_REGEX = r'"token_id"\s*:\s*"(?P<token>[^"]+)"'
@@ -45,6 +44,17 @@ PROCESSED_SCHEMA = pa.schema(
 )
 RELEVANT_UPDATE_TYPES = pa.array(["book_snapshot", "price_change"])
 PARQUET_BATCH_SIZE = 65536
+
+
+@dataclass(frozen=True)
+class FilteredHourArtifact:
+    filename: str
+    hour: str
+    condition_id: str
+    token_id: str
+    local_path: str
+    row_count: int
+    byte_size: int
 
 
 @dataclass(frozen=True)

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -98,9 +98,11 @@ Active mirror-focused endpoints:
 - `GET /v1/inflight`
 - `GET /v1/system`
 - `GET /v1/raw/{yyyy/mm/dd/filename}`
-- badge endpoints under `/v1/badge/*`
+- mirror/system badge endpoints under `/v1/badge/*`
 
-Filtered-hour HTTP endpoints are intentionally not part of the active relay path.
+`/v1/stats`, `/v1/queue`, and the active badge routes only expose raw-mirror
+state. Filtered-hour and processing-oriented HTTP endpoints are intentionally
+not part of the active relay path.
 
 ## Legacy Archive
 

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -17,7 +17,6 @@ from xml.sax.saxutils import escape
 from aiohttp import web
 
 from pmxt_relay.config import RelayConfig
-from pmxt_relay.index_db import PrebuildProgress
 from pmxt_relay.index_db import RelayIndex
 
 _RAW_FILENAME_RE = re.compile(
@@ -408,21 +407,6 @@ def _progress_color(*, numerator: int, denominator: int) -> str:
     return "orange"
 
 
-def _short_hour_label(value: str | None) -> str:
-    if value is None:
-        return "none"
-    normalized = value.strip()
-    if not normalized:
-        return "none"
-    if normalized.endswith("Z"):
-        normalized = normalized[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return value
-    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%HZ")
-
-
 def _status_badge_payload(
     *,
     stats: dict[str, int | str | None],
@@ -433,9 +417,6 @@ def _status_badge_payload(
         datetime.now(timezone.utc) if now is None else now.astimezone(timezone.utc)
     )
     last_event_at = _parse_db_timestamp(stats.get("last_event_at"))  # type: ignore[arg-type]
-    processing_hours = int(stats.get("processing_hours") or 0)
-    ready_hours = int(stats.get("ready_to_process_hours") or 0)
-    archive_hours = int(stats.get("archive_hours") or 0)
 
     if last_event_at is None:
         return _badge_payload(label="PMXT relay", message="starting", color="yellow")
@@ -444,32 +425,7 @@ def _status_badge_payload(
     stale_threshold = max(config.poll_interval_secs * 4, 3600)
     if age_seconds > stale_threshold:
         return _badge_payload(label="PMXT relay", message="stale", color="red")
-    if processing_hours > 0:
-        return _badge_payload(
-            label="PMXT relay", message="processing", color="brightgreen"
-        )
-    if ready_hours > 0 or archive_hours > 0:
-        return _badge_payload(label="PMXT relay", message="up", color="green")
-    return _badge_payload(label="PMXT relay", message="idle", color="blue")
-
-
-def _backfill_badge_payload(
-    *,
-    stats: dict[str, int | str | None],
-) -> dict[str, object]:
-    processed_hours = int(stats.get("processed_hours") or 0)
-    archive_hours = int(stats.get("archive_hours") or 0)
-
-    if archive_hours <= 0:
-        return _badge_payload(
-            label="Hours backfilled", message="0/0 hrs", color="lightgrey"
-        )
-
-    return _badge_payload(
-        label="Hours backfilled",
-        message=f"{processed_hours}/{archive_hours} hrs",
-        color=_progress_color(numerator=processed_hours, denominator=archive_hours),
-    )
+    return _badge_payload(label="PMXT relay", message="up", color="brightgreen")
 
 
 def _ratio_badge_payload(
@@ -501,34 +457,6 @@ def _mirrored_badge_payload(
     )
 
 
-def _processed_badge_payload(
-    *,
-    stats: dict[str, int | str | None],
-) -> dict[str, object]:
-    processed_hours = int(stats.get("processed_hours") or 0)
-    mirrored_hours = int(stats.get("mirrored_hours") or 0)
-    return _ratio_badge_payload(
-        label="Hours processed",
-        numerator=processed_hours,
-        denominator=mirrored_hours,
-    )
-
-
-def _latest_processed_badge_payload(
-    *,
-    queue: dict[str, int | str | None],
-) -> dict[str, object]:
-    latest_processed_hour = queue.get("latest_processed_hour")
-    latest_label = (
-        latest_processed_hour if isinstance(latest_processed_hour, str) else None
-    )
-    return _badge_payload(
-        label="Latest hour",
-        message=_short_hour_label(latest_label),
-        color="blue",
-    )
-
-
 def _latest_file_badge_payload(
     *,
     queue: dict[str, int | str | None],
@@ -543,111 +471,6 @@ def _latest_file_badge_payload(
         label="Latest file",
         message=filename_label or "none",
         color="blue" if filename_label is not None else "lightgrey",
-    )
-
-
-def _lag_badge_payload(
-    *,
-    stats: dict[str, int | str | None],
-) -> dict[str, object]:
-    archive_hours = int(stats.get("archive_hours") or 0)
-    processed_hours = int(stats.get("processed_hours") or 0)
-    lag_hours = max(0, archive_hours - processed_hours)
-
-    if lag_hours == 0:
-        color = "brightgreen"
-    elif lag_hours <= 24:
-        color = "green"
-    elif lag_hours <= 168:
-        color = "yellowgreen"
-    else:
-        color = "orange"
-
-    return _badge_payload(
-        label="Queue lag",
-        message=f"{lag_hours} hrs",
-        color=color,
-    )
-
-
-def _rate_badge_payload(
-    *,
-    stats: dict[str, int | str | None | float],
-) -> dict[str, object]:
-    rate = float(stats.get("processed_hours_per_hour_24h") or 0.0)
-    if rate >= 4.0:
-        color = "brightgreen"
-    elif rate >= 1.0:
-        color = "green"
-    elif rate >= 0.5:
-        color = "yellowgreen"
-    elif rate > 0.0:
-        color = "orange"
-    else:
-        color = "red"
-
-    if rate >= 10.0:
-        message = f"{rate:.0f} hr/hr"
-    elif rate >= 1.0:
-        message = f"{rate:.1f} hr/hr"
-    else:
-        message = f"{rate:.2f} hr/hr"
-
-    return _badge_payload(
-        label="Completion rate",
-        message=message,
-        color=color,
-    )
-
-
-def _file_badge_payload(
-    *,
-    stats: dict[str, int | str | None],
-    progress: PrebuildProgress | None,
-    current_filename: str | None = None,
-) -> dict[str, object]:
-    processing_hours = int(stats.get("processing_hours") or 0)
-    if processing_hours <= 0:
-        return _badge_payload(label="Current file", message="idle", color="lightgrey")
-    if current_filename is not None:
-        return _badge_payload(
-            label="Current file",
-            message=current_filename,
-            color="blue",
-        )
-    if progress is None:
-        return _badge_payload(label="Current file", message="starting", color="yellow")
-    return _badge_payload(
-        label="Current file",
-        message=progress.filename,
-        color="blue",
-    )
-
-
-def _rows_badge_payload(
-    *,
-    stats: dict[str, int | str | None],
-    progress: PrebuildProgress | None,
-    current_filename: str | None = None,
-) -> dict[str, object]:
-    processing_hours = int(stats.get("processing_hours") or 0)
-    if processing_hours <= 0:
-        return _badge_payload(label="Rows processed", message="idle", color="lightgrey")
-    if progress is None:
-        return _badge_payload(
-            label="Rows processed", message="starting", color="yellow"
-        )
-    if current_filename is not None and progress.filename != current_filename:
-        return _badge_payload(
-            label="Rows processed", message="starting", color="yellow"
-        )
-    return _badge_payload(
-        label="Rows processed",
-        message=f"{progress.processed_rows:,} / {progress.total_rows:,}",
-        color=_progress_color(
-            numerator=progress.processed_rows,
-            denominator=progress.total_rows,
-        ),
     )
 
 
@@ -746,7 +569,7 @@ def _resolve_raw_path(config: RelayConfig, filename: str) -> Path | None:
     return _resolve_path_under_root(config.raw_root, *Path(filename).parts)
 
 
-def _collect_inflight_processes(config: RelayConfig) -> list[dict[str, object]]:
+def _collect_inflight_downloads(config: RelayConfig) -> list[dict[str, object]]:
     inflight: list[dict[str, object]] = []
     for tmp_path in sorted(config.raw_root.rglob("*.tmp")):
         if not tmp_path.is_file():
@@ -823,19 +646,6 @@ async def _index_recent_events_async(index: object, limit: int):
     return await asyncio.to_thread(index.recent_events, limit=limit)
 
 
-async def _index_progress_snapshot_async(
-    index: object,
-) -> tuple[dict[str, object], dict[str, object] | None, str | None]:
-    def _snapshot():
-        return (
-            index.stats(),
-            index.latest_prebuild_progress(),
-            index.current_processing_filename(),
-        )
-
-    return await asyncio.to_thread(_snapshot)
-
-
 async def stats(request: web.Request) -> web.Response:
     index = request.app[INDEX_APP_KEY]
     return web.json_response(await _index_stats_async(index))
@@ -879,7 +689,7 @@ async def events(request: web.Request) -> web.Response:
 
 async def inflight(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
-    payload = await asyncio.to_thread(_collect_inflight_processes, config)
+    payload = await asyncio.to_thread(_collect_inflight_downloads, config)
     return web.json_response({"inflight": payload})
 
 
@@ -897,65 +707,10 @@ async def badge_status(request: web.Request) -> web.Response:
     )
 
 
-async def badge_backfill(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return web.json_response(
-        _backfill_badge_payload(stats=await _index_stats_async(index))
-    )
-
-
 async def badge_mirrored(request: web.Request) -> web.Response:
     index = request.app[INDEX_APP_KEY]
     return web.json_response(
         _mirrored_badge_payload(stats=await _index_stats_async(index))
-    )
-
-
-async def badge_processed(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return web.json_response(
-        _processed_badge_payload(stats=await _index_stats_async(index))
-    )
-
-
-async def badge_latest(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return web.json_response(
-        _latest_processed_badge_payload(queue=await _index_queue_summary_async(index))
-    )
-
-
-async def badge_lag(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return web.json_response(_lag_badge_payload(stats=await _index_stats_async(index)))
-
-
-async def badge_rate(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return web.json_response(_rate_badge_payload(stats=await _index_stats_async(index)))
-
-
-async def badge_file(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    stats, progress, current_filename = await _index_progress_snapshot_async(index)
-    return web.json_response(
-        _file_badge_payload(
-            stats=stats,
-            progress=progress,
-            current_filename=current_filename,
-        )
-    )
-
-
-async def badge_rows(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    stats, progress, current_filename = await _index_progress_snapshot_async(index)
-    return web.json_response(
-        _rows_badge_payload(
-            stats=stats,
-            progress=progress,
-            current_filename=current_filename,
-        )
     )
 
 
@@ -1008,10 +763,6 @@ def _service_metrics_for_badge(
     return service_metrics
 
 
-def _service_running_badge_payload(label: str) -> dict[str, object]:
-    return _badge_payload(label=label, message="running busy", color="brightgreen")
-
-
 async def badge_api_svg(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
     metrics = await asyncio.to_thread(_system_metrics_snapshot, config)
@@ -1041,33 +792,11 @@ async def badge_mirroring_svg(request: web.Request) -> web.Response:
     )
 
 
-async def badge_processing_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    queue = await _index_queue_summary_async(index)
-    return _badge_svg_response(
-        _stage_badge_payload(
-            label="Processing",
-            active_count=int(queue.get("process_processing") or 0),
-            queued_count=int(
-                (queue.get("process_ready") or 0) + (queue.get("process_pending") or 0)
-            ),
-            error_count=int(queue.get("process_error") or 0),
-        )
-    )
-
-
 async def badge_status_svg(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
     return _badge_svg_response(
         _status_badge_payload(stats=await _index_stats_async(index), config=config)
-    )
-
-
-async def badge_backfill_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return _badge_svg_response(
-        _backfill_badge_payload(stats=await _index_stats_async(index))
     )
 
 
@@ -1078,62 +807,10 @@ async def badge_mirrored_svg(request: web.Request) -> web.Response:
     )
 
 
-async def badge_processed_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return _badge_svg_response(
-        _processed_badge_payload(stats=await _index_stats_async(index))
-    )
-
-
-async def badge_latest_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return _badge_svg_response(
-        _latest_processed_badge_payload(queue=await _index_queue_summary_async(index))
-    )
-
-
 async def badge_latest_file_svg(request: web.Request) -> web.Response:
     index = request.app[INDEX_APP_KEY]
     return _badge_svg_response(
         _latest_file_badge_payload(queue=await _index_queue_summary_async(index))
-    )
-
-
-async def badge_lag_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return _badge_svg_response(
-        _lag_badge_payload(stats=await _index_stats_async(index))
-    )
-
-
-async def badge_rate_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    return _badge_svg_response(
-        _rate_badge_payload(stats=await _index_stats_async(index))
-    )
-
-
-async def badge_file_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    stats, progress, current_filename = await _index_progress_snapshot_async(index)
-    return _badge_svg_response(
-        _file_badge_payload(
-            stats=stats,
-            progress=progress,
-            current_filename=current_filename,
-        )
-    )
-
-
-async def badge_rows_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
-    stats, progress, current_filename = await _index_progress_snapshot_async(index)
-    return _badge_svg_response(
-        _rows_badge_payload(
-            stats=stats,
-            progress=progress,
-            current_filename=current_filename,
-        )
     )
 
 
@@ -1166,24 +843,10 @@ def create_app(config: RelayConfig) -> web.Application:
     app.router.add_get("/v1/inflight", inflight)
     app.router.add_get("/v1/system", system_metrics)
     app.router.add_get("/v1/badge/status", badge_status)
-    app.router.add_get("/v1/badge/backfill", badge_backfill)
     app.router.add_get("/v1/badge/mirrored", badge_mirrored)
-    app.router.add_get("/v1/badge/processed", badge_processed)
-    app.router.add_get("/v1/badge/latest", badge_latest)
-    app.router.add_get("/v1/badge/lag", badge_lag)
-    app.router.add_get("/v1/badge/rate", badge_rate)
-    app.router.add_get("/v1/badge/file", badge_file)
-    app.router.add_get("/v1/badge/rows", badge_rows)
     app.router.add_get("/v1/badge/status.svg", badge_status_svg)
-    app.router.add_get("/v1/badge/backfill.svg", badge_backfill_svg)
     app.router.add_get("/v1/badge/mirrored.svg", badge_mirrored_svg)
-    app.router.add_get("/v1/badge/processed.svg", badge_processed_svg)
-    app.router.add_get("/v1/badge/latest.svg", badge_latest_svg)
     app.router.add_get("/v1/badge/latest-file.svg", badge_latest_file_svg)
-    app.router.add_get("/v1/badge/lag.svg", badge_lag_svg)
-    app.router.add_get("/v1/badge/rate.svg", badge_rate_svg)
-    app.router.add_get("/v1/badge/file.svg", badge_file_svg)
-    app.router.add_get("/v1/badge/rows.svg", badge_rows_svg)
     app.router.add_get("/v1/badge/cpu.svg", badge_cpu_svg)
     app.router.add_get("/v1/badge/load.svg", badge_load_svg)
     app.router.add_get("/v1/badge/mem.svg", badge_mem_svg)
@@ -1192,6 +855,5 @@ def create_app(config: RelayConfig) -> web.Application:
     app.router.add_get("/v1/badge/api.svg", badge_api_svg)
     app.router.add_get("/v1/badge/worker.svg", badge_worker_svg)
     app.router.add_get("/v1/badge/mirroring.svg", badge_mirroring_svg)
-    app.router.add_get("/v1/badge/processing.svg", badge_processing_svg)
     app.router.add_get("/v1/raw/{filename:.*}", serve_raw)
     return app

--- a/pmxt_relay/cli.py
+++ b/pmxt_relay/cli.py
@@ -37,7 +37,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--vendor",
         choices=("pmxt",),
         default="pmxt",
-        help="Local processing vendor adapter to use",
+        help="Vendor adapter to use for raw mirror verification",
     )
     parser.add_argument(
         "--raw-root",

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
-from dataclasses import dataclass
-from datetime import UTC
-from datetime import datetime
-from datetime import timedelta
-import json
-from pathlib import Path
 import threading
 import time
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
 
 from pmxt_relay.storage import parse_archive_hour
+
 
 LOG = logging.getLogger(__name__)
 _LOCKED_ERROR_SNIPPETS = (
@@ -29,29 +28,24 @@ def _utc_now() -> str:
     return _utc_now_datetime().isoformat()
 
 
-@dataclass(frozen=True)
-class FilteredHourArtifact:
-    filename: str
-    hour: str
-    condition_id: str
-    token_id: str
-    local_path: str
-    row_count: int
-    byte_size: int
-
-
-@dataclass(frozen=True)
-class PrebuildProgress:
-    filename: str
-    created_at: str
-    processed_rows: int
-    total_rows: int
-
-
 class RelayIndex:
-    _REQUIRED_TABLES = frozenset({"archive_hours", "filtered_hours", "relay_events"})
+    _REQUIRED_TABLES = frozenset({"archive_hours", "relay_events"})
     _REQUIRED_ARCHIVE_COLUMNS = frozenset(
-        {"filtered_artifact_count", "prebuild_status", "prebuilt_at", "error_count"}
+        {
+            "filename",
+            "hour",
+            "source_url",
+            "archive_page",
+            "discovered_at",
+            "local_path",
+            "etag",
+            "content_length",
+            "last_modified",
+            "mirror_status",
+            "mirrored_at",
+            "last_error",
+            "error_count",
+        }
     )
 
     def __init__(
@@ -81,22 +75,15 @@ class RelayIndex:
         apply_maintenance: bool = True,
         reset_inflight: bool = False,
         reset_mirror_inflight: bool = True,
-        reset_process_inflight: bool = True,
-        reset_prebuild_inflight: bool = True,
-    ) -> tuple[int, int, int]:
+    ) -> int:
         schema_needs_bootstrap = self._schema_needs_bootstrap()
         if schema_needs_bootstrap or apply_maintenance:
             self._run_with_lock_retry(self._ensure_schema)
         if apply_maintenance:
-            self._run_with_lock_retry(self._normalize_archive_hours)
             self.prune_events(best_effort=True)
         if reset_inflight and apply_maintenance:
-            return self.reset_inflight_work(
-                reset_mirror=reset_mirror_inflight,
-                reset_process=reset_process_inflight,
-                reset_prebuild=reset_prebuild_inflight,
-            )
-        return 0, 0, 0
+            return self.reset_inflight_work(reset_mirror=reset_mirror_inflight)
+        return 0
 
     def _ensure_schema(self) -> None:
         self._conn.executescript(
@@ -112,33 +99,13 @@ class RelayIndex:
                 content_length INTEGER,
                 last_modified TEXT,
                 mirror_status TEXT NOT NULL DEFAULT 'pending',
-                process_status TEXT NOT NULL DEFAULT 'pending',
-                prebuild_status TEXT NOT NULL DEFAULT 'pending',
-                filtered_artifact_count INTEGER NOT NULL DEFAULT 0,
                 mirrored_at TEXT,
-                processed_at TEXT,
-                prebuilt_at TEXT,
                 last_error TEXT,
                 error_count INTEGER NOT NULL DEFAULT 0
             );
 
-            CREATE TABLE IF NOT EXISTS filtered_hours (
-                filename TEXT NOT NULL,
-                hour TEXT NOT NULL,
-                condition_id TEXT NOT NULL,
-                token_id TEXT NOT NULL,
-                local_path TEXT NOT NULL,
-                row_count INTEGER NOT NULL,
-                byte_size INTEGER NOT NULL,
-                created_at TEXT NOT NULL,
-                PRIMARY KEY (filename, condition_id, token_id)
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_filtered_market_token_hour
-            ON filtered_hours (condition_id, token_id, hour);
-
-            CREATE INDEX IF NOT EXISTS idx_filtered_filename
-            ON filtered_hours (filename);
+            CREATE INDEX IF NOT EXISTS idx_archive_hours_mirror_status_hour
+            ON archive_hours (mirror_status, hour DESC);
 
             CREATE TABLE IF NOT EXISTS relay_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -157,42 +124,6 @@ class RelayIndex:
             ON relay_events (event_type, id DESC);
             """
         )
-        self._ensure_archive_hours_column(
-            "filtered_artifact_count",
-            "INTEGER NOT NULL DEFAULT 0",
-        )
-        self._ensure_archive_hours_column(
-            "prebuild_status",
-            "TEXT NOT NULL DEFAULT 'pending'",
-        )
-        self._ensure_archive_hours_column(
-            "prebuilt_at",
-            "TEXT",
-        )
-        self._ensure_archive_hours_column(
-            "error_count",
-            "INTEGER NOT NULL DEFAULT 0",
-        )
-
-    def _normalize_archive_hours(self) -> None:
-        with self._conn:
-            self._conn.execute(
-                """
-                UPDATE archive_hours
-                SET prebuild_status = 'ready',
-                    prebuilt_at = COALESCE(prebuilt_at, processed_at)
-                WHERE filtered_artifact_count > 0
-                  AND prebuild_status != 'ready'
-                """
-            )
-            self._conn.execute(
-                """
-                UPDATE archive_hours
-                SET prebuild_status = 'pending'
-                WHERE (prebuild_status IS NULL OR prebuild_status = '')
-                  AND filtered_artifact_count = 0
-                """
-            )
 
     def _schema_needs_bootstrap(self) -> bool:
         tables = {
@@ -244,18 +175,6 @@ class RelayIndex:
                 time.sleep(delay)
                 delay = min(delay * 2, 5.0)
 
-    def _ensure_archive_hours_column(self, name: str, definition: str) -> None:
-        columns = {row[1] for row in self._fetchall("PRAGMA table_info(archive_hours)")}
-        if name in columns:
-            return
-        try:
-            self._conn.execute(
-                f"ALTER TABLE archive_hours ADD COLUMN {name} {definition}"
-            )
-        except sqlite3.OperationalError as exc:
-            if "duplicate column name" not in str(exc).lower():
-                raise
-
     def _fetchall(
         self,
         sql: str,
@@ -287,6 +206,10 @@ class RelayIndex:
         value = row[0]
         return default if value is None else value
 
+    def _write_single_update(self, sql: str, params: tuple[object, ...]) -> None:
+        with self._conn:
+            self._conn.execute(sql, params)
+
     def prune_events(self, *, best_effort: bool = False) -> None:
         def operation() -> None:
             with self._conn:
@@ -311,64 +234,30 @@ class RelayIndex:
         if result is not False:
             self._events_since_prune = 0
 
-    def reset_inflight_work(
-        self,
-        *,
-        reset_mirror: bool = True,
-        reset_process: bool = True,
-        reset_prebuild: bool = True,
-    ) -> tuple[int, int, int]:
-        def operation() -> tuple[int, int, int]:
+    def reset_inflight_work(self, *, reset_mirror: bool = True) -> int:
+        if not reset_mirror:
+            return 0
+
+        def operation() -> int:
             with self._conn:
-                mirror_cursor = (
-                    self._conn.execute(
-                        """
-                        UPDATE archive_hours
-                        SET mirror_status = 'pending',
-                            last_error = COALESCE(last_error, 'mirror interrupted by restart'),
-                            error_count = error_count + 1
-                        WHERE mirror_status = 'processing'
-                        """
-                    )
-                    if reset_mirror
-                    else None
+                cursor = self._conn.execute(
+                    """
+                    UPDATE archive_hours
+                    SET mirror_status = 'pending',
+                        last_error = COALESCE(last_error, 'mirror interrupted by restart'),
+                        error_count = error_count + 1
+                    WHERE mirror_status = 'processing'
+                    """
                 )
-                process_cursor = (
-                    self._conn.execute(
-                        """
-                        UPDATE archive_hours
-                        SET process_status = 'pending',
-                            last_error = COALESCE(last_error, 'processing interrupted by restart'),
-                            error_count = error_count + 1
-                        WHERE process_status = 'processing'
-                        """
-                    )
-                    if reset_process
-                    else None
-                )
-                prebuild_cursor = (
-                    self._conn.execute(
-                        """
-                        UPDATE archive_hours
-                        SET prebuild_status = 'pending',
-                            last_error = COALESCE(last_error, 'prebuild interrupted by restart'),
-                            error_count = error_count + 1
-                        WHERE prebuild_status = 'processing'
-                        """
-                    )
-                    if reset_prebuild
-                    else None
-                )
-            return (
-                0 if mirror_cursor is None else mirror_cursor.rowcount,
-                0 if process_cursor is None else process_cursor.rowcount,
-                0 if prebuild_cursor is None else prebuild_cursor.rowcount,
-            )
+            return cursor.rowcount
 
         return self._run_with_lock_retry(operation)
 
     def upsert_discovered_hour(
-        self, filename: str, source_url: str, archive_page: int
+        self,
+        filename: str,
+        source_url: str,
+        archive_page: int,
     ) -> bool:
         hour = parse_archive_hour(filename).isoformat()
 
@@ -404,74 +293,9 @@ class RelayIndex:
             SELECT *
             FROM archive_hours
             WHERE mirror_status IN ('pending', 'error')
-            ORDER BY error_count ASC, hour
+            ORDER BY error_count ASC, hour DESC
             """
         )
-
-    def mark_mirrored(
-        self,
-        filename: str,
-        *,
-        local_path: str,
-        etag: str | None,
-        content_length: int | None,
-        last_modified: str | None,
-        processing_enabled: bool = True,
-    ) -> None:
-        self._run_with_lock_retry(
-            lambda: self._write_mark_mirrored(
-                filename,
-                local_path=local_path,
-                etag=etag,
-                content_length=content_length,
-                last_modified=last_modified,
-                processing_enabled=processing_enabled,
-            )
-        )
-
-    def _write_mark_mirrored(
-        self,
-        filename: str,
-        *,
-        local_path: str,
-        etag: str | None,
-        content_length: int | None,
-        last_modified: str | None,
-        processing_enabled: bool,
-    ) -> None:
-        process_status = "pending" if processing_enabled else "disabled"
-        prebuild_status = "pending" if processing_enabled else "disabled"
-        with self._conn:
-            self._conn.execute(
-                """
-                UPDATE archive_hours
-                SET
-                    local_path = ?,
-                    etag = ?,
-                    content_length = ?,
-                    last_modified = ?,
-                    mirror_status = 'ready',
-                    process_status = ?,
-                    prebuild_status = ?,
-                    filtered_artifact_count = 0,
-                    mirrored_at = ?,
-                    processed_at = NULL,
-                    prebuilt_at = NULL,
-                    last_error = NULL,
-                    error_count = 0
-                WHERE filename = ?
-                """,
-                (
-                    local_path,
-                    etag,
-                    content_length,
-                    last_modified,
-                    process_status,
-                    prebuild_status,
-                    _utc_now(),
-                    filename,
-                ),
-            )
 
     def mark_mirroring(self, filename: str) -> None:
         self._run_with_lock_retry(
@@ -499,6 +323,41 @@ class RelayIndex:
             )
         )
 
+    def mark_mirrored(
+        self,
+        filename: str,
+        *,
+        local_path: str,
+        etag: str | None,
+        content_length: int | None,
+        last_modified: str | None,
+    ) -> None:
+        self._run_with_lock_retry(
+            lambda: self._write_single_update(
+                """
+                UPDATE archive_hours
+                SET
+                    local_path = ?,
+                    etag = ?,
+                    content_length = ?,
+                    last_modified = ?,
+                    mirror_status = 'ready',
+                    mirrored_at = ?,
+                    last_error = NULL,
+                    error_count = 0
+                WHERE filename = ?
+                """,
+                (
+                    local_path,
+                    etag,
+                    content_length,
+                    last_modified,
+                    _utc_now(),
+                    filename,
+                ),
+            )
+        )
+
     def register_local_raw(
         self,
         filename: str,
@@ -509,6 +368,7 @@ class RelayIndex:
         archive_page: int = 0,
     ) -> bool:
         hour = parse_archive_hour(filename).isoformat()
+        mirrored_at = _utc_now()
 
         def operation() -> bool:
             with self._conn:
@@ -531,10 +391,10 @@ class RelayIndex:
                         hour,
                         source_url,
                         archive_page,
-                        _utc_now(),
+                        mirrored_at,
                         local_path,
                         content_length,
-                        _utc_now(),
+                        mirrored_at,
                     ),
                 )
                 update_cursor = self._conn.execute(
@@ -545,385 +405,39 @@ class RelayIndex:
                         local_path = ?,
                         content_length = COALESCE(content_length, ?),
                         mirror_status = 'ready',
-                        mirrored_at = COALESCE(mirrored_at, ?)
+                        mirrored_at = COALESCE(mirrored_at, ?),
+                        last_error = NULL
                     WHERE filename = ?
                       AND (
                         local_path IS NULL
                         OR local_path != ?
                         OR mirror_status != 'ready'
                         OR (content_length IS NULL AND ? IS NOT NULL)
+                        OR source_url != ?
                       )
                     """,
                     (
                         source_url,
                         local_path,
                         content_length,
-                        _utc_now(),
+                        mirrored_at,
                         filename,
                         local_path,
                         content_length,
+                        source_url,
                     ),
                 )
-            return insert_cursor.rowcount > 0 or update_cursor.rowcount > 0
+            return (insert_cursor.rowcount + update_cursor.rowcount) > 0
 
         return self._run_with_lock_retry(operation)
 
-    def disable_processing_backlog(self) -> int:
-        def operation() -> int:
-            with self._conn:
-                cursor = self._conn.execute(
-                    """
-                    UPDATE archive_hours
-                    SET process_status = 'disabled',
-                        prebuild_status = 'disabled',
-                        processed_at = NULL,
-                        prebuilt_at = NULL,
-                        filtered_artifact_count = 0,
-                        last_error = NULL
-                    WHERE mirror_status = 'ready'
-                      AND (
-                        process_status IN ('pending', 'processing', 'error')
-                        OR prebuild_status IN ('pending', 'processing', 'error')
-                      )
-                    """
-                )
-            return cursor.rowcount
-
-        return self._run_with_lock_retry(operation)
-
-    def list_hours_needing_process(
-        self,
-        *,
-        include_errors: bool = True,
-    ) -> list[sqlite3.Row]:
-        statuses = ("pending", "error") if include_errors else ("pending",)
-        placeholders = ", ".join("?" for _ in statuses)
-        return self._fetchall(
-            f"""
-            SELECT *
-            FROM archive_hours
-            WHERE mirror_status = 'ready' AND process_status IN ({placeholders})
-            ORDER BY error_count ASC, hour
-            """,
-            tuple(statuses),
-        )
-
-    def list_processing_filenames(self) -> list[str]:
-        rows = self._fetchall(
-            """
-            SELECT filename
-            FROM archive_hours
-            WHERE process_status = 'processing'
-            ORDER BY hour
-            """
-        )
-        return [
-            str(row["filename"]) for row in rows if isinstance(row["filename"], str)
-        ]
-
-    def mark_processing(self, filename: str) -> None:
-        self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                UPDATE archive_hours
-                SET process_status = 'processing', last_error = NULL
-                WHERE filename = ?
-                """,
-                (filename,),
-            )
-        )
-
-    def mark_process_error(self, filename: str, error: str) -> None:
-        self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                UPDATE archive_hours
-                SET process_status = 'error',
-                    last_error = ?,
-                    error_count = error_count + 1
-                WHERE filename = ?
-                """,
-                (error, filename),
-            )
-        )
-
-    def replace_filtered_hours(
-        self,
-        filename: str,
-        artifacts: list[FilteredHourArtifact],
-    ) -> None:
-        def operation() -> None:
-            with self._conn:
-                self._conn.execute(
-                    "DELETE FROM filtered_hours WHERE filename = ?",
-                    (filename,),
-                )
-                self._conn.executemany(
-                    """
-                    INSERT INTO filtered_hours (
-                        filename,
-                        hour,
-                        condition_id,
-                        token_id,
-                        local_path,
-                        row_count,
-                        byte_size,
-                        created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    [
-                        (
-                            artifact.filename,
-                            artifact.hour,
-                            artifact.condition_id,
-                            artifact.token_id,
-                            artifact.local_path,
-                            artifact.row_count,
-                            artifact.byte_size,
-                            _utc_now(),
-                        )
-                        for artifact in artifacts
-                    ],
-                )
-                self._conn.execute(
-                    """
-                    UPDATE archive_hours
-                    SET process_status = 'ready',
-                        prebuild_status = 'ready',
-                        processed_at = ?,
-                        prebuilt_at = ?,
-                        filtered_artifact_count = ?,
-                        last_error = NULL,
-                        error_count = 0
-                    WHERE filename = ?
-                    """,
-                    (_utc_now(), _utc_now(), len(artifacts), filename),
-                )
-
-        self._run_with_lock_retry(operation)
-
-    def mark_sharded(
-        self,
-        filename: str,
-    ) -> None:
-        self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                UPDATE archive_hours
-                SET process_status = 'ready',
-                    processed_at = ?,
-                    last_error = NULL,
-                    error_count = 0
-                WHERE filename = ?
-                """,
-                (_utc_now(), filename),
-            )
-        )
-
-    def mark_prebuilding(self, filename: str) -> None:
-        self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                UPDATE archive_hours
-                SET prebuild_status = 'processing',
-                    last_error = NULL
-                WHERE filename = ?
-                """,
-                (filename,),
-            )
-        )
-
-    def mark_prebuild_error(self, filename: str, error: str) -> None:
-        self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                UPDATE archive_hours
-                SET prebuild_status = 'error',
-                    last_error = ?,
-                    error_count = error_count + 1
-                WHERE filename = ?
-                """,
-                (error, filename),
-            )
-        )
-
-    _PREBUILT_BATCH_SIZE = 5000
-
-    def mark_prebuilt(
-        self,
-        filename: str,
-        *,
-        filtered_artifact_count: int,
-        artifacts: list[FilteredHourArtifact] | None = None,
-    ) -> None:
-        if artifacts:
-            self._run_with_lock_retry(
-                lambda: self._write_single_update(
-                    "DELETE FROM filtered_hours WHERE filename = ?",
-                    (filename,),
-                )
-            )
-            for offset in range(0, len(artifacts), self._PREBUILT_BATCH_SIZE):
-                batch = artifacts[offset : offset + self._PREBUILT_BATCH_SIZE]
-                self._run_with_lock_retry(
-                    lambda batch=batch: self._write_filtered_artifact_batch(batch)
-                )
-        self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                UPDATE archive_hours
-                SET prebuild_status = 'ready',
-                    prebuilt_at = ?,
-                    filtered_artifact_count = ?,
-                    last_error = NULL,
-                    error_count = 0
-                WHERE filename = ?
-                """,
-                (_utc_now(), filtered_artifact_count, filename),
-            )
-        )
-
-    def _write_filtered_artifact_batch(
-        self,
-        batch: list[FilteredHourArtifact],
-    ) -> None:
-        with self._conn:
-            self._conn.executemany(
-                """
-                INSERT INTO filtered_hours (
-                    filename, hour, condition_id, token_id,
-                    local_path, row_count, byte_size, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        a.filename,
-                        a.hour,
-                        a.condition_id,
-                        a.token_id,
-                        a.local_path,
-                        a.row_count,
-                        a.byte_size,
-                        _utc_now(),
-                    )
-                    for a in batch
-                ],
-            )
-
-    def list_hours_needing_filtered_prebuild(self) -> list[sqlite3.Row]:
-        return self._fetchall(
-            """
-            SELECT *
-            FROM archive_hours
-            WHERE mirror_status = 'ready'
-              AND process_status = 'ready'
-              AND prebuild_status IN ('pending', 'error')
-              AND local_path IS NOT NULL
-            ORDER BY error_count ASC, hour DESC
-            """
-        )
-
-    def list_completed_hours(self) -> list[sqlite3.Row]:
-        return self._fetchall(
-            """
-            SELECT filename, hour, filtered_artifact_count
-            FROM archive_hours
-            WHERE mirror_status = 'ready'
-              AND process_status = 'ready'
-              AND prebuild_status = 'ready'
-            ORDER BY hour
-            """
-        )
-
-    def list_filtered_for_filename(self, filename: str) -> list[sqlite3.Row]:
-        return self._fetchall(
-            """
-            SELECT *
-            FROM filtered_hours
-            WHERE filename = ?
-            ORDER BY condition_id, token_id
-            """,
-            (filename,),
-        )
-
-    def get_filtered_hour(
-        self,
-        condition_id: str,
-        token_id: str,
-        filename: str,
-    ) -> sqlite3.Row | None:
-        return self._fetchone(
-            """
-            SELECT *
-            FROM filtered_hours
-            WHERE condition_id = ? AND token_id = ? AND filename = ?
-            """,
-            (condition_id, token_id, filename),
-        )
-
-    def list_filtered_hours(
-        self,
-        condition_id: str,
-        token_id: str,
-        *,
-        start_hour: str | None = None,
-        end_hour: str | None = None,
-    ) -> list[sqlite3.Row]:
-        query = """
-            SELECT *
-            FROM filtered_hours
-            WHERE condition_id = ? AND token_id = ?
-        """
-        params: list[str] = [condition_id, token_id]
-        if start_hour is not None:
-            query += " AND hour >= ?"
-            params.append(start_hour)
-        if end_hour is not None:
-            query += " AND hour <= ?"
-            params.append(end_hour)
-        query += " ORDER BY hour"
-        return self._fetchall(query, tuple(params))
-
-    def _processed_rate_summary(self, *, window_hours: int) -> dict[str, int | float]:
-        cutoff = (_utc_now_datetime() - timedelta(hours=window_hours)).isoformat()
-        processed_hours_last_window = int(
-            self._fetchscalar(
-                """
-                SELECT COUNT(*)
-                FROM archive_hours
-                WHERE prebuild_status = 'ready'
-                  AND prebuilt_at IS NOT NULL
-                  AND prebuilt_at >= ?
-                """,
-                (cutoff,),
-                default=0,
-            )
-        )
-        return {
-            f"processed_hours_last_{window_hours}h": processed_hours_last_window,
-            f"processed_hours_per_hour_{window_hours}h": round(
-                processed_hours_last_window / max(1, window_hours),
-                2,
-            ),
-        }
-
-    def stats(self) -> dict[str, int | float | str | None]:
+    def stats(self) -> dict[str, int | str | None]:
         row = self._fetchone(
             """
             SELECT
                 COUNT(*) AS archive_hours,
                 SUM(CASE WHEN mirror_status = 'ready' THEN 1 ELSE 0 END) AS mirrored_hours,
-                SUM(CASE WHEN process_status = 'ready' THEN 1 ELSE 0 END) AS sharded_hours,
-                SUM(CASE WHEN prebuild_status = 'ready' THEN 1 ELSE 0 END) AS processed_hours,
-                SUM(CASE WHEN mirror_status = 'ready' AND process_status IN ('pending', 'error') THEN 1 ELSE 0 END) AS ready_to_process_hours,
-                SUM(CASE WHEN process_status = 'ready' AND prebuild_status != 'ready' THEN 1 ELSE 0 END) AS ready_to_prebuild_hours,
-                SUM(CASE WHEN process_status = 'processing' OR prebuild_status = 'processing' THEN 1 ELSE 0 END) AS processing_hours,
-                SUM(CASE WHEN process_status = 'processing' THEN 1 ELSE 0 END) AS sharding_hours,
-                SUM(CASE WHEN prebuild_status = 'processing' THEN 1 ELSE 0 END) AS prebuilding_hours,
-                SUM(CASE WHEN process_status = 'disabled' THEN 1 ELSE 0 END) AS processing_disabled_hours,
-                SUM(CASE WHEN mirror_status = 'error' THEN 1 ELSE 0 END) AS mirror_errors,
-                SUM(CASE WHEN process_status = 'error' THEN 1 ELSE 0 END) AS shard_errors,
-                SUM(CASE WHEN prebuild_status = 'error' THEN 1 ELSE 0 END) AS prebuild_errors
+                SUM(CASE WHEN mirror_status = 'error' THEN 1 ELSE 0 END) AS mirror_errors
             FROM archive_hours
             """
         )
@@ -936,22 +450,13 @@ class RelayIndex:
             "SELECT MAX(created_at) FROM relay_events WHERE level = 'ERROR'",
             default=None,
         )
-        payload = {
+        return {
             "archive_hours": int(stats_row.get("archive_hours") or 0),
             "mirrored_hours": int(stats_row.get("mirrored_hours") or 0),
-            "processed_hours": int(stats_row.get("processed_hours") or 0),
-            "ready_to_process_hours": int(stats_row.get("ready_to_process_hours") or 0),
-            "processing_hours": int(stats_row.get("processing_hours") or 0),
-            "processing_disabled_hours": int(
-                stats_row.get("processing_disabled_hours") or 0
-            ),
             "mirror_errors": int(stats_row.get("mirror_errors") or 0),
-            "process_errors": int(stats_row.get("shard_errors") or 0),
             "last_event_at": last_event_at,
             "last_error_at": last_error_at,
         }
-        payload.update(self._processed_rate_summary(window_hours=24))
-        return payload
 
     def queue_summary(self) -> dict[str, int | str | None]:
         row = self._fetchone(
@@ -960,17 +465,7 @@ class RelayIndex:
                 SUM(CASE WHEN mirror_status = 'pending' THEN 1 ELSE 0 END) AS mirror_pending,
                 SUM(CASE WHEN mirror_status = 'processing' THEN 1 ELSE 0 END) AS mirror_processing,
                 SUM(CASE WHEN mirror_status = 'error' THEN 1 ELSE 0 END) AS mirror_error,
-                SUM(CASE WHEN mirror_status = 'ready' AND process_status = 'pending' THEN 1 ELSE 0 END) AS process_ready,
-                SUM(CASE WHEN process_status = 'pending' THEN 1 ELSE 0 END) AS process_pending,
-                SUM(CASE WHEN process_status = 'processing' THEN 1 ELSE 0 END) AS process_processing,
-                SUM(CASE WHEN process_status = 'error' THEN 1 ELSE 0 END) AS process_error,
-                SUM(CASE WHEN process_status = 'disabled' THEN 1 ELSE 0 END) AS process_disabled,
-                SUM(CASE WHEN process_status = 'ready' AND prebuild_status != 'ready' THEN 1 ELSE 0 END) AS prebuild_ready,
-                SUM(CASE WHEN prebuild_status = 'pending' THEN 1 ELSE 0 END) AS prebuild_pending,
-                SUM(CASE WHEN prebuild_status = 'processing' THEN 1 ELSE 0 END) AS prebuild_processing,
-                SUM(CASE WHEN prebuild_status = 'error' THEN 1 ELSE 0 END) AS prebuild_error,
                 MAX(CASE WHEN mirror_status = 'ready' THEN hour END) AS latest_mirrored_hour,
-                MAX(CASE WHEN prebuild_status = 'ready' THEN hour END) AS latest_processed_hour,
                 (
                     SELECT filename
                     FROM archive_hours latest_ready
@@ -981,30 +476,14 @@ class RelayIndex:
             FROM archive_hours
             """
         )
-        payload = dict(row) if row is not None else {}
-        for key in (
-            "prebuild_ready",
-            "prebuild_pending",
-            "prebuild_processing",
-            "prebuild_error",
-        ):
-            payload.pop(key, None)
-        return payload
-
-    def current_processing_filename(self) -> str | None:
-        row = self._fetchone(
-            """
-            SELECT filename
-            FROM archive_hours
-            WHERE process_status = 'processing' OR prebuild_status = 'processing'
-            ORDER BY hour
-            LIMIT 1
-            """
-        )
-        if row is None:
-            return None
-        filename = row["filename"]
-        return filename if isinstance(filename, str) else None
+        queue_row = dict(row) if row is not None else {}
+        return {
+            "mirror_pending": int(queue_row.get("mirror_pending") or 0),
+            "mirror_processing": int(queue_row.get("mirror_processing") or 0),
+            "mirror_error": int(queue_row.get("mirror_error") or 0),
+            "latest_mirrored_hour": queue_row.get("latest_mirrored_hour"),
+            "latest_mirrored_filename": queue_row.get("latest_mirrored_filename"),
+        }
 
     def log_event(
         self,
@@ -1018,79 +497,42 @@ class RelayIndex:
         payload_json = (
             json.dumps(payload, sort_keys=True) if payload is not None else None
         )
-        inserted = self._run_with_lock_retry(
-            lambda: self._write_single_update(
-                """
-                INSERT INTO relay_events (
-                    created_at,
-                    level,
-                    event_type,
-                    filename,
-                    message,
-                    payload_json
-                ) VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (_utc_now(), level, event_type, filename, message, payload_json),
-            ),
-            swallow_after_secs=10.0,
-            default=False,
-        )
-        if inserted is False:
-            return
-        self._events_since_prune += 1
-        prune_threshold = 1 if self._event_retention <= 250 else 250
-        if self._events_since_prune >= prune_threshold:
-            self.prune_events(best_effort=True)
 
-    def _write_single_update(
-        self,
-        sql: str,
-        params: tuple[object, ...],
-    ) -> bool:
-        with self._conn:
-            self._conn.execute(sql, params)
-        return True
+        def operation() -> None:
+            with self._conn:
+                self._conn.execute(
+                    """
+                    INSERT INTO relay_events (
+                        created_at,
+                        level,
+                        event_type,
+                        filename,
+                        message,
+                        payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (_utc_now(), level, event_type, filename, message, payload_json),
+                )
+
+        self._run_with_lock_retry(operation)
+        self._events_since_prune += 1
+        if self._events_since_prune >= 1000:
+            self.prune_events(best_effort=True)
 
     def recent_events(self, *, limit: int = 100) -> list[sqlite3.Row]:
         return self._fetchall(
             """
-            SELECT *
+            SELECT
+                id,
+                created_at,
+                level,
+                event_type,
+                filename,
+                message,
+                payload_json
             FROM relay_events
-            ORDER BY id DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT ?
             """,
-            (limit,),
-        )
-
-    def latest_prebuild_progress(self) -> PrebuildProgress | None:
-        row = self._fetchone(
-            """
-            SELECT created_at, filename, payload_json
-            FROM relay_events
-            WHERE event_type IN ('filtered_prebuild_progress', 'process_progress')
-            ORDER BY id DESC
-            LIMIT 1
-            """
-        )
-        if row is None or row["payload_json"] is None:
-            return None
-
-        try:
-            payload = json.loads(row["payload_json"])
-        except json.JSONDecodeError:
-            return None
-
-        filename = row["filename"]
-        processed_rows = payload.get("processed_rows")
-        total_rows = payload.get("total_rows")
-        if not isinstance(filename, str):
-            return None
-        if type(processed_rows) is not int or type(total_rows) is not int:
-            return None
-
-        return PrebuildProgress(
-            filename=filename,
-            created_at=row["created_at"],
-            processed_rows=processed_rows,
-            total_rows=total_rows,
+            (max(1, limit),),
         )

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -29,18 +29,10 @@ class RelayWorker:
         self._config = config
         self._config.ensure_directories()
         self._index = RelayIndex(config.db_path, event_retention=config.event_retention)
-        reset_mirror, _, _ = self._index.initialize(
+        reset_mirror = self._index.initialize(
             reset_inflight=reset_inflight,
             reset_mirror_inflight=reset_mirror_inflight,
         )
-        retired = self._index.disable_processing_backlog()
-        if retired > 0:
-            self._record_event(
-                level="INFO",
-                event_type="processing_disabled",
-                message="Disabled legacy processing backlog for mirror-only relay mode",
-                payload={"retired_hours": retired},
-            )
         if reset_mirror:
             self._record_event(
                 level="WARNING",
@@ -169,7 +161,6 @@ class RelayWorker:
                 continue
             adopted += 1
         if adopted > 0:
-            self._index.disable_processing_backlog()
             self._record_event(
                 level="INFO",
                 event_type="adopt_local_raw",
@@ -211,7 +202,6 @@ class RelayWorker:
                 etag=None,
                 content_length=raw_path.stat().st_size,
                 last_modified=None,
-                processing_enabled=False,
             )
             self._record_event(
                 level="INFO",
@@ -283,7 +273,6 @@ class RelayWorker:
             etag=etag,
             content_length=content_length,
             last_modified=last_modified,
-            processing_enabled=False,
         )
         self._record_event(
             level="INFO",

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
@@ -12,9 +15,10 @@ from pmxt_relay.api import (
     INDEX_APP_KEY,
     RequestRateLimiter,
     _client_id,
-    _collect_inflight_processes,
+    _collect_inflight_downloads,
     _cpu_percent_from_loadavg,
     _resolve_raw_path,
+    _status_badge_payload,
     create_app,
 )
 from pmxt_relay.config import RelayConfig
@@ -86,7 +90,7 @@ def test_raw_path_resolution_requires_known_archive_layout(tmp_path: Path):
     assert blocked_path is None
 
 
-def test_collect_inflight_processes_reports_raw_tmp_files(tmp_path: Path):
+def test_collect_inflight_downloads_reports_raw_tmp_files(tmp_path: Path):
     config = _make_config(tmp_path)
     config.ensure_directories()
     tmp_file = (
@@ -99,7 +103,7 @@ def test_collect_inflight_processes_reports_raw_tmp_files(tmp_path: Path):
     tmp_file.parent.mkdir(parents=True, exist_ok=True)
     tmp_file.write_bytes(b"abc")
 
-    inflight = _collect_inflight_processes(config)
+    inflight = _collect_inflight_downloads(config)
 
     assert len(inflight) == 1
     assert inflight[0]["filename"] == "polymarket_orderbook_2026-03-21T12.parquet"
@@ -157,6 +161,28 @@ def test_active_api_has_no_filtered_routes(tmp_path: Path):
             await client.close()
 
         assert response.status == 404
+
+    asyncio.run(scenario())
+
+
+def test_active_api_has_no_processing_badge_routes(tmp_path: Path):
+    async def scenario() -> None:
+        config = replace(_make_config(tmp_path))
+        config.ensure_directories()
+        app = create_app(config)
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            processing_response = await client.get("/v1/badge/processing.svg")
+            file_response = await client.get("/v1/badge/file.svg")
+            rows_response = await client.get("/v1/badge/rows.svg")
+        finally:
+            await client.close()
+
+        assert processing_response.status == 404
+        assert file_response.status == 404
+        assert rows_response.status == 404
 
     asyncio.run(scenario())
 
@@ -237,6 +263,38 @@ def test_worker_badge_reflects_live_service_state(tmp_path: Path):
     asyncio.run(scenario())
 
 
+def test_status_badge_uses_up_for_healthy_mirror_only_relay(tmp_path: Path):
+    config = _make_config(tmp_path)
+    now = datetime(2026, 4, 3, 20, 0, tzinfo=timezone.utc)
+
+    payload = _status_badge_payload(
+        stats={
+            "last_event_at": (now - timedelta(minutes=5)).isoformat(),
+        },
+        config=config,
+        now=now,
+    )
+
+    assert payload["message"] == "up"
+    assert payload["color"] == "brightgreen"
+
+
+def test_status_badge_uses_stale_for_old_last_event(tmp_path: Path):
+    config = _make_config(tmp_path)
+    now = datetime(2026, 4, 3, 20, 0, tzinfo=timezone.utc)
+
+    payload = _status_badge_payload(
+        stats={
+            "last_event_at": (now - timedelta(hours=2)).isoformat(),
+        },
+        config=config,
+        now=now,
+    )
+
+    assert payload["message"] == "stale"
+    assert payload["color"] == "red"
+
+
 def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
     async def scenario() -> None:
         config = _make_config(tmp_path)
@@ -259,7 +317,6 @@ def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
             etag=None,
             content_length=1,
             last_modified=None,
-            processing_enabled=False,
         )
         index.mark_mirrored(
             "polymarket_orderbook_2026-03-21T13.parquet",
@@ -267,7 +324,6 @@ def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
             etag=None,
             content_length=1,
             last_modified=None,
-            processing_enabled=False,
         )
 
         server = TestServer(app)
@@ -282,5 +338,50 @@ def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
         assert response.status == 200
         assert "Latest file" in payload
         assert "polymarket_orderbook_2026-03-21T13.parquet" in payload
+
+    asyncio.run(scenario())
+
+
+def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
+    async def scenario() -> None:
+        config = _make_config(tmp_path)
+        config.ensure_directories()
+        app = create_app(config)
+        index = app[INDEX_APP_KEY]
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        index.upsert_discovered_hour(
+            filename,
+            "https://raw.example.com/polymarket_orderbook_2026-03-21T12.parquet",
+            1,
+        )
+        index.mark_mirrored(
+            filename,
+            local_path=str(tmp_path / "hour.parquet"),
+            etag=None,
+            content_length=1,
+            last_modified=None,
+        )
+
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            stats_response = await client.get("/v1/stats")
+            queue_response = await client.get("/v1/queue")
+            stats_payload = await stats_response.json()
+            queue_payload = await queue_response.json()
+        finally:
+            await client.close()
+
+        assert stats_response.status == 200
+        assert queue_response.status == 200
+        assert "processed_hours" not in stats_payload
+        assert "processing_hours" not in stats_payload
+        assert "ready_to_process_hours" not in stats_payload
+        assert "process_errors" not in stats_payload
+        assert "process_pending" not in queue_payload
+        assert "process_processing" not in queue_payload
+        assert "prebuild_pending" not in queue_payload
+        assert queue_payload["latest_mirrored_filename"] == filename
 
     asyncio.run(scenario())

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from datetime import UTC
-from datetime import datetime
 from pathlib import Path
-import sqlite3
 
-from pmxt_relay.index_db import FilteredHourArtifact, RelayIndex
+from pmxt_relay.index_db import RelayIndex
 
 
-def test_relay_index_events_and_queue_summary(tmp_path: Path):
+def test_relay_index_events_and_queue_summary_are_mirror_only(tmp_path: Path):
     index = RelayIndex(tmp_path / "relay.sqlite3", event_retention=2)
-    reset_counts = index.initialize()
-    assert reset_counts == (0, 0, 0)
+    reset_count = index.initialize()
+    assert reset_count == 0
 
     index.upsert_discovered_hour(
         "polymarket_orderbook_2026-03-21T12.parquet",
@@ -24,16 +21,16 @@ def test_relay_index_events_and_queue_summary(tmp_path: Path):
         1,
     )
     index.mark_mirroring("polymarket_orderbook_2026-03-21T12.parquet")
-    index.mark_processing("polymarket_orderbook_2026-03-21T13.parquet")
 
     queue = index.queue_summary()
     assert queue["mirror_processing"] == 1
-    assert queue["process_processing"] == 1
-    assert queue["process_ready"] == 0
+    assert queue["mirror_pending"] == 1
+    assert "process_pending" not in queue
 
     index.log_event(level="INFO", event_type="first", message="first message")
     index.log_event(level="INFO", event_type="second", message="second message")
     index.log_event(level="ERROR", event_type="third", message="third message")
+    index.prune_events()
 
     events = index.recent_events(limit=10)
     stats = index.stats()
@@ -41,10 +38,9 @@ def test_relay_index_events_and_queue_summary(tmp_path: Path):
     assert [event["event_type"] for event in events] == ["third", "second"]
     assert len(events) == 2
     assert stats["archive_hours"] == 2
-    assert stats["ready_to_process_hours"] == 0
-    assert stats["processing_hours"] == 1
+    assert stats["mirrored_hours"] == 0
     assert stats["mirror_errors"] == 0
-    assert stats["process_errors"] == 0
+    assert "processed_hours" not in stats
     assert stats["last_event_at"] is not None
     assert stats["last_error_at"] is not None
 
@@ -60,153 +56,24 @@ def test_upsert_discovered_hour_is_idempotent(tmp_path: Path):
     )
     second_insert = index.upsert_discovered_hour(
         "polymarket_orderbook_2026-03-21T12.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
+        "https://mirror.example.com/polymarket_orderbook_2026-03-21T12.parquet",
         2,
     )
 
     assert first_insert is True
     assert second_insert is False
-    stats = index.stats()
-    assert stats["archive_hours"] == 1
-
-
-def test_initialize_resets_stale_inflight_rows(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T12.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
-        1,
-    )
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T13.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet",
-        1,
-    )
-    index.mark_mirroring("polymarket_orderbook_2026-03-21T12.parquet")
-    index.mark_processing("polymarket_orderbook_2026-03-21T13.parquet")
-
-    reopened = RelayIndex(tmp_path / "relay.sqlite3")
-    reset_counts = reopened.initialize(reset_inflight=True)
-    queue = reopened.queue_summary()
-
-    assert reset_counts == (1, 1, 0)
-    assert queue["mirror_pending"] == 2
-    assert queue["process_pending"] == 2
-    assert queue["mirror_processing"] == 0
-    assert queue["process_processing"] == 0
-
-
-def test_initialize_can_reset_prebuild_inflight_separately(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    index.upsert_discovered_hour(
-        filename,
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
-        1,
-    )
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_sharded(filename)
-    index.mark_prebuilding(filename)
-
-    reopened = RelayIndex(tmp_path / "relay.sqlite3")
-    reset_counts = reopened.initialize(
-        reset_inflight=True,
-        reset_mirror_inflight=False,
-        reset_process_inflight=False,
-        reset_prebuild_inflight=True,
-    )
-
-    assert reset_counts == (0, 0, 1)
-    row = reopened._conn.execute(  # noqa: SLF001
-        "SELECT prebuild_status FROM archive_hours WHERE filename = ?",
-        (filename,),
+    row = index._conn.execute(  # noqa: SLF001
+        "SELECT archive_page, source_url FROM archive_hours WHERE filename = ?",
+        ("polymarket_orderbook_2026-03-21T12.parquet",),
     ).fetchone()
     assert row is not None
-    assert row["prebuild_status"] == "pending"
-
-
-def test_list_hours_needing_process_excludes_already_processing(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T12.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
-        1,
+    assert row["archive_page"] == 2
+    assert row["source_url"] == (
+        "https://mirror.example.com/polymarket_orderbook_2026-03-21T12.parquet"
     )
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T13.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet",
-        1,
-    )
-    index.mark_mirrored(
-        "polymarket_orderbook_2026-03-21T12.parquet",
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_mirrored(
-        "polymarket_orderbook_2026-03-21T13.parquet",
-        local_path="/tmp/b",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_processing("polymarket_orderbook_2026-03-21T12.parquet")
-    index.mark_process_error("polymarket_orderbook_2026-03-21T13.parquet", "boom")
-
-    rows = index.list_hours_needing_process()
-
-    assert [row["filename"] for row in rows] == [
-        "polymarket_orderbook_2026-03-21T13.parquet"
-    ]
 
 
-def test_list_hours_needing_process_pending_only_skips_errors(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T12.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
-        1,
-    )
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T13.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet",
-        1,
-    )
-    index.mark_mirrored(
-        "polymarket_orderbook_2026-03-21T12.parquet",
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_mirrored(
-        "polymarket_orderbook_2026-03-21T13.parquet",
-        local_path="/tmp/b",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_process_error("polymarket_orderbook_2026-03-21T12.parquet", "boom")
-
-    rows = index.list_hours_needing_process(include_errors=False)
-
-    assert [row["filename"] for row in rows] == [
-        "polymarket_orderbook_2026-03-21T13.parquet"
-    ]
-
-
-def test_mark_prebuilt_tracks_filtered_artifact_count(tmp_path: Path):
+def test_initialize_resets_stale_mirror_rows(tmp_path: Path):
     index = RelayIndex(tmp_path / "relay.sqlite3")
     index.initialize()
     filename = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -215,542 +82,62 @@ def test_mark_prebuilt_tracks_filtered_artifact_count(tmp_path: Path):
         "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
         1,
     )
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_sharded(filename)
+    index.mark_mirroring(filename)
 
-    rows = index.list_hours_needing_filtered_prebuild()
-    assert [row["filename"] for row in rows] == [filename]
-
-    index.mark_prebuilt(filename, filtered_artifact_count=42)
-
-    stats = index.stats()
-
-    assert stats["processed_hours"] == 1
-    assert index.list_hours_needing_filtered_prebuild() == []
-
-
-def test_stats_include_processed_hours_per_hour_24h(tmp_path: Path, monkeypatch):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-
-    recent_filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    stale_filename = "polymarket_orderbook_2026-03-20T12.parquet"
-    for filename in (recent_filename, stale_filename):
-        index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-        index.mark_mirrored(
-            filename,
-            local_path="/tmp/" + filename,
-            etag=None,
-            content_length=None,
-            last_modified=None,
-        )
-        index.mark_sharded(filename)
-        index.mark_prebuilt(filename, filtered_artifact_count=1)
-
-    with index._conn:  # noqa: SLF001
-        index._conn.execute(  # noqa: SLF001
-            """
-            UPDATE archive_hours
-            SET prebuilt_at = ?
-            WHERE filename = ?
-            """,
-            ("2026-03-22T11:30:00+00:00", recent_filename),
-        )
-        index._conn.execute(  # noqa: SLF001
-            """
-            UPDATE archive_hours
-            SET prebuilt_at = ?
-            WHERE filename = ?
-            """,
-            ("2026-03-20T10:00:00+00:00", stale_filename),
-        )
-
-    monkeypatch.setattr(
-        "pmxt_relay.index_db._utc_now_datetime",
-        lambda: datetime(2026, 3, 22, 12, 0, tzinfo=UTC),
-    )
-
-    stats = index.stats()
-
-    assert stats["processed_hours_last_24h"] == 1
-    assert stats["processed_hours_per_hour_24h"] == 0.04
-
-
-def test_latest_prebuild_progress_returns_latest_progress_event(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-
-    index.log_event(
-        level="INFO",
-        event_type="filtered_prebuild_progress",
-        filename="polymarket_orderbook_2026-03-21T11.parquet",
-        message="first prebuild progress",
-        payload={"processed_rows": 128, "total_rows": 1024},
-    )
-    index.log_event(
-        level="INFO",
-        event_type="mirror_start",
-        filename="polymarket_orderbook_2026-03-21T12.parquet",
-        message="mirror is noisier than prebuild",
-    )
-    index.log_event(
-        level="INFO",
-        event_type="filtered_prebuild_progress",
-        filename="polymarket_orderbook_2026-03-21T12.parquet",
-        message="latest prebuild progress",
-        payload={"processed_rows": 512, "total_rows": 2048},
-    )
-
-    progress = index.latest_prebuild_progress()
-
-    assert progress is not None
-    assert progress.filename == "polymarket_orderbook_2026-03-21T12.parquet"
-    assert progress.processed_rows == 512
-    assert progress.total_rows == 2048
-    assert progress.created_at is not None
-
-
-def test_latest_prebuild_progress_accepts_process_progress_events(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-
-    index.log_event(
-        level="INFO",
-        event_type="process_progress",
-        filename="polymarket_orderbook_2026-03-21T13.parquet",
-        message="latest process progress",
-        payload={"processed_rows": 768, "total_rows": 4096},
-    )
-
-    progress = index.latest_prebuild_progress()
-
-    assert progress is not None
-    assert progress.filename == "polymarket_orderbook_2026-03-21T13.parquet"
-    assert progress.processed_rows == 768
-    assert progress.total_rows == 4096
-
-
-def test_current_processing_filename_returns_active_hour(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T14.parquet"
-    index.upsert_discovered_hour(
-        filename,
-        f"https://r2.pmxt.dev/{filename}",
-        1,
-    )
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/raw.parquet",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_processing(filename)
-
-    assert index.current_processing_filename() == filename
-
-
-def test_lock_retry_retries_until_success(tmp_path: Path, monkeypatch) -> None:
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    attempts = 0
-
-    monkeypatch.setattr("pmxt_relay.index_db.time.sleep", lambda _: None)
-
-    def flaky_operation() -> str:
-        nonlocal attempts
-        attempts += 1
-        if attempts < 3:
-            raise sqlite3.OperationalError("database is locked")
-        return "ok"
-
-    assert index._run_with_lock_retry(flaky_operation) == "ok"  # noqa: SLF001
-    assert attempts == 3
-
-
-def test_lock_retry_can_drop_best_effort_writes(tmp_path: Path, monkeypatch) -> None:
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    now = 0.0
-
-    def fake_monotonic() -> float:
-        return now
-
-    def fake_sleep(delay: float) -> None:
-        nonlocal now
-        now += delay
-
-    monkeypatch.setattr("pmxt_relay.index_db.time.monotonic", fake_monotonic)
-    monkeypatch.setattr("pmxt_relay.index_db.time.sleep", fake_sleep)
-
-    def always_locked() -> None:
-        raise sqlite3.OperationalError("database is locked")
-
-    dropped = index._run_with_lock_retry(  # noqa: SLF001
-        always_locked,
-        swallow_after_secs=0.2,
-        default=False,
-    )
-
-    assert dropped is False
-
-
-def test_initialize_without_maintenance_skips_startup_write_work(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    db_path = tmp_path / "relay.sqlite3"
-    index = RelayIndex(db_path)
-    index.initialize()
-    index.upsert_discovered_hour(
-        "polymarket_orderbook_2026-03-21T12.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
-        1,
-    )
-    index.mark_mirroring("polymarket_orderbook_2026-03-21T12.parquet")
-
-    reopened = RelayIndex(db_path)
-
-    def fail_prune(*, best_effort: bool = False) -> None:
-        raise AssertionError("initialize(apply_maintenance=False) should not prune")
-
-    monkeypatch.setattr(reopened, "prune_events", fail_prune)
-
-    reset_counts = reopened.initialize(
-        apply_maintenance=False,
-        reset_inflight=True,
-    )
-
-    assert reset_counts == (0, 0, 0)
+    reopened = RelayIndex(tmp_path / "relay.sqlite3")
+    reset_count = reopened.initialize(reset_inflight=True)
     queue = reopened.queue_summary()
-    assert queue["mirror_processing"] == 1
+
+    assert reset_count == 1
+    assert queue["mirror_pending"] == 1
+    assert queue["mirror_processing"] == 0
 
 
-def test_error_count_deprioritizes_but_never_abandons(tmp_path: Path):
+def test_register_local_raw_marks_hour_ready(tmp_path: Path):
     index = RelayIndex(tmp_path / "relay.sqlite3")
     index.initialize()
     filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-
-    # Mirror errors: hour stays in queue no matter how many errors
-    index.mark_mirror_error(filename, "timeout 1")
-    assert len(index.list_hours_needing_mirror()) == 1
-    index.mark_mirror_error(filename, "timeout 2")
-    assert len(index.list_hours_needing_mirror()) == 1
-    index.mark_mirror_error(filename, "timeout 3")
-    assert len(index.list_hours_needing_mirror()) == 1  # still queued
-
-    # Success resets error_count
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_process_error(filename, "corrupt 1")
-    assert len(index.list_hours_needing_process()) == 1
-    index.mark_process_error(filename, "corrupt 2")
-    index.mark_process_error(filename, "corrupt 3")
-    assert len(index.list_hours_needing_process()) == 1  # still queued
-
-    # Prebuild errors — never abandoned
-    index.mark_sharded(filename)  # resets error_count
-    index.mark_prebuild_error(filename, "oom 1")
-    assert len(index.list_hours_needing_filtered_prebuild()) == 1
-    index.mark_prebuild_error(filename, "oom 2")
-    index.mark_prebuild_error(filename, "oom 3")
-    assert len(index.list_hours_needing_filtered_prebuild()) == 1  # still queued
-
-    # Errored hours sort to the back (deprioritized, not abandoned)
-    filename2 = "polymarket_orderbook_2026-03-21T13.parquet"
-    index.upsert_discovered_hour(filename2, "https://r2.pmxt.dev/" + filename2, 1)
-    index.mark_mirrored(
-        filename2,
-        local_path="/tmp/b",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_sharded(filename2)
-    hours = index.list_hours_needing_filtered_prebuild()
-    assert len(hours) == 2
-    # Clean hour comes first (error_count=0), errored hour comes last
-    assert hours[0]["filename"] == filename2
-    assert hours[1]["filename"] == filename
-
-
-def test_register_local_raw_adopts_existing_raw_without_resetting_processed_state(
-    tmp_path: Path,
-) -> None:
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    source_url = "https://r2.pmxt.dev/" + filename
-    local_path = "/srv/pmxt-relay/raw/2026/03/21/" + filename
-    index.upsert_discovered_hour(filename, source_url, 1)
-    index.mark_mirrored(
-        filename,
-        local_path=local_path,
-        etag=None,
-        content_length=100,
-        last_modified=None,
-    )
-    index.mark_sharded(filename)
-    index.mark_prebuilt(filename, filtered_artifact_count=7)
 
     changed = index.register_local_raw(
         filename,
-        local_path=local_path,
-        content_length=100,
-        source_url=source_url,
+        local_path="/srv/pmxt-relay/raw/2026/03/21/" + filename,
+        content_length=123,
+        source_url="https://r2.pmxt.dev/" + filename,
     )
 
+    assert changed is True
     row = index._conn.execute(  # noqa: SLF001
         """
-        SELECT mirror_status, process_status, prebuild_status, filtered_artifact_count
+        SELECT local_path, content_length, mirror_status, mirrored_at
         FROM archive_hours
         WHERE filename = ?
         """,
         (filename,),
     ).fetchone()
-
-    assert changed is False
+    assert row is not None
     assert row["mirror_status"] == "ready"
-    assert row["process_status"] == "ready"
-    assert row["prebuild_status"] == "ready"
-    assert row["filtered_artifact_count"] == 7
+    assert row["content_length"] == 123
+    assert row["mirrored_at"] is not None
 
 
-def test_mark_prebuilt_registers_artifacts_in_filtered_hours(tmp_path: Path):
+def test_queue_summary_reports_latest_mirrored_filename(tmp_path: Path):
     index = RelayIndex(tmp_path / "relay.sqlite3")
     index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_sharded(filename)
-
-    artifacts = [
-        FilteredHourArtifact(
-            filename=filename,
-            hour="2026-03-21T12:00:00+00:00",
-            condition_id="0x" + "ab" * 32,
-            token_id="123",
-            local_path="/srv/filtered/0xab/123/" + filename,
-            row_count=100,
-            byte_size=5000,
-        ),
-        FilteredHourArtifact(
-            filename=filename,
-            hour="2026-03-21T12:00:00+00:00",
-            condition_id="0x" + "cd" * 32,
-            token_id="456",
-            local_path="/srv/filtered/0xcd/456/" + filename,
-            row_count=50,
-            byte_size=2500,
-        ),
+    filenames = [
+        "polymarket_orderbook_2026-03-21T12.parquet",
+        "polymarket_orderbook_2026-03-21T13.parquet",
     ]
-    index.mark_prebuilt(filename, filtered_artifact_count=2, artifacts=artifacts)
-
-    # Verify filtered_hours table
-    rows = index.list_filtered_for_filename(filename)
-    assert len(rows) == 2
-    assert rows[0]["condition_id"] == "0x" + "ab" * 32
-    assert rows[0]["row_count"] == 100
-    assert rows[1]["condition_id"] == "0x" + "cd" * 32
-
-    # Verify the listing API works
-    listed = index.list_filtered_hours("0x" + "ab" * 32, "123")
-    assert len(listed) == 1
-    assert listed[0]["filename"] == filename
-
-    # Re-prebuilt replaces old artifacts
-    new_artifacts = [artifacts[0]]
-    index.mark_prebuilt(filename, filtered_artifact_count=1, artifacts=new_artifacts)
-    rows = index.list_filtered_for_filename(filename)
-    assert len(rows) == 1
-
-
-def test_mark_prebuilt_without_artifacts_does_not_touch_filtered_hours(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_sharded(filename)
-
-    # mark_prebuilt without artifacts should NOT insert into filtered_hours
-    index.mark_prebuilt(filename, filtered_artifact_count=42)
-    rows = index.list_filtered_for_filename(filename)
-    assert len(rows) == 0
-
-    # But archive_hours should still show ready
-    stats = index.stats()
-    assert stats["processed_hours"] == 1
-
-
-def test_event_pruning_respects_retention_limit(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3", event_retention=5)
-    index.initialize()
-
-    for i in range(10):
-        index.log_event(level="INFO", event_type=f"evt_{i}", message=f"message {i}")
-
-    events = index.recent_events(limit=100)
-    assert len(events) == 5
-    # Most recent events survive
-    assert events[0]["event_type"] == "evt_9"
-    assert events[-1]["event_type"] == "evt_5"
-
-
-def test_mark_sharded_resets_error_count(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-
-    # Accumulate process errors
-    index.mark_process_error(filename, "err1")
-    index.mark_process_error(filename, "err2")
-    assert len(index.list_hours_needing_process()) == 1
-
-    # mark_sharded resets error_count so the file is eligible for prebuild
-    index.mark_sharded(filename)
-    queue = index.queue_summary()
-    assert queue["process_error"] == 0
-
-
-def test_list_filtered_hours_with_hour_range(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-
-    condition_id = "0x" + "ab" * 32
-    token_id = "123"
-    for hour_str in ["T10", "T12", "T14", "T16"]:
-        filename = f"polymarket_orderbook_2026-03-21{hour_str}.parquet"
-        index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
+    for filename in filenames:
+        index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
         index.mark_mirrored(
             filename,
-            local_path="/tmp/a",
+            local_path=f"/srv/pmxt-relay/raw/{filename}",
             etag=None,
-            content_length=None,
+            content_length=1,
             last_modified=None,
         )
-        index.mark_sharded(filename)
-        artifacts = [
-            FilteredHourArtifact(
-                filename=filename,
-                hour=f"2026-03-21{hour_str}:00:00+00:00",
-                condition_id=condition_id,
-                token_id=token_id,
-                local_path=f"/srv/filtered/{condition_id}/{token_id}/{filename}",
-                row_count=100,
-                byte_size=5000,
-            ),
-        ]
-        index.mark_prebuilt(filename, filtered_artifact_count=1, artifacts=artifacts)
-
-    # All hours
-    all_hours = index.list_filtered_hours(condition_id, token_id)
-    assert len(all_hours) == 4
-
-    # Range filter
-    ranged = index.list_filtered_hours(
-        condition_id,
-        token_id,
-        start_hour="2026-03-21T12:00:00+00:00",
-        end_hour="2026-03-21T14:00:00+00:00",
-    )
-    assert len(ranged) == 2
-
-    # Non-existent market returns empty
-    empty = index.list_filtered_hours("0xdeadbeef", "999")
-    assert len(empty) == 0
-
-
-def test_replace_filtered_hours_sets_all_statuses_ready(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-
-    artifacts = [
-        FilteredHourArtifact(
-            filename=filename,
-            hour="2026-03-21T12:00:00+00:00",
-            condition_id="0x" + "ab" * 32,
-            token_id="123",
-            local_path="/srv/filtered/0xab/123/" + filename,
-            row_count=100,
-            byte_size=5000,
-        ),
-    ]
-    index.replace_filtered_hours(filename, artifacts)
 
     queue = index.queue_summary()
-    assert queue["process_error"] == 0
-    rows = index.list_filtered_for_filename(filename)
-    assert len(rows) == 1
-    stats = index.stats()
-    assert stats["processed_hours"] == 1
 
-
-def test_get_filtered_hour_returns_single_row(tmp_path: Path):
-    index = RelayIndex(tmp_path / "relay.sqlite3")
-    index.initialize()
-    filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    condition_id = "0x" + "ab" * 32
-    token_id = "123"
-    index.upsert_discovered_hour(filename, "https://r2.pmxt.dev/" + filename, 1)
-    index.mark_mirrored(
-        filename,
-        local_path="/tmp/a",
-        etag=None,
-        content_length=None,
-        last_modified=None,
-    )
-    index.mark_sharded(filename)
-    artifacts = [
-        FilteredHourArtifact(
-            filename=filename,
-            hour="2026-03-21T12:00:00+00:00",
-            condition_id=condition_id,
-            token_id=token_id,
-            local_path="/srv/filtered/test/" + filename,
-            row_count=50,
-            byte_size=2500,
-        ),
-    ]
-    index.mark_prebuilt(filename, filtered_artifact_count=1, artifacts=artifacts)
-
-    row = index.get_filtered_hour(condition_id, token_id, filename)
-    assert row is not None
-    assert row["row_count"] == 50
-    assert row["byte_size"] == 2500
-
-    # Non-existent returns None
-    assert index.get_filtered_hour("0xdead", "999", filename) is None
+    assert queue["latest_mirrored_filename"] == filenames[-1]
+    assert queue["latest_mirrored_hour"] == "2026-03-21T13:00:00+00:00"

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -89,7 +89,6 @@ def test_mirror_hour_falls_back_to_get_when_head_is_rejected(
     stats = worker._index.stats()  # noqa: SLF001
     assert stats["archive_hours"] == 1
     assert stats["mirrored_hours"] == 1
-    assert stats["processing_disabled_hours"] == 1
 
 
 def test_run_once_only_discovers_adopts_and_mirrors(
@@ -104,7 +103,7 @@ def test_run_once_only_discovers_adopts_and_mirrors(
     assert worker.run_once() == 10
 
 
-def test_adopt_local_raw_marks_hours_as_disabled_for_processing(tmp_path: Path) -> None:
+def test_adopt_local_raw_marks_hours_as_mirrored(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
     worker = RelayWorker(config, reset_inflight=False)
     raw_path = (
@@ -122,4 +121,3 @@ def test_adopt_local_raw_marks_hours_as_disabled_for_processing(tmp_path: Path) 
     assert adopted == 1
     stats = worker._index.stats()  # noqa: SLF001
     assert stats["mirrored_hours"] == 1
-    assert stats["processing_disabled_hours"] == 1


### PR DESCRIPTION
## What changed
- removed processing and prebuild state from the active `pmxt_relay` index and API surface
- simplified the live relay status badge to mirror-only health states: `starting`, `stale`, or healthy `up`
- removed retired processing badge routes and processing-shaped stats/queue payload fields from the active relay
- decoupled `pmxt_local` from `pmxt_relay.index_db` so local processing types live on the local side, not the live relay
- updated relay tests and relay docs to match the mirror-only deployment model

## Why it changed
The active relay was still carrying schema fields, badge routes, and API payloads from the old processing relay. That made the deployed mirror look like it still had a processing stage when it does not.

## Impact
- the live mirror no longer exposes processing-oriented badge states or queue/stats fields
- relay status will not show `processing` anymore; a healthy mirror reports `up` in `brightgreen`
- the active relay code is cleaner and matches the production architecture more closely

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
