### PR TITLE
[codex] Tighten PMXT docs wording

### DIFF
--- a/docs/execution-modeling.md
+++ b/docs/execution-modeling.md
@@ -44,9 +44,10 @@ the raw venue data are:
 
 ### PMXT
 
-- the loader prefers local filtered cache first, then any local raw PMXT
-  mirror, then relay-hosted filtered hours if the configured relay still serves
-  them, then the configured remote raw archive, then relay-hosted raw hours
+- the loader prefers local filtered cache first, then raw sources in the order
+  configured by the runner
+- for the public PMXT runners in this repo, that usually means local raw
+  mirror first, then the configured remote archive, then a raw mirror fallback
 - the current shared relay direction is mirror-only, so the durable shared
   server path is raw parquet serving rather than server-side filtered-hour
   processing

--- a/docs/pmxt-byod.md
+++ b/docs/pmxt-byod.md
@@ -41,16 +41,15 @@ DATA = MarketDataConfig(
 With PMXT, the active public contract is:
 
 1. local cache
-2. local raw mirror
-3. explicit remote PMXT archive
-4. explicit raw mirror or relay fallback
+2. each explicit raw source in the order you list it
 
 After the cache layer, the runner honors the raw-source order exactly as you
 list it in `DATA.sources`.
 
-The underlying Nautilus PMXT loader still has a filtered-relay tier for people
-running a legacy or self-hosted full-stack relay. In this repository's current
-mirror-first setup, that filtered tier is not the shared-server path to rely on.
+The vendored Nautilus PMXT loader still exposes legacy compatibility modes for
+people running a self-hosted full-stack relay. In this repository's current
+mirror-first setup, the supported shared-server path is raw parquet serving,
+not relay-hosted filtered parquet.
 
 Legacy `PMXT_DATA_SOURCE` mode flags still work too:
 
@@ -114,10 +113,10 @@ The current "bring your own data" story is therefore:
 - or use `PMXT_DATA_SOURCE=raw-local` with `PMXT_LOCAL_MIRROR_DIR`
 - or run your own raw mirror and point `PMXT_RELAY_BASE_URL` at it
 
-When the runner falls back to a remote raw source (`r2.pmxt.dev` or a relay
-`/v1/raw/...`), it downloads that hour to a temporary local parquet file,
-filters it locally, and deletes the temp artifact afterward. Persistent raw
-disk growth only happens when you intentionally configure a local raw mirror.
+When the runner falls back to a remote raw source, it downloads that hour to a
+temporary local parquet file, filters it locally, and deletes the temp
+artifact afterward. Persistent raw disk growth only happens when you
+intentionally configure a local raw mirror.
 
 The important distinction is:
 
@@ -291,11 +290,9 @@ that field must be present and string-encoded exactly as expected.
 
 ## Relay Mode
 
-The default relay is:
-
-```text
-https://209-209-10-83.sslip.io
-```
+The public runner layer does not assume a repo-wide default relay host. If you
+want a relay fallback, set it explicitly in `DATA.sources` or with the loader
+env var below.
 
 Override it with:
 


### PR DESCRIPTION
## What changed
- updated the PMXT execution-modeling page so it describes the current runner-driven raw source order instead of the retired filtered-relay flow
- updated the PMXT BYOD page so it no longer implies a repo-wide default relay host and more clearly describes mirror-only raw serving as the supported shared-server path

## Why
The docs had a small but real drift from the current architecture. The active repo direction is local-first with mirror-only shared relay behavior, so filtered-relay wording and a hardcoded live relay default were both stale.

## Impact
- the docs now match the current PMXT runner contract more closely
- relay guidance is more generic and sustainable for self-hosted setups
- readers are less likely to infer that filtered relay serving is still part of the active shared path

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
