### PR TITLE
[codex] fix docs code block overflow

### DIFF
--- a/docs/stylesheets/overrides.css
+++ b/docs/stylesheets/overrides.css
@@ -1,0 +1,13 @@
+article pre {
+  max-height: none !important;
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+article .codehilite {
+  overflow-x: auto;
+}
+
+article .codehilite pre {
+  max-height: none !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,3 +78,6 @@ markdown_extensions:
   - fenced_code
   - codehilite
   - toc
+
+extra_css:
+  - stylesheets/overrides.css


### PR DESCRIPTION
## What changed
- added a docs override stylesheet to remove the shadcn theme's hard `max-height` cap on article code blocks
- wired that stylesheet into MkDocs with `extra_css`
- kept horizontal scrolling for wide code blocks without clipping their vertical content

## Why it changed
The docs theme was rendering long highlighted code samples inside a capped block with no normal vertical overflow handling, which let later paragraphs and lists draw on top of the code block.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
- `uv run --with mkdocs-shadcn mkdocs build --strict`
