### PR TITLE
[codex] Improve main menu and replace PMXT sports runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ backtest:
 	uv run python main.py
 
 install:
-	unset CONDA_PREFIX && uv venv --python 3.13 && uv pip install -e nautilus_pm/ bokeh plotly numpy py-clob-client duckdb simple-term-menu
+	unset CONDA_PREFIX && uv venv --python 3.13 && uv pip install -e nautilus_pm/ bokeh plotly numpy py-clob-client duckdb textual
 
 check:
 	uv run ruff check --exclude nautilus_pm .

--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ Backtesting framework for prediction market strategies on
 top of [NautilusTrader](https://github.com/nautechsystems/nautilus_trader) with
 custom exchange adapters. Plotting inspired by [minitrade](https://github.com/dodid/minitrade). This repo is still in active development, and **a full release should happen within the next one to two months.**
 
-The public strategies in this repo are textbook research examples and runner
-templates, not claims of durable live edge. Repo-owned backtests now surface
-early-stop metadata when a run does not complete its full simulated window.
-The relay badges separate relay health from `r2.pmxt.dev` availability so an
-`r2.pmxt.dev` outage does not masquerade as a relay failure.
 
 Fantastic single & multi-market charting. Featuring: equity (total & individual markets), profit / loss ticks, P&L periodic bars, market allocation, YES price (with green buy and red sell fills), drawdown, sharpe (with above/below shading), cash / equity, monthly returns, and cumulative brier advantage.
 ![Charting preview](https://raw.githubusercontent.com/evan-kolberg/prediction-market-backtesting/main/docs/assets/charting-preview.jpeg)

--- a/backtests/_shared/_polymarket_quote_tick_pmxt_multi_runner.py
+++ b/backtests/_shared/_polymarket_quote_tick_pmxt_multi_runner.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from backtests._shared._polymarket_quote_tick_pmxt_runner import (
+    run_single_market_pmxt_backtest,
+)
+from backtests._shared._prediction_market_backtest import MarketReportConfig
+from backtests._shared._prediction_market_backtest import PredictionMarketBacktest
+from backtests._shared._prediction_market_backtest import finalize_market_results
+
+
+async def run_multi_sim_pmxt_backtest_async(
+    *,
+    backtest: PredictionMarketBacktest,
+) -> list[dict[str, Any]]:
+    if (
+        backtest.data.platform != "polymarket"
+        or backtest.data.data_type != "quote_tick"
+        or backtest.data.vendor != "pmxt"
+    ):
+        raise ValueError(
+            "run_multi_sim_pmxt_backtest_async requires PMXT quote-tick data"
+        )
+
+    results: list[dict[str, Any]] = []
+    for sim in backtest.sims:
+        if sim.market_slug is None:
+            raise ValueError("market_slug is required for Polymarket quote-tick sims.")
+
+        result = await run_single_market_pmxt_backtest(
+            name=backtest.name,
+            market_slug=sim.market_slug,
+            token_index=sim.token_index,
+            probability_window=backtest.probability_window,
+            strategy_configs=backtest.strategy_configs,
+            min_quotes=backtest.min_quotes,
+            min_price_range=backtest.min_price_range,
+            initial_cash=backtest.initial_cash,
+            emit_summary=False,
+            emit_html=False,
+            start_time=sim.start_time,
+            end_time=sim.end_time,
+            data_sources=backtest.data.sources,
+            execution=backtest.execution,
+        )
+        if result is None:
+            continue
+
+        result.update(dict(sim.metadata or {}))
+        results.append(result)
+
+    return results
+
+
+def run_reported_multi_sim_pmxt_backtest(
+    *,
+    backtest: PredictionMarketBacktest,
+    report: MarketReportConfig,
+    empty_message: str | None = None,
+    partial_message: str | None = None,
+) -> list[dict[str, Any]]:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        results = asyncio.run(run_multi_sim_pmxt_backtest_async(backtest=backtest))
+    else:
+        raise RuntimeError(
+            "run_reported_multi_sim_pmxt_backtest() cannot run inside an active event loop."
+        )
+
+    if not results:
+        if empty_message:
+            print(empty_message)
+        return []
+
+    if partial_message and len(results) < len(backtest.sims):
+        print(partial_message.format(completed=len(results), total=len(backtest.sims)))
+
+    finalize_market_results(name=backtest.name, results=results, report=report)
+    return results

--- a/backtests/polymarket_quote_tick_pmxt_sports_vwap_reversion.py
+++ b/backtests/polymarket_quote_tick_pmxt_sports_vwap_reversion.py
@@ -4,22 +4,14 @@
 # See the repository NOTICE file for provenance and licensing scope.
 
 """
-VWAP reversion on current Polymarket sports-game markets using PMXT quote ticks.
+Example PMXT quote-tick runner using multiple fixed historical sims.
 """
 
 # ruff: noqa: E402
 
 from __future__ import annotations
 
-import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
-import json
-import re
-import subprocess
-from urllib.error import HTTPError
-
-import pandas as pd
 
 from _script_helpers import ensure_repo_root
 
@@ -27,13 +19,12 @@ ensure_repo_root(__file__)
 
 from backtests._shared._execution_config import ExecutionModelConfig
 from backtests._shared._execution_config import StaticLatencyConfig
+from backtests._shared._polymarket_quote_tick_pmxt_multi_runner import (
+    run_reported_multi_sim_pmxt_backtest,
+)
 from backtests._shared._prediction_market_backtest import MarketReportConfig
 from backtests._shared._prediction_market_backtest import MarketSimConfig
 from backtests._shared._prediction_market_backtest import PredictionMarketBacktest
-from backtests._shared._prediction_market_backtest import finalize_market_results
-from backtests._shared._polymarket_quote_tick_pmxt_runner import (
-    run_single_market_pmxt_backtest,
-)
 from backtests._shared._prediction_market_runner import MarketDataConfig
 from backtests._shared._timing_harness import timing_harness
 from backtests._shared.data_sources import PMXT, Polymarket, QuoteTick
@@ -41,10 +32,7 @@ from backtests._shared.data_sources import PMXT, Polymarket, QuoteTick
 
 NAME = "polymarket_quote_tick_pmxt_sports_vwap_reversion"
 
-DESCRIPTION = (
-    "VWAP reversion on current Polymarket sports-game markets discovered from the "
-    "live sports page using PMXT L2 data"
-)
+DESCRIPTION = "Example PMXT quote-tick runner showing multiple fixed historical sims"
 
 DATA = MarketDataConfig(
     platform=Polymarket,
@@ -57,42 +45,36 @@ DATA = MarketDataConfig(
     ),
 )
 
-DISCOVERY_PAGE_URL = "https://polymarket.com/sports/live"
-_GAMMA_MARKET_URL = "https://gamma-api.polymarket.com/markets/slug/{slug}"
-_GAMMA_EVENT_URL = "https://gamma-api.polymarket.com/events/slug/{slug}"
-_HTTP_USER_AGENT = "prediction-market-backtesting/1.0"
-_HTTP_TIMEOUT_SECS = 10
-_EVENT_SLUG_PATTERN = re.compile(r'href="/event/([^"]+)"')
-_DATED_EVENT_SLUG_PATTERN = re.compile(r"-20\d{2}-\d{2}-\d{2}(?:$|-)")
-_TARGET_SIM_COUNT = 5
-_CANDIDATE_LIMIT = 24
-_MAX_DISCOVERY_EVENT_SLUGS = 64
-_DISCOVERY_LOOKBACK = pd.Timedelta(hours=24)
-_DISCOVERY_LOOKAHEAD = pd.Timedelta(hours=12)
-_CURRENT_WINDOW = pd.Timedelta(hours=2)
-_BEST_ASK_DEAD_THRESHOLD = 0.002
-_BEST_BID_DEAD_THRESHOLD = 0.998
-_INITIAL_CASH = 100.0
-_PROBABILITY_WINDOW = 30
-_MIN_QUOTES = 500
-_MIN_PRICE_RANGE = 0.005
-
-
-def _sample(
-    market_slug: str,
-    *,
-    start_time: str,
-    end_time: str,
-) -> MarketSimConfig:
-    return MarketSimConfig(
-        market_slug=market_slug,
+SIMS = (
+    MarketSimConfig(
+        market_slug="will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026",
         token_index=0,
-        start_time=start_time,
-        end_time=end_time,
-    )
-
-
-SIMS: tuple[MarketSimConfig, ...] = ()
+        start_time="2026-02-21T16:00:00Z",
+        end_time="2026-02-23T10:00:00Z",
+        metadata={"sim_label": "sample-a-full-window"},
+    ),
+    MarketSimConfig(
+        market_slug="will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026",
+        token_index=0,
+        start_time="2026-02-22T10:00:00Z",
+        end_time="2026-02-22T22:00:00Z",
+        metadata={"sim_label": "sample-b-2026-02-22-day"},
+    ),
+    MarketSimConfig(
+        market_slug="will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026",
+        token_index=0,
+        start_time="2026-02-22T22:00:00Z",
+        end_time="2026-02-23T10:00:00Z",
+        metadata={"sim_label": "sample-c-2026-02-22-late"},
+    ),
+    MarketSimConfig(
+        market_slug="will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026",
+        token_index=0,
+        start_time="2026-03-24T03:00:00Z",
+        end_time="2026-03-24T08:00:00Z",
+        metadata={"sim_label": "sample-d-close-window"},
+    ),
+)
 
 STRATEGY_CONFIGS = [
     {
@@ -114,6 +96,7 @@ REPORT = MarketReportConfig(
     count_key="quotes",
     count_label="Quotes",
     pnl_label="PnL (USDC)",
+    market_key="sim_label",
 )
 
 EXECUTION = ExecutionModelConfig(
@@ -131,276 +114,22 @@ BACKTEST = PredictionMarketBacktest(
     data=DATA,
     sims=SIMS,
     strategy_configs=STRATEGY_CONFIGS,
-    initial_cash=_INITIAL_CASH,
-    probability_window=_PROBABILITY_WINDOW,
-    min_quotes=_MIN_QUOTES,
-    min_price_range=_MIN_PRICE_RANGE,
+    initial_cash=100.0,
+    probability_window=30,
+    min_quotes=500,
+    min_price_range=0.005,
     execution=EXECUTION,
 )
 
 
-def _iso_z(ts: pd.Timestamp) -> str:
-    ts_utc = ts.tz_convert("UTC")
-    return ts_utc.isoformat().replace("+00:00", "Z")
-
-
-def _fetch_text(url: str) -> str:
-    completed = subprocess.run(
-        ["curl", "-fsSL", "-A", _HTTP_USER_AGENT, url],
-        capture_output=True,
-        check=True,
-        text=True,
-        timeout=_HTTP_TIMEOUT_SECS,
-    )
-    return completed.stdout
-
-
-def _fetch_json(url: str) -> dict | list:
-    return json.loads(_fetch_text(url))
-
-
-def _extract_event_slugs(html: str) -> tuple[str, ...]:
-    slugs: list[str] = []
-    seen: set[str] = set()
-    for raw_slug in _EVENT_SLUG_PATTERN.findall(html):
-        slug = raw_slug.split("/", 1)[0].strip()
-        if not slug or slug in seen:
-            continue
-        if _DATED_EVENT_SLUG_PATTERN.search(slug) is None:
-            continue
-        seen.add(slug)
-        slugs.append(slug)
-    return tuple(slugs[:_MAX_DISCOVERY_EVENT_SLUGS])
-
-
-def _fetch_market(slug: str) -> dict | None:
-    try:
-        payload = _fetch_json(_GAMMA_MARKET_URL.format(slug=slug))
-    except HTTPError as exc:
-        if exc.code == 404:
-            return None
-        raise
-    except subprocess.CalledProcessError as exc:
-        if exc.returncode == 22:
-            return None
-        raise
-
-    if isinstance(payload, list):
-        if not payload:
-            return None
-        payload = payload[0]
-    if not isinstance(payload, dict):
-        return None
-    return payload
-
-
-def _fetch_event(slug: str) -> dict | None:
-    try:
-        payload = _fetch_json(_GAMMA_EVENT_URL.format(slug=slug))
-    except HTTPError as exc:
-        if exc.code == 404:
-            return None
-        raise
-    except subprocess.CalledProcessError as exc:
-        if exc.returncode == 22:
-            return None
-        raise
-    return payload if isinstance(payload, dict) else None
-
-
-def _safe_float(value: object) -> float | None:
-    if value in (None, ""):
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _parse_game_start(value: object) -> pd.Timestamp | None:
-    if not value:
-        return None
-    ts = pd.Timestamp(value)
-    if ts.tzinfo is None:
-        ts = ts.tz_localize("UTC")
-    else:
-        ts = ts.tz_convert("UTC")
-    return ts
-
-
-def _market_score(market: dict, *, now: pd.Timestamp) -> tuple[float, float, float]:
-    best_bid = _safe_float(market.get("bestBid"))
-    best_ask = _safe_float(market.get("bestAsk"))
-    volume = _safe_float(market.get("volume24hrClob")) or 0.0
-    liquidity = _safe_float(market.get("liquidityClob")) or 0.0
-    game_start = _parse_game_start(market.get("gameStartTime"))
-
-    if best_bid is None or best_ask is None:
-        competitiveness = 1.0
-    else:
-        competitiveness = abs(((best_bid + best_ask) / 2.0) - 0.5)
-
-    if game_start is None:
-        recency_hours = float("inf")
-    else:
-        recency_hours = abs((now - game_start) / pd.Timedelta(hours=1))
-
-    return competitiveness, recency_hours, -(volume + liquidity)
-
-
-def _markets_for_candidate_slug(candidate_slug: str) -> tuple[dict, ...]:
-    direct_market = _fetch_market(candidate_slug)
-    if direct_market is not None:
-        market_slugs = [str(direct_market.get("slug") or candidate_slug)]
-    else:
-        event = _fetch_event(candidate_slug)
-        if event is None:
-            return ()
-        market_slugs = [
-            str(market.get("slug") or "").strip() for market in event.get("markets", [])
-        ]
-
-    markets: list[dict] = []
-    for market_slug in market_slugs:
-        if not market_slug:
-            continue
-        market = (
-            direct_market
-            if direct_market and market_slug == direct_market.get("slug")
-            else _fetch_market(market_slug)
-        )
-        if market is not None:
-            markets.append(market)
-    return tuple(markets)
-
-
-def _candidate_market_dicts(*, now: pd.Timestamp) -> tuple[dict, ...]:
-    html = _fetch_text(DISCOVERY_PAGE_URL)
-    candidate_slugs = _extract_event_slugs(html)
-    markets: list[dict] = []
-    seen_market_slugs: set[str] = set()
-    max_workers = min(8, len(candidate_slugs)) or 1
-
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        for fetched_markets in executor.map(
-            _markets_for_candidate_slug, candidate_slugs
-        ):
-            for market in fetched_markets:
-                market_slug = str(market.get("slug") or "").strip()
-                if not market_slug or market_slug in seen_market_slugs:
-                    continue
-                if str(market.get("sportsMarketType") or "").casefold() != "moneyline":
-                    continue
-                game_start = _parse_game_start(market.get("gameStartTime"))
-                if game_start is None:
-                    continue
-                if game_start < now - _DISCOVERY_LOOKBACK:
-                    continue
-                if game_start > now + _DISCOVERY_LOOKAHEAD:
-                    continue
-                best_bid = _safe_float(market.get("bestBid"))
-                best_ask = _safe_float(market.get("bestAsk"))
-                if best_bid is not None and best_bid >= _BEST_BID_DEAD_THRESHOLD:
-                    continue
-                if best_ask is not None and best_ask <= _BEST_ASK_DEAD_THRESHOLD:
-                    continue
-                seen_market_slugs.add(market_slug)
-                markets.append(market)
-
-    markets.sort(key=lambda market: _market_score(market, now=now))
-    return tuple(markets)
-
-
-def discover_recent_market_sims(
-    *,
-    now: pd.Timestamp | None = None,
-    limit: int = _CANDIDATE_LIMIT,
-) -> tuple[MarketSimConfig, ...]:
-    now_ts = pd.Timestamp.now(tz="UTC") if now is None else pd.Timestamp(now)
-    if now_ts.tzinfo is None:
-        now_ts = now_ts.tz_localize("UTC")
-    else:
-        now_ts = now_ts.tz_convert("UTC")
-
-    sims: list[MarketSimConfig] = []
-    for market in _candidate_market_dicts(now=now_ts):
-        market_slug = str(market.get("slug") or "").strip()
-        if not market_slug:
-            continue
-        start_time = now_ts - _CURRENT_WINDOW
-        sims.append(
-            _sample(
-                market_slug,
-                start_time=_iso_z(start_time),
-                end_time=_iso_z(now_ts),
-            )
-        )
-        if len(sims) >= limit:
-            break
-
-    return tuple(sims)
-
-
-async def _run_discovered_market_sims(
-    sims: tuple[MarketSimConfig, ...],
-) -> list[dict[str, object]]:
-    results: list[dict[str, object]] = []
-    for sim in sims:
-        market_slug = sim.market_slug
-        if not market_slug:
-            continue
-        result = await run_single_market_pmxt_backtest(
-            name=NAME,
-            market_slug=market_slug,
-            token_index=sim.token_index,
-            probability_window=_PROBABILITY_WINDOW,
-            strategy_configs=STRATEGY_CONFIGS,
-            min_quotes=_MIN_QUOTES,
-            min_price_range=_MIN_PRICE_RANGE,
-            initial_cash=_INITIAL_CASH,
-            emit_summary=False,
-            emit_html=False,
-            start_time=sim.start_time,
-            end_time=sim.end_time,
-            data_sources=DATA.sources,
-            execution=EXECUTION,
-        )
-        if result is None:
-            continue
-        results.append(result)
-        if len(results) >= _TARGET_SIM_COUNT:
-            break
-
-    return results
-
-
 @timing_harness
 def run() -> None:
-    print(f"Discovering current sports-game markets from {DISCOVERY_PAGE_URL}...")
-    sims = discover_recent_market_sims()
-    if not sims:
-        print(
-            "No current Polymarket sports-game markets were eligible for PMXT probing."
-        )
-        return
-
-    print(
-        "Discovered "
-        f"{len(sims)} candidate sports-game sims; collecting up to "
-        f"{_TARGET_SIM_COUNT} usable PMXT runs."
+    run_reported_multi_sim_pmxt_backtest(
+        backtest=BACKTEST,
+        report=REPORT,
+        empty_message="No PMXT multi-sim example windows met the quote-tick requirements.",
+        partial_message="Completed {completed} of {total} fixed example sims.",
     )
-    results = asyncio.run(_run_discovered_market_sims(sims))
-    if not results:
-        print(
-            "No current Polymarket PMXT sports-game sims met the quote-tick requirements."
-        )
-        return
-
-    target_count = min(_TARGET_SIM_COUNT, len(sims))
-    if len(results) < target_count:
-        print(f"Completed {len(results)} of {len(sims)} discovered sports-game sims.")
-
-    finalize_market_results(name=NAME, results=results[:target_count], report=REPORT)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -32,9 +32,21 @@ from string import ascii_uppercase
 from typing import Any
 
 try:
-    from simple_term_menu import TerminalMenu
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.containers import Horizontal, Vertical
+    from textual.events import Key
+    from textual.widgets import Footer, Input, ListItem, ListView, Static
+
+    TEXTUAL_AVAILABLE = True
 except ImportError:  # pragma: no cover - fallback is covered through non-TTY tests
-    TerminalMenu = None
+    App = None  # type: ignore[assignment]
+    ComposeResult = Any  # type: ignore[misc,assignment]
+    Binding = None  # type: ignore[assignment]
+    Horizontal = Vertical = None  # type: ignore[assignment]
+    Footer = Input = ListItem = ListView = Static = None  # type: ignore[assignment]
+    Key = None  # type: ignore[assignment]
+    TEXTUAL_AVAILABLE = False
 
 PROJECT_ROOT = Path(__file__).parent
 BACKTESTS_ROOT = PROJECT_ROOT / "backtests"
@@ -45,8 +57,6 @@ RESET = "\033[0m"
 ENABLE_TIMING_ENV = "BACKTEST_ENABLE_TIMING"
 SHORTCUT_LETTERS = ascii_lowercase.replace("q", "") + ascii_uppercase.replace("Q", "")
 MENU_TITLE = "Prediction Market Backtests"
-MENU_PREVIEW_SIZE = 0.30
-RUNNER_PREVIEW_MAX_LINES = 10
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -188,6 +198,53 @@ def _menu_label(backtest: dict[str, Any]) -> str:
     return _relative_runner_path(backtest).as_posix()
 
 
+def _textual_menu_label(backtest: dict[str, Any], shortcut: str | None) -> str:
+    label = _menu_label(backtest)
+    if shortcut is None:
+        return label
+    return f"[{shortcut}] {label}"
+
+
+def _runner_search_text(backtest: dict[str, Any]) -> str:
+    return " ".join(
+        part
+        for part in (
+            backtest.get("name", ""),
+            backtest.get("description", ""),
+            _menu_label(backtest),
+        )
+        if part
+    ).casefold()
+
+
+def _filter_backtests(
+    backtests: list[dict[str, Any]],
+    query: str,
+) -> list[int]:
+    normalized = query.strip().casefold()
+    if not normalized:
+        return list(range(len(backtests)))
+    return [
+        index
+        for index, backtest in enumerate(backtests)
+        if normalized in _runner_search_text(backtest)
+    ]
+
+
+def _runner_details(backtest: dict[str, Any], shortcut: str | None) -> str:
+    details: list[str] = [_menu_label(backtest)]
+    description = str(backtest.get("description") or "").strip()
+    name = str(backtest.get("name") or _runner_stem(backtest))
+    meta = [f"runner: {name}"]
+    if shortcut is not None:
+        meta.append(f"shortcut: {shortcut}")
+    if description:
+        meta.append(f"description: {description}")
+    details.extend(meta)
+    details.extend(("", "Preview", _runner_preview(backtest)))
+    return "\n".join(details)
+
+
 def _shortcut_candidates(backtest: dict[str, Any]) -> list[str]:
     words = re.findall(
         r"[A-Za-z]+",
@@ -240,42 +297,261 @@ def _assign_shortcuts(
 
 
 @lru_cache(maxsize=None)
-def _runner_file_preview(
-    path: Path,
-    *,
-    max_lines: int = RUNNER_PREVIEW_MAX_LINES,
-) -> str:
+def _runner_file_preview(path: Path) -> str:
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        return path.read_text(encoding="utf-8")
     except OSError as exc:
         return f"(unable to read runner file: {exc})"
 
-    start = 0
-    for marker in (
-        "DATA =",
-        "SIMS =",
-        "STRATEGY_CONFIGS =",
-        "BACKTEST =",
-        "NAME =",
-    ):
-        for index, line in enumerate(lines):
-            if line.startswith(marker):
-                start = index
-                break
-        else:
-            continue
-        break
-
-    snippet_lines = lines[start : start + max_lines]
-    return "\n".join(snippet_lines).strip() or "(runner file is empty)"
-
 
 def _runner_preview(backtest: dict[str, Any]) -> str:
-    name = str(backtest.get("name") or _runner_stem(backtest))
-    snippet = _runner_file_preview(PROJECT_ROOT / _relative_runner_path(backtest))
-    if snippet.startswith("NAME ="):
-        return snippet
-    return f"{name}\n\n{snippet}"
+    return _runner_file_preview(PROJECT_ROOT / _relative_runner_path(backtest))
+
+
+if TEXTUAL_AVAILABLE:
+
+    class _BacktestListItem(ListItem):
+        def __init__(self, backtest_index: int, label: str) -> None:
+            super().__init__(Static(label, classes="runner-label", markup=False))
+            self.backtest_index = backtest_index
+
+    class _BacktestMenuApp(App[int]):
+        CSS = """
+        Screen {
+            background: $surface;
+            color: $text;
+        }
+
+        #banner {
+            dock: top;
+            height: 1;
+            padding: 0 1;
+            background: $panel;
+            color: $text;
+            text-style: bold;
+        }
+
+        #body {
+            height: 1fr;
+            padding: 0 1;
+        }
+
+        #sidebar {
+            width: 80;
+            min-width: 60;
+            border: round $primary;
+            padding: 0 1;
+            margin: 1 1 1 0;
+        }
+
+        #filter {
+            margin: 1 0;
+        }
+
+        #runner_list {
+            height: 1fr;
+            border: none;
+        }
+
+        _BacktestListItem {
+            padding: 0 1;
+        }
+
+        .runner-label {
+            width: 1fr;
+            text-wrap: nowrap;
+        }
+
+        #details {
+            width: 1fr;
+            border: round $secondary;
+            padding: 0 1;
+            margin: 1 0 1 0;
+        }
+
+        #details_title {
+            margin-top: 1;
+            text-style: bold;
+            color: $primary;
+        }
+
+        #details_meta {
+            margin: 1 0;
+        }
+
+        #preview_heading {
+            text-style: bold;
+            color: $text;
+        }
+
+        #details_preview {
+            height: 1fr;
+            margin: 1 0 0 0;
+            padding: 0 1 1 1;
+            border: tall $secondary;
+            overflow: auto auto;
+            text-wrap: nowrap;
+        }
+        """
+
+        BINDINGS = [
+            Binding("q", "quit", "Quit"),
+            Binding("slash", "focus_filter", "Filter", key_display="/"),
+            Binding("escape", "dismiss_filter", "Back"),
+            Binding("enter", "run_selected", "Run"),
+        ]
+
+        def __init__(self, backtests: list[dict[str, Any]]) -> None:
+            super().__init__()
+            self.backtests = backtests
+            self.shortcuts = _assign_shortcuts(backtests)
+            self.shortcut_to_index = {
+                shortcut: index
+                for index, backtest in enumerate(backtests)
+                if (shortcut := self.shortcuts[_menu_label(backtest)]) is not None
+            }
+            self.filtered_indices: list[int] = list(range(len(backtests)))
+            self._details_backtest_index: int | None = None
+
+        def compose(self) -> ComposeResult:
+            yield Static("", id="banner")
+            with Horizontal(id="body"):
+                with Vertical(id="sidebar"):
+                    yield Input(
+                        placeholder="Filter runners",
+                        compact=True,
+                        id="filter",
+                    )
+                    yield ListView(id="runner_list")
+                with Vertical(id="details"):
+                    yield Static("", id="details_title", markup=False)
+                    yield Static("", id="details_meta", markup=False)
+                    yield Static("File Preview", id="preview_heading")
+                    yield Static("", id="details_preview", markup=False)
+            yield Footer(show_command_palette=False, compact=True)
+
+        async def on_mount(self) -> None:
+            await self._refresh_menu()
+            self.query_one(ListView).focus()
+
+        def _set_banner(self) -> None:
+            query = self.query_one(Input).value.strip()
+            shown = len(self.filtered_indices)
+            total = len(self.backtests)
+            if query:
+                banner = f"{MENU_TITLE} | showing {shown} of {total} for '{query}'"
+            else:
+                banner = f"{MENU_TITLE} | {total} runnable entries"
+            self.query_one("#banner", Static).update(banner)
+
+        def _update_details(self, backtest_index: int | None) -> None:
+            if backtest_index == self._details_backtest_index:
+                return
+
+            title = self.query_one("#details_title", Static)
+            meta = self.query_one("#details_meta", Static)
+            preview = self.query_one("#details_preview", Static)
+
+            if backtest_index is None:
+                query = self.query_one(Input).value.strip()
+                title.update("No runners match the current filter.")
+                meta.update(
+                    f"Filter: {query}" if query else "No runnable backtests found."
+                )
+                preview.update("Try a broader search or press Esc to clear the filter.")
+                self._details_backtest_index = None
+                return
+
+            backtest = self.backtests[backtest_index]
+            shortcut = self.shortcuts[_menu_label(backtest)]
+            description = str(backtest.get("description") or "").strip()
+            title.update(_menu_label(backtest))
+            meta_lines = [f"runner: {backtest.get('name', _runner_stem(backtest))}"]
+            if shortcut is not None:
+                meta_lines.append(f"shortcut: {shortcut}")
+            if description:
+                meta_lines.append(description)
+            meta.update("\n".join(meta_lines))
+            preview.update(_runner_preview(backtest))
+            self._details_backtest_index = backtest_index
+
+        async def _refresh_menu(self, preferred_index: int | None = None) -> None:
+            list_view = self.query_one(ListView)
+            query = self.query_one(Input).value
+            self.filtered_indices = _filter_backtests(self.backtests, query)
+            items = [
+                _BacktestListItem(
+                    backtest_index=index,
+                    label=_textual_menu_label(
+                        self.backtests[index],
+                        self.shortcuts[_menu_label(self.backtests[index])],
+                    ),
+                )
+                for index in self.filtered_indices
+            ]
+            await list_view.clear()
+            if items:
+                await list_view.extend(items)
+                target_index = (
+                    preferred_index
+                    if preferred_index in self.filtered_indices
+                    else self.filtered_indices[0]
+                )
+                list_view.index = self.filtered_indices.index(target_index)
+                self._update_details(target_index)
+            else:
+                self._update_details(None)
+            self._set_banner()
+
+        def _selected_backtest_index(self) -> int | None:
+            highlighted = self.query_one(ListView).highlighted_child
+            if isinstance(highlighted, _BacktestListItem):
+                return highlighted.backtest_index
+            return None
+
+        def action_focus_filter(self) -> None:
+            self.query_one(Input).focus()
+
+        def action_dismiss_filter(self) -> None:
+            filter_widget = self.query_one(Input)
+            if filter_widget.value:
+                filter_widget.value = ""
+            self.query_one(ListView).focus()
+
+        def action_run_selected(self) -> None:
+            selected = self._selected_backtest_index()
+            if selected is not None:
+                self.exit(selected)
+
+        async def on_input_changed(self, event: Input.Changed) -> None:
+            if event.input.id != "filter":
+                return
+            await self._refresh_menu(self._selected_backtest_index())
+
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            if event.input.id != "filter":
+                return
+            self.action_run_selected()
+
+        def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+            if isinstance(event.item, _BacktestListItem):
+                self._update_details(event.item.backtest_index)
+
+        def on_list_view_selected(self, event: ListView.Selected) -> None:
+            if isinstance(event.item, _BacktestListItem):
+                self.exit(event.item.backtest_index)
+
+        def on_key(self, event: Key) -> None:
+            if self.focused is self.query_one(Input):
+                return
+            character = event.character
+            if character is None:
+                return
+            selected = self.shortcut_to_index.get(character)
+            if selected is None:
+                return
+            self.exit(selected)
+            event.stop()
 
 
 def _load_runner(backtest: dict[str, Any]) -> Any:
@@ -306,8 +582,8 @@ def _load_runner(backtest: dict[str, Any]) -> Any:
     return runner
 
 
-def _supports_terminal_menu() -> bool:
-    if TerminalMenu is None:
+def _supports_textual_menu() -> bool:
+    if not TEXTUAL_AVAILABLE or App is None:
         return False
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         return False
@@ -355,51 +631,14 @@ def _show_basic_menu(backtests: list[dict[str, Any]]) -> int:
     return choice - 1
 
 
-def _show_terminal_menu(backtests: list[dict[str, Any]]) -> int:
-    shortcuts = _assign_shortcuts(backtests)
-
-    backtests_by_key: dict[str, dict[str, Any]] = {}
-    menu_entries: list[str] = []
-    for backtest in backtests:
-        relative_key = _relative_runner_path(backtest).as_posix()
-        shortcut = shortcuts[relative_key]
-        backtests_by_key[relative_key] = backtest
-        if shortcut is None:
-            menu_entries.append(f"{_menu_label(backtest)}|{relative_key}")
-        else:
-            menu_entries.append(f"[{shortcut}] {_menu_label(backtest)}|{relative_key}")
-
-    terminal_menu = TerminalMenu(
-        menu_entries,
-        title=(
-            MENU_TITLE,
-            "assigned letters run immediately, enter runs selection, / searches, q exits",
-            f"{len(backtests)} runnable entries | preview shows a file excerpt",
-        ),
-        menu_cursor="> ",
-        menu_cursor_style=("fg_cyan", "bold"),
-        menu_highlight_style=("bold",),
-        shortcut_brackets_highlight_style=("fg_gray",),
-        shortcut_key_highlight_style=("fg_blue", "bold"),
-        preview_command=lambda preview_key: _runner_preview(
-            backtests_by_key[preview_key]
-        ),
-        preview_size=MENU_PREVIEW_SIZE,
-        preview_title="file",
-        search_case_sensitive=False,
-        show_search_hint=True,
-        show_shortcut_hints=False,
-    )
-    selection = terminal_menu.show()
+def _show_textual_menu(backtests: list[dict[str, Any]]) -> int:
+    if not TEXTUAL_AVAILABLE:
+        raise NotImplementedError("Textual is not installed")
+    app = _BacktestMenuApp(backtests)
+    selection = app.run()
     if selection is None:
         return -1
-
-    selected_entry = menu_entries[selection]
-    selected_key = selected_entry.split("|", 1)[1]
-    for index, backtest in enumerate(backtests):
-        if _relative_runner_path(backtest).as_posix() == selected_key:
-            return index
-    return -1
+    return int(selection)
 
 
 def _build_menu_tree(backtests: list[dict[str, Any]]) -> dict[str, Any]:
@@ -447,9 +686,9 @@ def _render_menu_tree(
 
 def show_menu(backtests: list[dict]) -> int:
     """Return the chosen backtest index, or -1 to exit."""
-    if _supports_terminal_menu():
+    if _supports_textual_menu():
         try:
-            return _show_terminal_menu(backtests)
+            return _show_textual_menu(backtests)
         except (NotImplementedError, OSError, subprocess.SubprocessError):
             pass
     return _show_basic_menu(backtests)

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -69,7 +69,7 @@ git clone https://github.com/evan-kolberg/prediction-market-backtesting.git /opt
 cd /opt/prediction-market-backtesting
 
 uv venv --python 3.12
-uv pip install -e nautilus_pm/ bokeh plotly numpy py-clob-client duckdb simple-term-menu
+uv pip install -e nautilus_pm/ bokeh plotly numpy py-clob-client duckdb textual
 
 useradd --system --home /srv/pmxt-relay --shell /usr/sbin/nologin pmxtrelay || true
 install -o pmxtrelay -g pmxtrelay -d /srv/pmxt-relay /srv/pmxt-relay/raw /srv/pmxt-relay/state /srv/pmxt-relay/tmp

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 import sys
 from pathlib import Path
@@ -166,19 +167,23 @@ def test_assign_shortcuts_leaves_overflow_entries_without_hotkeys():
     assert len(unassigned) == 5
 
 
-def test_runner_preview_shows_file_excerpt_without_generated_sections(
+def test_runner_preview_shows_full_file_contents(
     tmp_path: Path,
     monkeypatch,
 ):
     runner_path = tmp_path / "backtests" / "demo_runner.py"
     runner_path.parent.mkdir(parents=True)
-    runner_path.write_text(
+    contents = (
         'NAME = "demo_runner"\n'
         'DESCRIPTION = "Demo runner"\n'
+        "\n"
+        "from pathlib import Path\n"
+        "\n"
         "DATA = object()\n"
         "SIMS = ()\n",
-        encoding="utf-8",
     )
+    contents = "".join(contents)
+    runner_path.write_text(contents, encoding="utf-8")
 
     backtest = {
         "name": "demo_runner",
@@ -190,11 +195,7 @@ def test_runner_preview_shows_file_excerpt_without_generated_sections(
 
     preview = main_module._runner_preview(backtest)
 
-    assert preview.startswith("demo_runner\n\nDATA = object()")
-    assert "SIMS = ()" in preview
-    assert "Run\n" not in preview
-    assert "Spec\n" not in preview
-    assert "backtests/demo_runner.py" not in preview
+    assert preview == contents
 
 
 def test_discoverable_backtest_paths_stay_flat(tmp_path: Path) -> None:
@@ -290,37 +291,138 @@ def test_load_runner_defers_import_failure_until_selection(
         main_module._load_runner(discovered[0])
 
 
-def test_terminal_menu_keeps_preview_lazy(monkeypatch) -> None:
+def test_filter_backtests_matches_name_description_and_path() -> None:
+    backtests = [
+        {
+            "name": "demo_runner",
+            "description": "Demo runner",
+            "relative_parts": ("demo_runner.py",),
+        },
+        {
+            "name": "pmxt_runner",
+            "description": "PMXT quote runner",
+            "relative_parts": ("pmxt_runner.py",),
+        },
+    ]
+
+    assert main_module._filter_backtests(backtests, "") == [0, 1]
+    assert main_module._filter_backtests(backtests, "quote") == [1]
+    assert main_module._filter_backtests(backtests, "backtests/demo_runner.py") == [0]
+
+
+def test_textual_menu_keeps_preview_lazy(monkeypatch) -> None:
+    if not main_module.TEXTUAL_AVAILABLE:
+        pytest.skip("textual is not installed")
+
     preview_calls: list[str] = []
-    terminal_kwargs: dict[str, object] = {}
-
-    class FakeTerminalMenu:
-        def __init__(self, _entries, **_kwargs):
-            terminal_kwargs.update(_kwargs)
-
-        def show(self) -> None:
-            return None
-
-    monkeypatch.setattr(main_module, "TerminalMenu", FakeTerminalMenu)
     monkeypatch.setattr(
         main_module,
         "_runner_preview",
-        lambda backtest: preview_calls.append(backtest["name"]) or "",
+        lambda backtest: preview_calls.append(backtest["name"]) or backtest["name"],
     )
 
-    choice = main_module._show_terminal_menu(
-        [
-            {
-                "name": "demo_runner",
-                "description": "Demo runner",
-                "module_name": "backtests.demo_runner",
-                "relative_parts": ("demo_runner.py",),
-            }
-        ],
-    )
+    backtests = [
+        {
+            "name": "demo_runner",
+            "description": "Demo runner",
+            "module_name": "backtests.demo_runner",
+            "relative_parts": ("demo_runner.py",),
+        },
+        {
+            "name": "pmxt_runner",
+            "description": "PMXT runner",
+            "module_name": "backtests.pmxt_runner",
+            "relative_parts": ("pmxt_runner.py",),
+        },
+    ]
 
-    assert choice == -1
-    assert preview_calls == []
-    assert terminal_kwargs.get("preview_border", True) is True
-    assert terminal_kwargs["preview_size"] == main_module.MENU_PREVIEW_SIZE
-    assert "status_bar" not in terminal_kwargs
+    async def run() -> None:
+        app = main_module._BacktestMenuApp(backtests)
+        async with app.run_test(size=(120, 32)) as pilot:
+            await pilot.pause()
+            assert preview_calls == ["demo_runner"]
+            await pilot.press("down")
+            await pilot.pause()
+            assert preview_calls == ["demo_runner", "pmxt_runner"]
+            await pilot.press("enter")
+        assert app.return_value == 1
+
+    asyncio.run(run())
+
+
+def test_textual_menu_filters_and_submits_selection() -> None:
+    if not main_module.TEXTUAL_AVAILABLE:
+        pytest.skip("textual is not installed")
+
+    backtests = [
+        {
+            "name": "demo_runner",
+            "description": "Demo runner",
+            "module_name": "backtests.demo_runner",
+            "relative_parts": ("demo_runner.py",),
+        },
+        {
+            "name": "pmxt_runner",
+            "description": "PMXT runner",
+            "module_name": "backtests.pmxt_runner",
+            "relative_parts": ("pmxt_runner.py",),
+        },
+    ]
+
+    async def run() -> None:
+        app = main_module._BacktestMenuApp(backtests)
+        async with app.run_test(size=(120, 32)) as pilot:
+            await pilot.pause()
+            await pilot.press("slash")
+            await pilot.pause()
+            assert getattr(app.focused, "id", None) == "filter"
+            await pilot.press("p", "m", "x", "t")
+            await pilot.pause()
+            assert app.filtered_indices == [1]
+            assert (
+                str(app.query_one("#details_title").content)
+                == "backtests/pmxt_runner.py"
+            )
+            await pilot.press("enter")
+        assert app.return_value == 1
+
+    asyncio.run(run())
+
+
+def test_textual_menu_shortcut_runs_selected_entry() -> None:
+    if not main_module.TEXTUAL_AVAILABLE:
+        pytest.skip("textual is not installed")
+
+    backtests = [
+        {
+            "name": "demo_runner",
+            "description": "Demo runner",
+            "module_name": "backtests.demo_runner",
+            "relative_parts": ("demo_runner.py",),
+        },
+        {
+            "name": "pmxt_runner",
+            "description": "PMXT runner",
+            "module_name": "backtests.pmxt_runner",
+            "relative_parts": ("pmxt_runner.py",),
+        },
+    ]
+
+    async def run() -> None:
+        app = main_module._BacktestMenuApp(backtests)
+        async with app.run_test(size=(120, 32)) as pilot:
+            await pilot.pause()
+            await pilot.press("p")
+        assert app.return_value == 1
+
+    asyncio.run(run())
+
+
+def test_textual_list_item_disables_markup() -> None:
+    if not main_module.TEXTUAL_AVAILABLE:
+        pytest.skip("textual is not installed")
+
+    item = main_module._BacktestListItem(0, "[u] backtests/demo_runner.py")
+    child = item._pending_children[0]
+
+    assert getattr(child, "_render_markup", None) is False

--- a/tests/test_polymarket_pmxt_backtests.py
+++ b/tests/test_polymarket_pmxt_backtests.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import pandas as pd
 import pytest
 
 from backtests._shared._polymarket_quote_tick_defaults import (
@@ -252,90 +251,22 @@ def test_time_based_pmxt_single_market_samples_overlap_strategy_window(
     assert market_close_time_ns <= end_ns
 
 
-def test_pmxt_sports_backtest_discovers_live_samples(
+def test_pmxt_multi_sim_example_runner_uses_fixed_windows(
     monkeypatch: pytest.MonkeyPatch,
 ):
     module = importlib.import_module(
         "backtests.polymarket_quote_tick_pmxt_sports_vwap_reversion"
     )
-    now = pd.Timestamp("2026-04-04T20:00:00Z")
-    html = """
-    <a href="/event/cs2-prv-lgc-2026-04-04">cs2</a>
-    <a href="/event/fl1-lil-rcl-2026-04-04">soccer</a>
-    """
+    captured: dict[str, object] = {}
 
-    market_payloads = {
-        "cs2-prv-lgc-2026-04-04": {
-            "slug": "cs2-prv-lgc-2026-04-04",
-            "sportsMarketType": "moneyline",
-            "gameStartTime": "2026-04-04 14:10:00+00",
-            "bestBid": 0.45,
-            "bestAsk": 0.46,
-            "volume24hrClob": 900000.0,
-            "liquidityClob": 150000.0,
-        },
-        "fl1-lil-rcl-2026-04-04-draw": {
-            "slug": "fl1-lil-rcl-2026-04-04-draw",
-            "sportsMarketType": "moneyline",
-            "gameStartTime": "2026-04-04 19:05:00+00",
-            "bestBid": 0.24,
-            "bestAsk": 0.25,
-            "volume24hrClob": 128000.0,
-            "liquidityClob": 42000.0,
-        },
-        "fl1-lil-rcl-2026-04-04-rcl": {
-            "slug": "fl1-lil-rcl-2026-04-04-rcl",
-            "sportsMarketType": "moneyline",
-            "gameStartTime": "2026-04-04 19:05:00+00",
-            "bestBid": 0.10,
-            "bestAsk": 0.11,
-            "volume24hrClob": 131000.0,
-            "liquidityClob": 37700.0,
-        },
-    }
-    event_payloads = {
-        "fl1-lil-rcl-2026-04-04": {
-            "markets": [
-                {"slug": "fl1-lil-rcl-2026-04-04-draw"},
-                {"slug": "fl1-lil-rcl-2026-04-04-rcl"},
-            ]
-        }
-    }
+    def _fake_run_reported_multi_sim_pmxt_backtest(**kwargs):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return []
 
-    monkeypatch.setattr(module, "_fetch_text", lambda _url: html)
-    monkeypatch.setattr(module, "_fetch_market", lambda slug: market_payloads.get(slug))
-    monkeypatch.setattr(module, "_fetch_event", lambda slug: event_payloads.get(slug))
-
-    sims = module.discover_recent_market_sims(now=now, limit=3)
-
-    finalized_calls: list[dict[str, object]] = []
-    runner_calls: list[tuple[str, str, str]] = []
-
-    async def _fake_run_single_market_pmxt_backtest(**kwargs):  # type: ignore[no-untyped-def]
-        runner_calls.append(
-            (
-                kwargs["market_slug"],
-                kwargs["start_time"],
-                kwargs["end_time"],
-            )
-        )
-        return {
-            "slug": kwargs["market_slug"],
-            "quotes": 1000,
-            "fills": 2,
-            "pnl": 1.25,
-        }
-
-    monkeypatch.setattr(module, "discover_recent_market_sims", lambda: sims)
     monkeypatch.setattr(
         module,
-        "run_single_market_pmxt_backtest",
-        _fake_run_single_market_pmxt_backtest,
-    )
-    monkeypatch.setattr(
-        module,
-        "finalize_market_results",
-        lambda **kwargs: finalized_calls.append(kwargs),
+        "run_reported_multi_sim_pmxt_backtest",
+        _fake_run_reported_multi_sim_pmxt_backtest,
     )
 
     module.run()
@@ -348,18 +279,33 @@ def test_pmxt_sports_backtest_discovers_live_samples(
     assert module.BACKTEST.min_price_range == 0.005
     assert module.BACKTEST.probability_window == 30
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
-    assert module.SIMS == ()
-    assert [sim.market_slug for sim in sims] == [
-        "cs2-prv-lgc-2026-04-04",
-        "fl1-lil-rcl-2026-04-04-draw",
-        "fl1-lil-rcl-2026-04-04-rcl",
+    assert module.REPORT.market_key == "sim_label"
+    assert [sim.market_slug for sim in module.SIMS] == [
+        EXPECTED_MARKET_SLUG,
+        EXPECTED_MARKET_SLUG,
+        EXPECTED_MARKET_SLUG,
+        EXPECTED_MARKET_SLUG,
     ]
-    assert sims[0].start_time == "2026-04-04T18:00:00Z"
-    assert sims[0].end_time == "2026-04-04T20:00:00Z"
-    assert sims[1].start_time == "2026-04-04T18:00:00Z"
-    assert sims[1].end_time == "2026-04-04T20:00:00Z"
+    assert [sim.start_time for sim in module.SIMS] == [
+        "2026-02-21T16:00:00Z",
+        "2026-02-22T10:00:00Z",
+        "2026-02-22T22:00:00Z",
+        "2026-03-24T03:00:00Z",
+    ]
+    assert [sim.end_time for sim in module.SIMS] == [
+        "2026-02-23T10:00:00Z",
+        "2026-02-22T22:00:00Z",
+        "2026-02-23T10:00:00Z",
+        "2026-03-24T08:00:00Z",
+    ]
+    assert [sim.metadata for sim in module.SIMS] == [
+        {"sim_label": "sample-a-full-window"},
+        {"sim_label": "sample-b-2026-02-22-day"},
+        {"sim_label": "sample-c-2026-02-22-late"},
+        {"sim_label": "sample-d-close-window"},
+    ]
 
-    for sim in sims:
+    for sim in module.SIMS:
         assert sim.market_slug
         assert sim.token_index == 0
         assert isinstance(sim.start_time, str) and sim.start_time
@@ -375,16 +321,16 @@ def test_pmxt_sports_backtest_discovers_live_samples(
     assert isinstance(strategy, QuoteTickVWAPReversionStrategy)
     assert isinstance(strategy.config, QuoteTickVWAPReversionConfig)
 
-    assert runner_calls == [
-        (sim.market_slug, sim.start_time, sim.end_time) for sim in sims
-    ]
-    assert len(finalized_calls) == 1
-    assert finalized_calls[0]["name"] == module.NAME
-    assert finalized_calls[0]["report"] == module.REPORT
-    assert finalized_calls[0]["results"] == [
-        {"slug": sim.market_slug, "quotes": 1000, "fills": 2, "pnl": 1.25}
-        for sim in sims[: module._TARGET_SIM_COUNT]
-    ]
+    assert captured["backtest"] is module.BACKTEST
+    assert captured["report"] == module.REPORT
+    assert (
+        captured["empty_message"]
+        == "No PMXT multi-sim example windows met the quote-tick requirements."
+    )
+    assert (
+        captured["partial_message"]
+        == "Completed {completed} of {total} fixed example sims."
+    )
 
 
 def test_pmxt_runner_window_env_overrides(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## What changed
- replace the old `polymarket_quote_tick_pmxt_sports_vwap_reversion` live-discovery runner with a fixed historical multi-sim PMXT example
- add a shared PMXT multi-sim helper so the public runner stays flat and declarative
- switch the interactive runner UI in `main.py` from `simple-term-menu` to `Textual`, including filtering, previews, and shortcut coverage
- update install docs and setup commands to use `textual`
- expand tests for the new menu behavior and the replacement PMXT runner

## Why
- the PMXT sports runner was scanning live Polymarket pages to find supposedly historical replay windows, which made the example misleading and brittle
- the menu work needed a richer UI than the previous terminal menu path provided
- install instructions needed to match the runtime dependency change from `simple-term-menu` to `textual`

## Impact
- the `main.py` menu now uses `Textual` when available and still falls back to the basic numbered menu in non-TTY contexts
- the PMXT sports runner path now demonstrates multiple fixed historical sims instead of live market discovery
- local and relay setup commands install the dependency the menu actually uses

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
- `uv run python backtests/polymarket_quote_tick_pmxt_sports_vwap_reversion.py`
- `printf '13\n' | uv run python main.py`
