### PR TITLE
[codex] Fix backtest reproducibility and relay pruning

### DIFF
--- a/backtests/_shared/_polymarket_quote_tick_pmxt_runner.py
+++ b/backtests/_shared/_polymarket_quote_tick_pmxt_runner.py
@@ -1,6 +1,6 @@
 # Derived from NautilusTrader prediction-market example code.
 # Distributed under the GNU Lesser General Public License Version 3.0 or later.
-# Modified in this repository on 2026-03-11, 2026-03-15, and 2026-03-31.
+# Modified in this repository on 2026-03-11, 2026-03-15, 2026-03-31, and 2026-04-04.
 # See the repository NOTICE file for provenance and licensing scope.
 
 """
@@ -13,7 +13,6 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import UTC
 from datetime import datetime
-import os
 from typing import Any
 
 import pandas as pd
@@ -44,34 +43,6 @@ from backtests._shared.data_sources.pmxt import (
 type StrategyFactory = Callable[[InstrumentId], Strategy]
 
 
-def _apply_window_env_overrides(
-    *,
-    start_time: pd.Timestamp | datetime | str | None,
-    end_time: pd.Timestamp | datetime | str | None,
-    lookback_hours: float | None,
-) -> tuple[
-    pd.Timestamp | datetime | str | None,
-    pd.Timestamp | datetime | str | None,
-    float | None,
-]:
-    override_start = os.getenv("START_TIME", "").strip()
-    override_end = os.getenv("END_TIME", "").strip()
-    override_lookback = os.getenv("LOOKBACK_HOURS", "").strip()
-
-    if override_start:
-        start_time = override_start
-    if override_end:
-        end_time = override_end
-    if override_lookback:
-        try:
-            lookback_hours = float(override_lookback)
-        except ValueError as exc:
-            raise ValueError(
-                f"LOOKBACK_HOURS must be numeric, got {override_lookback!r}"
-            ) from exc
-    return start_time, end_time, lookback_hours
-
-
 async def run_single_market_pmxt_backtest(
     *,
     name: str,
@@ -99,11 +70,6 @@ async def run_single_market_pmxt_backtest(
         strategy_factory=strategy_factory,
         strategy_configs=strategy_configs,
     )
-    start_time, end_time, lookback_hours = _apply_window_env_overrides(
-        start_time=start_time,
-        end_time=end_time,
-        lookback_hours=lookback_hours,
-    )
     try:
         end = pd.Timestamp(end_time if end_time is not None else datetime.now(UTC))
         if end.tzinfo is None:
@@ -120,12 +86,12 @@ async def run_single_market_pmxt_backtest(
         elif lookback_hours is not None:
             start = end - pd.Timedelta(hours=lookback_hours)
         else:
-            raise ValueError("set START_TIME/END_TIME or LOOKBACK_HOURS")
+            raise ValueError("set start_time/end_time or lookback_hours")
 
         if start >= end:
             raise ValueError(
-                f"START_TIME {start.isoformat()} must be earlier than "
-                f"END_TIME {end.isoformat()}"
+                f"start_time {start.isoformat()} must be earlier than "
+                f"end_time {end.isoformat()}"
             )
     except Exception as exc:
         print(f"Unable to resolve PMXT backtest window for {market_slug}: {exc}")

--- a/backtests/polymarket_trade_tick_sports_final_period_momentum.py
+++ b/backtests/polymarket_trade_tick_sports_final_period_momentum.py
@@ -1,6 +1,6 @@
 # Derived from NautilusTrader prediction-market example code.
 # Distributed under the GNU Lesser General Public License Version 3.0 or later.
-# Modified in this repository on 2026-03-11 and 2026-04-03.
+# Modified in this repository on 2026-03-11, 2026-04-03, and 2026-04-04.
 # See the repository NOTICE file for provenance and licensing scope.
 
 """
@@ -28,7 +28,9 @@ from backtests._shared.data_sources import Native, Polymarket, TradeTick
 
 NAME = "polymarket_trade_tick_sports_final_period_momentum"
 
-DESCRIPTION = "Late-breakout momentum on a fixed Polymarket sports basket"
+DESCRIPTION = (
+    "Late-breakout momentum on a fixed Polymarket sports basket pinned to market close"
+)
 
 DATA = MarketDataConfig(
     platform=Polymarket,
@@ -41,9 +43,15 @@ DATA = MarketDataConfig(
     ),
 )
 
+# Pin each replay window to the market close so the fixed basket stays
+# reproducible and under the public trades API offset ceiling.
+FIXED_LOOKBACK_DAYS = 7
+
 SIMS = (
     MarketSimConfig(
         market_slug="will-ukraine-qualify-for-the-2026-fifa-world-cup",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-26T23:53:59Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1774569239000000000,
@@ -51,6 +59,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-man-city-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:28:17Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773797297000000000,
@@ -58,6 +68,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-chelsea-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:22:09Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773796929000000000,
@@ -65,6 +77,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-newcastle-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T22:56:01Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773874561000000000,
@@ -72,6 +86,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-leverkusen-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:28:15Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773797295000000000,
@@ -108,8 +124,7 @@ BACKTEST = PredictionMarketBacktest(
     initial_cash=100.0,
     probability_window=180,
     min_trades=25,
-    min_price_range=0.05,
-    default_lookback_days=30,
+    min_price_range=0.01,
 )
 
 

--- a/backtests/polymarket_trade_tick_sports_late_favorite_limit_hold.py
+++ b/backtests/polymarket_trade_tick_sports_late_favorite_limit_hold.py
@@ -1,6 +1,6 @@
 # Derived from NautilusTrader prediction-market example code.
 # Distributed under the GNU Lesser General Public License Version 3.0 or later.
-# Modified in this repository on 2026-03-11 and 2026-04-03.
+# Modified in this repository on 2026-03-11, 2026-04-03, and 2026-04-04.
 # See the repository NOTICE file for provenance and licensing scope.
 
 """
@@ -34,7 +34,7 @@ from backtests._shared.data_sources import Native, Polymarket, TradeTick
 
 NAME = "polymarket_trade_tick_sports_late_favorite_limit_hold"
 
-DESCRIPTION = "Late-favorite limit holds on a fixed Polymarket sports basket"
+DESCRIPTION = "Late-favorite limit holds on a fixed Polymarket sports basket pinned to market close"
 
 DATA = MarketDataConfig(
     platform=Polymarket,
@@ -47,9 +47,15 @@ DATA = MarketDataConfig(
     ),
 )
 
+# Pin each replay window to the market close so the fixed basket stays
+# reproducible and under the public trades API offset ceiling.
+FIXED_LOOKBACK_DAYS = 7
+
 SIMS = (
     MarketSimConfig(
         market_slug="will-ukraine-qualify-for-the-2026-fifa-world-cup",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-26T23:53:59Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1774569239000000000,
@@ -58,6 +64,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-man-city-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:28:17Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773797297000000000,
@@ -66,6 +74,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-chelsea-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:22:09Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773796929000000000,
@@ -74,6 +84,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-newcastle-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T22:56:01Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773874561000000000,
@@ -82,6 +94,8 @@ SIMS = (
     ),
     MarketSimConfig(
         market_slug="will-leverkusen-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:28:15Z",
         outcome="Yes",
         metadata={
             "market_close_time_ns": 1773797295000000000,
@@ -127,8 +141,7 @@ BACKTEST = PredictionMarketBacktest(
     initial_cash=100.0,
     probability_window=180,
     min_trades=25,
-    min_price_range=0.05,
-    default_lookback_days=30,
+    min_price_range=0.01,
     execution=EXECUTION,
 )
 

--- a/backtests/polymarket_trade_tick_sports_vwap_reversion.py
+++ b/backtests/polymarket_trade_tick_sports_vwap_reversion.py
@@ -1,6 +1,6 @@
 # Derived from NautilusTrader prediction-market example code.
 # Distributed under the GNU Lesser General Public License Version 3.0 or later.
-# Modified in this repository on 2026-03-11, 2026-03-16, and 2026-04-03.
+# Modified in this repository on 2026-03-11, 2026-03-16, 2026-04-03, and 2026-04-04.
 # See the repository NOTICE file for provenance and licensing scope.
 
 """
@@ -28,7 +28,9 @@ from backtests._shared.data_sources import Native, Polymarket, TradeTick
 
 NAME = "polymarket_trade_tick_sports_vwap_reversion"
 
-DESCRIPTION = "VWAP reversion on a fixed Polymarket sports basket"
+DESCRIPTION = (
+    "VWAP reversion on a fixed Polymarket sports basket pinned to market close"
+)
 
 DATA = MarketDataConfig(
     platform=Polymarket,
@@ -41,26 +43,55 @@ DATA = MarketDataConfig(
     ),
 )
 
+# Pin each replay window to the market close so the fixed basket stays
+# reproducible and under the public trades API offset ceiling.
+FIXED_LOOKBACK_DAYS = 7
+
 SIMS = (
     MarketSimConfig(
         market_slug="will-ukraine-qualify-for-the-2026-fifa-world-cup",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-26T23:53:59Z",
         outcome="Yes",
+        metadata={
+            "market_close_time_ns": 1774569239000000000,
+        },
     ),
     MarketSimConfig(
         market_slug="will-man-city-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:28:17Z",
         outcome="Yes",
+        metadata={
+            "market_close_time_ns": 1773797297000000000,
+        },
     ),
     MarketSimConfig(
         market_slug="will-chelsea-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:22:09Z",
         outcome="Yes",
+        metadata={
+            "market_close_time_ns": 1773796929000000000,
+        },
     ),
     MarketSimConfig(
         market_slug="will-newcastle-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T22:56:01Z",
         outcome="Yes",
+        metadata={
+            "market_close_time_ns": 1773874561000000000,
+        },
     ),
     MarketSimConfig(
         market_slug="will-leverkusen-win-the-202526-champions-league",
+        lookback_days=FIXED_LOOKBACK_DAYS,
+        end_time="2026-03-18T01:28:15Z",
         outcome="Yes",
+        metadata={
+            "market_close_time_ns": 1773797295000000000,
+        },
     ),
 )
 
@@ -94,8 +125,7 @@ BACKTEST = PredictionMarketBacktest(
     initial_cash=100.0,
     probability_window=80,
     min_trades=25,
-    min_price_range=0.05,
-    default_lookback_days=30,
+    min_price_range=0.01,
 )
 
 

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -44,6 +44,8 @@ _BADGE_COLOR_HEX = {
 }
 _SYSTEM_METRICS_CACHE_TTL_SECS = 2.0
 _SYSTEM_METRICS_SAMPLE_SECS = 0.2
+_RATE_LIMITER_PRUNE_INTERVAL_SECS = 60.0
+_RATE_LIMITER_FORCE_PRUNE_CLIENTS = 10_000
 _SYSTEM_SERVICE_SPECS = {
     "api": ("pmxt-relay-api.service", "API service"),
     "worker": ("pmxt-relay-worker.service", "Worker service"),
@@ -540,6 +542,7 @@ class RequestRateLimiter:
     def __init__(self, requests_per_minute: int) -> None:
         self._requests_per_minute = requests_per_minute
         self._requests: dict[str, deque[float]] = defaultdict(deque)
+        self._last_prune_at = 0.0
 
     @staticmethod
     def _prune_bucket(bucket: deque[float], *, window_start: float) -> None:
@@ -556,11 +559,24 @@ class RequestRateLimiter:
         for client_id in stale_clients:
             del self._requests[client_id]
 
+    def _maybe_prune_stale_buckets(self, *, now: float) -> None:
+        if len(self._requests) >= _RATE_LIMITER_FORCE_PRUNE_CLIENTS:
+            self._prune_stale_buckets(now=now)
+            self._last_prune_at = now
+            return
+
+        if (now - self._last_prune_at) < _RATE_LIMITER_PRUNE_INTERVAL_SECS:
+            return
+
+        self._prune_stale_buckets(now=now)
+        self._last_prune_at = now
+
     def allow(self, client_id: str, *, now: float | None = None) -> bool:
         if self._requests_per_minute <= 0:
             return True
 
         current = time.monotonic() if now is None else now
+        self._maybe_prune_stale_buckets(now=current)
         window_start = current - 60.0
         bucket = self._requests[client_id]
         self._prune_bucket(bucket, window_start=window_start)
@@ -569,8 +585,6 @@ class RequestRateLimiter:
             return False
 
         bucket.append(current)
-        if len(self._requests) > 10000:
-            self._prune_stale_buckets(now=current)
         return True
 
     def bucket_size(self, client_id: str, *, now: float | None = None) -> int:

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -24,6 +24,12 @@ PMXT_SINGLE_MARKET_QUOTE_TICK_RUNNERS = sorted(
     if "sports_" not in path.name and "multi_sim_runner" not in path.name
 )
 
+FIXED_SPORTS_TRADE_TICK_RUNNERS = [
+    Path("backtests/polymarket_trade_tick_sports_final_period_momentum.py"),
+    Path("backtests/polymarket_trade_tick_sports_late_favorite_limit_hold.py"),
+    Path("backtests/polymarket_trade_tick_sports_vwap_reversion.py"),
+]
+
 
 @pytest.mark.parametrize(
     "relative_path",
@@ -131,3 +137,31 @@ def test_pmxt_single_market_quote_tick_runners_expose_explicit_experiment_consta
     assert backtest.initial_cash == 100.0
     assert backtest.min_quotes == 500
     assert backtest.min_price_range == 0.005
+
+
+@pytest.mark.parametrize("relative_path", FIXED_SPORTS_TRADE_TICK_RUNNERS)
+def test_fixed_sports_trade_tick_runners_pin_historical_close_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: Path,
+) -> None:
+    script_path = REPO_ROOT / relative_path
+    normalized_sys_path = [
+        entry for entry in sys.path if Path(entry or ".").resolve() != REPO_ROOT
+    ]
+    monkeypatch.setattr(sys, "path", [str(script_path.parent), *normalized_sys_path])
+
+    globals_dict = runpy.run_path(str(script_path), run_name="__script_test__")
+
+    sims = globals_dict["SIMS"]
+    backtest = globals_dict["BACKTEST"]
+    pd = pytest.importorskip("pandas")
+
+    assert backtest.default_lookback_days is None
+    assert backtest.min_price_range == 0.01
+    assert len(sims) >= 2
+    for sim in sims:
+        assert sim.market_slug
+        assert sim.lookback_days == 7
+        assert isinstance(sim.end_time, str) and sim.end_time
+        close_ns = sim.metadata["market_close_time_ns"]
+        assert pd.Timestamp(sim.end_time).value == close_ns

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -55,6 +55,16 @@ def test_rate_limiter_enforces_sliding_window():
     assert limiter.allow("203.0.113.1", now=20.0) is False
 
 
+def test_rate_limiter_periodically_prunes_stale_clients():
+    limiter = RequestRateLimiter(requests_per_minute=2)
+
+    assert limiter.allow("203.0.113.1", now=0.0) is True
+    assert "203.0.113.1" in limiter._requests  # noqa: SLF001
+
+    assert limiter.allow("198.51.100.7", now=61.0) is True
+    assert "203.0.113.1" not in limiter._requests  # noqa: SLF001
+
+
 def test_client_id_uses_forwarded_for_from_trusted_proxy():
     class _Transport:
         def get_extra_info(self, name: str):  # type: ignore[no-untyped-def]

--- a/tests/test_polymarket_pmxt_backtests.py
+++ b/tests/test_polymarket_pmxt_backtests.py
@@ -331,22 +331,3 @@ def test_pmxt_multi_sim_example_runner_uses_fixed_windows(
         captured["partial_message"]
         == "Completed {completed} of {total} fixed example sims."
     )
-
-
-def test_pmxt_runner_window_env_overrides(monkeypatch: pytest.MonkeyPatch):
-    runner = importlib.import_module(
-        "backtests._shared._polymarket_quote_tick_pmxt_runner"
-    )
-    monkeypatch.setenv("START_TIME", "2026-02-21T16:00:00Z")
-    monkeypatch.setenv("END_TIME", "2026-02-23T06:00:00Z")
-    monkeypatch.setenv("LOOKBACK_HOURS", "38")
-
-    start_time, end_time, lookback_hours = runner._apply_window_env_overrides(  # noqa: SLF001
-        start_time=EXPECTED_START_TIME,
-        end_time=EXPECTED_END_TIME,
-        lookback_hours=None,
-    )
-
-    assert start_time == "2026-02-21T16:00:00Z"
-    assert end_time == "2026-02-23T06:00:00Z"
-    assert lookback_hours == 38.0

--- a/tests/test_polymarket_pmxt_runner.py
+++ b/tests/test_polymarket_pmxt_runner.py
@@ -188,6 +188,9 @@ def test_pmxt_runner_respects_explicit_start_and_end_times(monkeypatch):
             "pnl": 0.0,
         },
     )
+    monkeypatch.setenv("START_TIME", "2030-01-01T00:00:00Z")
+    monkeypatch.setenv("END_TIME", "2030-01-01T01:00:00Z")
+    monkeypatch.setenv("LOOKBACK_HOURS", "999")
 
     result = asyncio.run(
         pmxt_runner.run_single_market_pmxt_backtest(


### PR DESCRIPTION
## What changed
- removed hidden `START_TIME` / `END_TIME` / `LOOKBACK_HOURS` overrides from the shared PMXT quote-tick runner so public runner configs stay self-contained and reproducible
- pinned the three fixed Polymarket sports trade-tick runners to explicit market-close windows with a 7-day lookback and lower price-range floor so the full fixed basket loads reliably under the public trades API limits
- made the relay request rate limiter prune stale client buckets periodically instead of only after the client map grows past 10k entries
- added regression coverage for the pinned sports windows, periodic rate-limiter pruning, and PMXT runner immunity to ambient window env vars

## Why
This repo is most valuable when backtests are honest and operational assumptions are explicit. Three things were violating that:
- the PMXT runner could silently replay a different window than the one declared in code
- the fixed sports runners were not actually fixed and could quietly complete only 2 of 5 sims while still exiting successfully
- the relay rate limiter could retain stale per-client buckets indefinitely on lower-churn public traffic

## Impact
- public PMXT examples now match the documented runner contract
- the fixed sports runners are reproducible and currently execute 5 of 5 sims on this branch
- relay memory use is better bounded for stale clients without changing request semantics

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
- full direct-runner sweep across every runnable entrypoint under `backtests/` on the current worktree
- `printf '8\n' | TERM=dumb uv run python main.py` menu-path PMXT smoke
- public relay observation over `/healthz`, `/v1/stats`, and `/v1/system` across three samples over about one minute
