### PR TITLE
[codex] Fix PMXT timing progress on runner override

### DIFF
--- a/backtests/_shared/_timing_test.py
+++ b/backtests/_shared/_timing_test.py
@@ -618,9 +618,13 @@ def install_timing() -> None:
 
         loader_cls._load_local_archive_market_batches = patched_local_archive
 
-    _install_full_timing(PolymarketPMXTDataLoader)
     if RunnerPolymarketPMXTDataLoader is not None:
+        # Patch the repo-layer runner first because it overrides
+        # _load_market_batches; patching only the base class leaves local
+        # mirror scans outside the started/completed hour bookkeeping.
+        _install_full_timing(RunnerPolymarketPMXTDataLoader)
         _install_runner_local_archive_timing(RunnerPolymarketPMXTDataLoader)
+    _install_full_timing(PolymarketPMXTDataLoader)
 
 
 def _load_backtest_module(path_str: str):

--- a/tests/test_timing_test.py
+++ b/tests/test_timing_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from backtests._shared._timing_test import _progress_bar_description
@@ -162,3 +164,55 @@ def test_active_transfer_progress_dedupes_by_hour() -> None:
 
     assert active_hours == 1
     assert active_progress == pytest.approx(0.96)
+
+
+def test_install_timing_patches_runner_loader_override() -> None:
+    from backtests._shared import _timing_test as timing_module
+    from backtests._shared.data_sources.pmxt import RunnerPolymarketPMXTDataLoader
+    from nautilus_trader.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
+
+    timing_module = importlib.reload(timing_module)
+
+    method_names = (
+        "_load_cached_market_batches",
+        "_load_relay_market_batches",
+        "_load_relay_raw_market_batches",
+        "_load_local_archive_market_batches",
+        "_load_remote_market_batches",
+        "_load_market_batches",
+        "_iter_market_batches",
+    )
+    base_originals = {
+        name: getattr(PolymarketPMXTDataLoader, name) for name in method_names
+    }
+    runner_originals = {
+        name: getattr(RunnerPolymarketPMXTDataLoader, name) for name in method_names
+    }
+    runner_had_own = {
+        name: name in RunnerPolymarketPMXTDataLoader.__dict__ for name in method_names
+    }
+
+    try:
+        timing_module.install_timing()
+
+        assert (
+            RunnerPolymarketPMXTDataLoader._load_market_batches
+            is not runner_originals["_load_market_batches"]
+        )
+        assert (
+            RunnerPolymarketPMXTDataLoader._iter_market_batches
+            is not runner_originals["_iter_market_batches"]
+        )
+        assert (
+            PolymarketPMXTDataLoader._load_market_batches
+            is not base_originals["_load_market_batches"]
+        )
+    finally:
+        timing_module._installed = False
+        for name, original in base_originals.items():
+            setattr(PolymarketPMXTDataLoader, name, original)
+        for name, original in runner_originals.items():
+            if runner_had_own[name]:
+                setattr(RunnerPolymarketPMXTDataLoader, name, original)
+            elif name in RunnerPolymarketPMXTDataLoader.__dict__:
+                delattr(RunnerPolymarketPMXTDataLoader, name)


### PR DESCRIPTION
## Summary
- patch the repo-layer `RunnerPolymarketPMXTDataLoader` before the vendored base loader so PMXT timing bookkeeping applies on runner overrides too
- keep local/raw/archive/relay progress accounting consistent by preserving the existing timing hooks while fixing the install order
- add a regression test that proves `install_timing()` patches the runner override methods, not just the base loader

## Root Cause
The timing harness wrapped `PolymarketPMXTDataLoader`, but the repo runs through `RunnerPolymarketPMXTDataLoader`, which overrides `_load_market_batches`. That left local raw mirror scans outside the started/done bookkeeping and caused progress lines like `1/44 started` while multiple hours were active.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
- cleared `/Users/evankolberg/.cache/nautilus_trader/pmxt` and reran `uv run python backtests/_shared/_timing_test.py backtests/polymarket_quote_tick_pmxt_ema_crossover.py`
- exercised the direct script path with `uv run python backtests/polymarket_quote_tick_pmxt_ema_crossover.py` and the menu path via `uv run python main.py`, confirming the fixed started/done counters on real PMXT output
