### PR TITLE
[codex] Improve PMXT raw progress output and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Detailed guides have been filed away in the [docs index](https://evan-kolberg.gi
   - [What Is Not Plug-And-Play Yet](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-byod/#what-is-not-plug-and-play-yet)
 - [Mirror And Relay Ops](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-relay/)
   - [Active Mirror Service](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-relay/#active-mirror-service)
-  - [Local-First Alternative](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-relay/#local-first-alternative)
+  - [PC-Side Alternative](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-relay/#pc-side-alternative)
   - [Archived Relay Snapshot](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-relay/#archived-relay-snapshot)
 - [Vendor Fetch Sources And Timing](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-fetch-sources/)
   - [Example Output](https://evan-kolberg.github.io/prediction-market-backtesting/pmxt-fetch-sources/#example-output)

--- a/backtests/_shared/_timing_test.py
+++ b/backtests/_shared/_timing_test.py
@@ -30,6 +30,9 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 _installed = False
+_COMPLETED_HOUR_TIMESTAMP_WIDTH = 25
+_COMPLETED_HOUR_ELAPSED_WIDTH = 9
+_COMPLETED_HOUR_ROWS_WIDTH = 8
 
 
 def _hour_label(source: str) -> str:
@@ -116,6 +119,20 @@ def _progress_bar_position(
     remaining = max(0.0, float(total - completed))
     active_progress = min(max(0.0, active_hours_progress), remaining)
     return completed + active_progress
+
+
+def _format_completed_hour_line(
+    hour,  # type: ignore[no-untyped-def]
+    *,
+    elapsed: float,
+    rows: int,
+    source: str,
+) -> str:
+    return (
+        f"  {hour.isoformat():>{_COMPLETED_HOUR_TIMESTAMP_WIDTH}s}"
+        f"  {elapsed:{_COMPLETED_HOUR_ELAPSED_WIDTH}.3f}s"
+        f"  {rows:>{_COMPLETED_HOUR_ROWS_WIDTH}} rows  {_transfer_label(source)}"
+    )
 
 
 def _hour_label_from_hour(hour) -> str:  # type: ignore[no-untyped-def]
@@ -510,7 +527,12 @@ def install_timing() -> None:
                 bar = pbar_state["bar"]
                 if bar is not None:
                     bar.write(
-                        f"  {hour.isoformat():>25s}  {elapsed:6.3f}s  {rows:>6} rows  {_transfer_label(source)}"
+                        _format_completed_hour_line(
+                            hour,
+                            elapsed=elapsed,
+                            rows=rows,
+                            source=source,
+                        )
                     )
                     _mark_hour_completed(hour)
                     _refresh_transfer_status()

--- a/docs/pmxt-byod.md
+++ b/docs/pmxt-byod.md
@@ -103,11 +103,15 @@ To mirror raw archive hours locally for this repo's runners, use:
 make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
 ```
 
-The downloader prints a live progress bar while it walks archive hours. Example
-output:
+The downloader prints per-hour completion lines plus the active transfer while
+it walks archive hours. Example output:
 
 ```text
-Downloading PMXT raws:  13%|███████████████████████▍| 137/1017 [41:27<3:37:59, 14.86s/hour, archive 2026-02-27T11:00:00+00:00 392.0/445.9 MiB]
+PMXT raw source: explicit priority (archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+Downloading PMXT raw hours to /path/to/pmxt_raws (requested_hours=3, window_start=2026-02-27T11, window_end=2026-02-27T13)...
+  2026-02-27T11  12.431s   445.9 MiB  archive
+  2026-02-27T12   0.000s    existing  skip
+Downloading raw hours (2/3 done, 1 active):  67%|████████████████████████████████████████████████████████████▏                              | [00:41<00:20]active: relay 2026-02-27T13 392.0/445.9 MiB 14.8s
 ```
 
 Those values vary with the archive listing and whatever hour is currently in

--- a/docs/pmxt-fetch-sources.md
+++ b/docs/pmxt-fetch-sources.md
@@ -40,13 +40,13 @@ Running: polymarket_quote_tick_pmxt_panic_fade
 
 PMXT source: explicit priority (cache -> local /Volumes/LaCie/pmxt_raws -> archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
 Loading PMXT Polymarket market will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026 (token_index=0, window_start=2026-02-21T16:00:00+00:00, window_end=2026-02-23T10:00:00+00:00)...
-  2026-02-21T18:00:00+00:00   0.002s     263 rows  cache 2026-02-21T18
-  2026-02-21T17:00:00+00:00   0.002s     339 rows  cache 2026-02-21T17
-  2026-02-21T16:00:00+00:00   0.003s     117 rows  cache 2026-02-21T16
-  2026-02-21T15:00:00+00:00   0.553s       0 rows  none
-  2026-02-21T19:00:00+00:00   6.466s     862 rows  local raw 2026-02-21T19
-  2026-02-22T01:00:00+00:00  22.608s    4156 rows  local raw 2026-02-22T01
-  2026-02-22T16:00:00+00:00  24.068s    3571 rows  local raw 2026-02-22T16
+  2026-02-21T18:00:00+00:00      0.002s       263 rows  cache 2026-02-21T18
+  2026-02-21T17:00:00+00:00      0.002s       339 rows  cache 2026-02-21T17
+  2026-02-21T16:00:00+00:00      0.003s       117 rows  cache 2026-02-21T16
+  2026-02-21T15:00:00+00:00      0.553s         0 rows  none
+  2026-02-21T19:00:00+00:00      6.466s       862 rows  local raw 2026-02-21T19
+  2026-02-22T01:00:00+00:00     22.608s      4156 rows  local raw 2026-02-22T01
+  2026-02-22T16:00:00+00:00     24.068s      3571 rows  local raw 2026-02-22T16
 Fetching hours (41/44 done, 3 active):  95%|████████████████████████████████████████████████████████████████████████████████████████████████████████▉| [02:43<00:07], prefetch: - local raw 2026-02-23T09 scan 529.8MiB 574b 220r 3.6s | local raw 2026-02-23T08 scan 563.5MiB 3.6s | +1 more
 ```
 

--- a/docs/pmxt-relay.md
+++ b/docs/pmxt-relay.md
@@ -42,37 +42,14 @@ Operational note:
 The archived relay under `archive/pmxt_relay_legacy/` is historical context
 only. It is not part of the active public relay path.
 
-## Local-First Alternative
+## PC-Side Alternative
 
-If you do not want to run storage-heavy infrastructure for raw mirrors, the
-recommended path is much simpler:
+The active relay docs here stay focused on VPS infrastructure. If you only need
+a one-off local raw download for a PC or external drive, use the local workflow
+docs instead:
 
-- download the raw dumps to a local drive
-- point runners at that raw mirror with `local:/path`
-- let the normal loader cache warm itself as you replay
-
-A large local or external drive is usually enough:
-
-![External drive for local PMXT dumps](https://www.digitaltrends.com/tachyon/2017/03/Lacie-Rugged-4gb-HD-inhandscale.jpg?resize=1200%2C720)
-
-That path avoids VPS relay storage pressure and usually keeps first-pass replay
-fast enough if the raw dump is on a decent SSD or a fast external drive.
-
-The repo-level downloader for that workflow is:
-
-```bash
-make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
-```
-
-The local mirror download is expected to run for a while and report progress in
-place. Example output:
-
-```text
-Downloading PMXT raws:  13%|███████████████████████▍| 137/1017 [41:27<3:37:59, 14.86s/hour, archive 2026-02-27T11:00:00+00:00 392.0/445.9 MiB]
-```
-
-The exact percent, hour count, timestamp, source, and transferred bytes depend
-on the archive state and the mirror window.
+- [`docs/pmxt-byod.md`](https://github.com/evan-kolberg/prediction-market-backtesting/blob/main/docs/pmxt-byod.md)
+- [`docs/setup.md`](https://github.com/evan-kolberg/prediction-market-backtesting/blob/main/docs/setup.md)
 
 ## Archived Relay Snapshot
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -69,14 +69,19 @@ To mirror PMXT raw archive hours locally, run:
 make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
 ```
 
-The download is long-running and prints a live progress bar. Example output:
+The download is long-running and prints per-hour completion lines plus the
+currently active transfer. Example output:
 
 ```text
-Downloading PMXT raws:  13%|███████████████████████▍| 137/1017 [41:27<3:37:59, 14.86s/hour, archive 2026-02-27T11:00:00+00:00 392.0/445.9 MiB]
+PMXT raw source: explicit priority (archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+Downloading PMXT raw hours to /path/to/pmxt_raws (requested_hours=3, window_start=2026-02-27T11, window_end=2026-02-27T13)...
+  2026-02-27T11  12.431s   445.9 MiB  archive
+  2026-02-27T12   0.000s    existing  skip
+Downloading raw hours (2/3 done, 1 active):  67%|████████████████████████████████████████████████████████████▏                              | [00:41<00:20]active: relay 2026-02-27T13 392.0/445.9 MiB 14.8s
 ```
 
-The counts, hour timestamp, source label, and byte totals vary with the
-current archive and the window you are mirroring.
+The counts, hour labels, source label, and byte totals vary with the current
+archive and the window you are mirroring.
 
 ## Timing And Cache Defaults
 

--- a/pmxt_raw_download.py
+++ b/pmxt_raw_download.py
@@ -27,6 +27,8 @@ _DEFAULT_ARCHIVE_BASE_URL = "https://r2.pmxt.dev"
 _DEFAULT_RELAY_BASE_URL = "https://209-209-10-83.sslip.io"
 _DOWNLOAD_CHUNK_SIZE = 8 * 1024 * 1024
 _STATUS_REFRESH_SECS = 0.2
+_RAW_FILENAME_PREFIX = "polymarket_orderbook_"
+_RAW_FILENAME_SUFFIX = ".parquet"
 
 
 @dataclass(frozen=True)
@@ -123,23 +125,192 @@ def _relay_url(base_url: str, filename: str) -> str:
     return f"{base_url.rstrip('/')}/v1/raw/{relative}"
 
 
+def _hour_label_for_filename(filename: str) -> str:
+    if filename.startswith(_RAW_FILENAME_PREFIX) and filename.endswith(
+        _RAW_FILENAME_SUFFIX
+    ):
+        return filename.removeprefix(_RAW_FILENAME_PREFIX).removesuffix(
+            _RAW_FILENAME_SUFFIX
+        )
+    return parse_archive_hour(filename).strftime("%Y-%m-%dT%H")
+
+
+def _progress_bar_description(
+    *,
+    total_hours: int,
+    completed_hours: int,
+    active_hours: int,
+) -> str:
+    if total_hours <= 0:
+        return "Downloading raw hours"
+
+    completed = min(max(0, completed_hours), total_hours)
+    active = min(max(0, active_hours), total_hours)
+    if active > 0:
+        return (
+            f"Downloading raw hours ({completed}/{total_hours} done, {active} active)"
+        )
+    if completed >= total_hours:
+        return f"Downloading raw hours ({total_hours}/{total_hours} done)"
+    return f"Downloading raw hours ({completed}/{total_hours} done)"
+
+
+def _format_mib(size_bytes: int) -> str:
+    return f"{size_bytes / (1024 * 1024):.1f} MiB"
+
+
+def _active_status_text(
+    *,
+    source: str,
+    hour_label: str,
+    written_bytes: int,
+    total_bytes: int | None,
+    elapsed_secs: float,
+) -> str:
+    if total_bytes is None:
+        transfer = _format_mib(written_bytes)
+    else:
+        transfer = f"{_format_mib(written_bytes)}/{_format_mib(total_bytes)}"
+    return f"active: {source} {hour_label} {transfer} {elapsed_secs:4.1f}s"
+
+
+def _hour_result_text(
+    *,
+    hour_label: str,
+    elapsed_secs: float,
+    detail: str,
+    source: str,
+) -> str:
+    return f"  {hour_label:>13s}  {elapsed_secs:6.3f}s  {detail:>10s}  {source}"
+
+
+def _source_priority_summary(
+    *,
+    source_sequence: list[str],
+    archive_base_url: str,
+    relay_base_url: str,
+) -> str:
+    parts: list[str] = []
+    for source in source_sequence:
+        if source == "archive":
+            parts.append(f"archive {archive_base_url.rstrip('/')}")
+        else:
+            parts.append(f"relay {relay_base_url.rstrip('/')}")
+    return "PMXT raw source: explicit priority (" + " -> ".join(parts) + ")"
+
+
+def _window_label_from_filenames(
+    filenames: list[str],
+) -> tuple[str | None, str | None]:
+    if not filenames:
+        return None, None
+    return _hour_label_for_filename(filenames[0]), _hour_label_for_filename(
+        filenames[-1]
+    )
+
+
+def _pid_is_active(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _stale_tmp_download_paths(destination: Path) -> list[Path]:
+    if not destination.parent.exists():
+        return []
+
+    tmp_paths: list[Path] = []
+    plain_tmp_path = destination.with_name(f"{destination.name}.tmp")
+    if plain_tmp_path.exists():
+        tmp_paths.append(plain_tmp_path)
+    tmp_paths.extend(sorted(destination.parent.glob(f"{destination.name}.tmp.*")))
+    return tmp_paths
+
+
+def _is_stale_tmp_download_path(
+    tmp_path: Path,
+    *,
+    destination_exists: bool,
+) -> bool:
+    if tmp_path.name.endswith(".tmp"):
+        return destination_exists
+
+    tmp_marker = ".tmp."
+    if tmp_marker not in tmp_path.name:
+        return False
+
+    pid_text = tmp_path.name.rsplit(tmp_marker, maxsplit=1)[-1]
+    try:
+        pid = int(pid_text)
+    except ValueError:
+        return True
+    return not _pid_is_active(pid)
+
+
+def _cleanup_stale_tmp_downloads(destination: Path) -> int:
+    destination_exists = destination.exists()
+    removed = 0
+    for tmp_path in _stale_tmp_download_paths(destination):
+        if not tmp_path.is_file():
+            continue
+        if not _is_stale_tmp_download_path(
+            tmp_path,
+            destination_exists=destination_exists,
+        ):
+            continue
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            continue
+        removed += 1
+    return removed
+
+
 def _set_status(
     progress_bar: tqdm | None,
-    status: str,
     *,
+    total_hours: int,
+    completed_hours: int,
+    active_hours: int,
+    status: str,
     force: bool = False,
 ) -> None:
     if progress_bar is None:
         return
+    description = _progress_bar_description(
+        total_hours=total_hours,
+        completed_hours=completed_hours,
+        active_hours=active_hours,
+    )
     now = time.monotonic()
     last_update = float(getattr(progress_bar, "_pmxt_last_status_ts", 0.0))
     last_status = str(getattr(progress_bar, "_pmxt_last_status", ""))
-    if not force and status == last_status and now - last_update < _STATUS_REFRESH_SECS:
+    last_description = str(getattr(progress_bar, "_pmxt_last_description", ""))
+    if (
+        not force
+        and status == last_status
+        and description == last_description
+        and now - last_update < _STATUS_REFRESH_SECS
+    ):
         return
-    progress_bar.set_postfix_str(status)
+    progress_bar.set_description_str(description, refresh=False)
+    progress_bar.set_postfix_str(status, refresh=False)
     progress_bar.refresh()
     setattr(progress_bar, "_pmxt_last_status_ts", now)
     setattr(progress_bar, "_pmxt_last_status", status)
+    setattr(progress_bar, "_pmxt_last_description", description)
+
+
+def _write_progress_line(progress_bar: tqdm | None, line: str) -> None:
+    if progress_bar is None:
+        return
+    progress_bar.write(line)
 
 
 def _download_one(
@@ -148,12 +319,30 @@ def _download_one(
     destination: Path,
     timeout_secs: int,
     progress_bar: tqdm | None,
-    status_prefix: str,
-) -> None:
+    total_hours: int,
+    completed_hours: int,
+    source: str,
+    hour_label: str,
+) -> int:
     destination.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = destination.with_name(f"{destination.name}.tmp.{os.getpid()}")
     request = Request(url, headers={"User-Agent": _USER_AGENT})
+    started_at = time.perf_counter()
     try:
+        _set_status(
+            progress_bar,
+            total_hours=total_hours,
+            completed_hours=completed_hours,
+            active_hours=1,
+            status=_active_status_text(
+                source=source,
+                hour_label=hour_label,
+                written_bytes=0,
+                total_bytes=None,
+                elapsed_secs=0.0,
+            ),
+            force=True,
+        )
         with (
             urlopen(request, timeout=timeout_secs) as response,
             tmp_path.open("wb") as handle,
@@ -161,22 +350,29 @@ def _download_one(
             total_bytes_header = response.headers.get("Content-Length")
             total_bytes = int(total_bytes_header) if total_bytes_header else None
             written = 0
-            _set_status(progress_bar, f"{status_prefix} 0.0 MiB", force=True)
             while True:
                 chunk = response.read(_DOWNLOAD_CHUNK_SIZE)
                 if not chunk:
                     break
                 handle.write(chunk)
                 written += len(chunk)
-                if total_bytes is None:
-                    status = f"{status_prefix} {written / (1024 * 1024):.1f} MiB"
-                else:
-                    status = (
-                        f"{status_prefix} {written / (1024 * 1024):.1f}/"
-                        f"{total_bytes / (1024 * 1024):.1f} MiB"
-                    )
-                _set_status(progress_bar, status)
+                _set_status(
+                    progress_bar,
+                    total_hours=total_hours,
+                    completed_hours=completed_hours,
+                    active_hours=1,
+                    status=_active_status_text(
+                        source=source,
+                        hour_label=hour_label,
+                        written_bytes=written,
+                        total_bytes=total_bytes,
+                        elapsed_secs=time.perf_counter() - started_at,
+                    ),
+                )
         os.replace(tmp_path, destination)
+        if written == 0 and total_bytes is not None:
+            return total_bytes
+        return written
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -239,8 +435,37 @@ def download_raw_hours(
             end_hour=end_hour,
         )
 
+    if show_progress:
+        print(
+            _source_priority_summary(
+                source_sequence=source_sequence,
+                archive_base_url=archive_base_url,
+                relay_base_url=relay_base_url,
+            )
+        )
+        window_start_label, window_end_label = _window_label_from_filenames(filenames)
+        window_parts = [f"requested_hours={len(filenames)}"]
+        if window_start_label is not None:
+            window_parts.append(f"window_start={window_start_label}")
+        if window_end_label is not None:
+            window_parts.append(f"window_end={window_end_label}")
+        print(
+            f"Downloading PMXT raw hours to {normalized_destination} "
+            f"({', '.join(window_parts)})..."
+        )
+
     progress_bar = (
-        tqdm(total=len(filenames), desc="Downloading PMXT raws", unit="hour")
+        tqdm(
+            total=len(filenames),
+            desc=_progress_bar_description(
+                total_hours=len(filenames),
+                completed_hours=0,
+                active_hours=0,
+            ),
+            unit="hr",
+            leave=False,
+            bar_format=("{l_bar}{bar}| [{elapsed}<{remaining}]{postfix}"),
+        )
         if show_progress
         else None
     )
@@ -248,19 +473,41 @@ def download_raw_hours(
     failed_hours: list[str] = []
     downloaded_hours = 0
     skipped_existing_hours = 0
+    completed_hours = 0
 
     try:
         for filename in filenames:
             destination_path = normalized_destination / raw_relative_path(filename)
-            hour_label = parse_archive_hour(filename).isoformat()
+            _cleanup_stale_tmp_downloads(destination_path)
+            hour_label = _hour_label_for_filename(filename)
             if destination_path.exists() and not overwrite:
                 skipped_existing_hours += 1
-                _set_status(progress_bar, f"skip {hour_label}", force=True)
+                _write_progress_line(
+                    progress_bar,
+                    _hour_result_text(
+                        hour_label=hour_label,
+                        elapsed_secs=0.0,
+                        detail="existing",
+                        source="skip",
+                    ),
+                )
                 if progress_bar is not None:
                     progress_bar.update(1)
+                completed_hours += 1
+                _set_status(
+                    progress_bar,
+                    total_hours=len(filenames),
+                    completed_hours=completed_hours,
+                    active_hours=0,
+                    status="",
+                    force=True,
+                )
                 continue
 
             last_error: Exception | None = None
+            hour_started_at = time.perf_counter()
+            completed_source: str | None = None
+            downloaded_size_bytes: int | None = None
             for source in source_sequence:
                 if source == "archive":
                     url = _archive_url(archive_base_url, filename)
@@ -269,15 +516,19 @@ def download_raw_hours(
                     url = _relay_url(relay_base_url, filename)
                     source_label = f"relay:{relay_base_url.rstrip('/')}"
                 try:
-                    _download_one(
+                    downloaded_size_bytes = _download_one(
                         url=url,
                         destination=destination_path,
                         timeout_secs=timeout_secs,
                         progress_bar=progress_bar,
-                        status_prefix=f"{source} {hour_label}",
+                        total_hours=len(filenames),
+                        completed_hours=completed_hours,
+                        source=source,
+                        hour_label=hour_label,
                     )
                     source_hits[source_label] += 1
                     downloaded_hours += 1
+                    completed_source = source
                     last_error = None
                     break
                 except HTTPError as exc:
@@ -288,11 +539,39 @@ def download_raw_hours(
                     last_error = exc
                     continue
 
+            elapsed_secs = time.perf_counter() - hour_started_at
             if last_error is not None:
-                failed_hours.append(hour_label)
-                _set_status(progress_bar, f"failed {hour_label}", force=True)
+                failed_hours.append(parse_archive_hour(filename).isoformat())
+                _write_progress_line(
+                    progress_bar,
+                    _hour_result_text(
+                        hour_label=hour_label,
+                        elapsed_secs=elapsed_secs,
+                        detail="failed",
+                        source=" -> ".join(source_sequence),
+                    ),
+                )
+            elif downloaded_size_bytes is not None and completed_source is not None:
+                _write_progress_line(
+                    progress_bar,
+                    _hour_result_text(
+                        hour_label=hour_label,
+                        elapsed_secs=elapsed_secs,
+                        detail=_format_mib(downloaded_size_bytes),
+                        source=completed_source,
+                    ),
+                )
             if progress_bar is not None:
                 progress_bar.update(1)
+            completed_hours += 1
+            _set_status(
+                progress_bar,
+                total_hours=len(filenames),
+                completed_hours=completed_hours,
+                active_hours=0,
+                status="",
+                force=True,
+            )
     finally:
         if progress_bar is not None:
             progress_bar.close()

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -1,12 +1,14 @@
 # PMXT Relay
 
-`pmxt_relay/` is now the active mirror-focused PMXT service layer for this repo.
+`pmxt_relay/` is the VPS deployment subtree for the active PMXT mirror service.
+Keep this folder limited to server infrastructure, service code, and deploy
+artifacts. PC-side download helpers and other local workflows should live
+outside `pmxt_relay/`.
 
 Current direction:
 
 - mirror raw PMXT archive hours onto disk
 - optionally expose those mirrored raw files over `/v1/raw/*`
-- use mirrored raw files directly from runners or the repo downloader
 - keep the active relay scoped to raw mirroring and raw file serving
 
 Older relay code has been archived under `archive/pmxt_relay_legacy/`.
@@ -24,21 +26,6 @@ Mirror API:
 ```bash
 uv run python -m pmxt_relay api
 ```
-
-Repo-level raw download helper:
-
-```bash
-make download-pmxt-raws DESTINATION=/data/pmxt/raw
-```
-
-It shows a live progress bar while copying raw archive hours. Example output:
-
-```text
-Downloading PMXT raws:  13%|███████████████████████▍| 137/1017 [41:27<3:37:59, 14.86s/hour, archive 2026-02-27T11:00:00+00:00 392.0/445.9 MiB]
-```
-
-Expect those numbers to vary by current archive size, source, and the
-destination window you are downloading.
 
 ## Directory Layout
 

--- a/tests/test_pmxt_raw_download.py
+++ b/tests/test_pmxt_raw_download.py
@@ -36,6 +36,42 @@ class _Response:
         return chunk
 
 
+class _FakeTqdm:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        del args
+        self.total = kwargs["total"]
+        self.desc = kwargs["desc"]
+        self.unit = kwargs["unit"]
+        self.leave = kwargs["leave"]
+        self.bar_format = kwargs["bar_format"]
+        self.n = 0
+        self.descriptions = [self.desc]
+        self.postfixes: list[str] = []
+        self.writes: list[str] = []
+        self.closed = False
+
+    def set_description_str(self, desc: str, refresh: bool = True) -> None:
+        del refresh
+        self.desc = desc
+        self.descriptions.append(desc)
+
+    def set_postfix_str(self, postfix: str, refresh: bool = True) -> None:
+        del refresh
+        self.postfixes.append(postfix)
+
+    def refresh(self) -> None:
+        return
+
+    def update(self, value: int) -> None:
+        self.n += value
+
+    def write(self, text: str) -> None:
+        self.writes.append(text)
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def _raw_parquet_payload() -> bytes:
     buffer = BytesIO()
     pq.write_table(
@@ -181,3 +217,126 @@ def test_download_raw_hours_skips_existing_files(monkeypatch, tmp_path: Path) ->
     assert summary.downloaded_hours == 1
     assert summary.skipped_existing_hours == 1
     assert existing_path.read_bytes() == b"existing"
+
+
+def test_download_raw_hours_removes_stale_temp_files_before_skipping(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "raws"
+    existing_path = (
+        destination
+        / "2026"
+        / "03"
+        / "21"
+        / "polymarket_orderbook_2026-03-21T09.parquet"
+    )
+    existing_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_path.write_bytes(b"existing")
+
+    plain_tmp_path = existing_path.with_name(f"{existing_path.name}.tmp")
+    plain_tmp_path.write_bytes(b"stale-plain-tmp")
+
+    pid_tmp_path = existing_path.with_name(f"{existing_path.name}.tmp.999999")
+    pid_tmp_path.write_bytes(b"stale-pid-tmp")
+
+    monkeypatch.setattr(
+        raw_download,
+        "discover_archive_hours",
+        lambda **_: [
+            raw_download.parse_archive_hour(
+                "polymarket_orderbook_2026-03-21T09.parquet"
+            ),
+        ],
+    )
+
+    def fake_pid_is_active(pid: int) -> bool:
+        del pid
+        return False
+
+    def unexpected_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
+        del timeout
+        raise AssertionError(f"unexpected download request for {request.full_url}")
+
+    monkeypatch.setattr(raw_download, "_pid_is_active", fake_pid_is_active)
+    monkeypatch.setattr(raw_download, "urlopen", unexpected_urlopen)
+
+    summary = raw_download.download_raw_hours(
+        destination=destination,
+        show_progress=False,
+    )
+
+    assert summary.downloaded_hours == 0
+    assert summary.skipped_existing_hours == 1
+    assert existing_path.read_bytes() == b"existing"
+    assert not plain_tmp_path.exists()
+    assert not pid_tmp_path.exists()
+
+
+def test_download_raw_hours_progress_output_uses_short_hour_labels(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    payload = _raw_parquet_payload()
+    bars: list[_FakeTqdm] = []
+
+    monkeypatch.setattr(
+        raw_download,
+        "discover_archive_hours",
+        lambda **_: [
+            raw_download.parse_archive_hour(
+                "polymarket_orderbook_2026-03-21T09.parquet"
+            ),
+            raw_download.parse_archive_hour(
+                "polymarket_orderbook_2026-03-21T10.parquet"
+            ),
+        ],
+    )
+
+    def fake_tqdm(*args, **kwargs):  # type: ignore[no-untyped-def]
+        bar = _FakeTqdm(*args, **kwargs)
+        bars.append(bar)
+        return bar
+
+    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
+        del timeout
+        if (
+            request.full_url.endswith("2026-03-21T10.parquet")
+            and "/v1/raw/" not in request.full_url
+        ):
+            raise HTTPError(request.full_url, 404, "missing", hdrs=None, fp=None)
+        return _Response(payload, headers={"Content-Length": str(len(payload))})
+
+    monkeypatch.setattr(raw_download, "tqdm", fake_tqdm)
+    monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
+
+    summary = raw_download.download_raw_hours(
+        destination=tmp_path / "raws",
+        show_progress=True,
+    )
+
+    assert summary.downloaded_hours == 2
+    assert len(bars) == 1
+
+    bar = bars[0]
+    captured = capsys.readouterr()
+
+    assert (
+        "PMXT raw source: explicit priority "
+        "(archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)"
+    ) in captured.out
+    assert "window_start=2026-03-21T09" in captured.out
+    assert "window_end=2026-03-21T10" in captured.out
+    assert any("active: archive 2026-03-21T09" in status for status in bar.postfixes)
+    assert any("active: relay 2026-03-21T10" in status for status in bar.postfixes)
+    assert not any("+00:00" in status for status in bar.postfixes)
+    assert any(
+        "2026-03-21T09" in line and line.endswith("archive") for line in bar.writes
+    )
+    assert any(
+        "2026-03-21T10" in line and line.endswith("relay") for line in bar.writes
+    )
+    assert not any("+00:00" in line for line in bar.writes)
+    assert "Downloading raw hours (0/2 done, 1 active)" in bar.descriptions
+    assert bar.desc == "Downloading raw hours (2/2 done)"

--- a/tests/test_timing_test.py
+++ b/tests/test_timing_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib
+from datetime import datetime
+from datetime import timezone
 
 import pytest
 
@@ -8,6 +10,7 @@ from backtests._shared._timing_test import _progress_bar_description
 from backtests._shared._timing_test import _progress_bar_position
 from backtests._shared._timing_test import _progress_bar_total
 from backtests._shared._timing_test import _active_transfer_progress
+from backtests._shared._timing_test import _format_completed_hour_line
 from backtests._shared._timing_test import _transfer_progress_fraction
 from backtests._shared._timing_test import _transfer_label
 
@@ -52,6 +55,20 @@ def test_transfer_label_identifies_r2_raw_urls() -> None:
     )
 
     assert label == "r2 raw 2026-02-22T11"
+
+
+def test_format_completed_hour_line_keeps_long_elapsed_values_aligned() -> None:
+    line = _format_completed_hour_line(
+        datetime(2026, 2, 22, 1, tzinfo=timezone.utc),
+        elapsed=22.608,
+        rows=4156,
+        source="local-raw::/Volumes/LaCie/pmxt_raws/2026/02/22/polymarket_orderbook_2026-02-22T01.parquet",
+    )
+
+    assert (
+        line
+        == "  2026-02-22T01:00:00+00:00     22.608s      4156 rows  local raw 2026-02-22T01"
+    )
 
 
 def test_progress_bar_description_reports_started_hours_before_completion() -> None:


### PR DESCRIPTION
## Summary
- improve PMXT raw download progress output with clearer hour labels, active-transfer status, and stale temp cleanup
- align timing output formatting and add tests for the new progress/reporting behavior
- tighten PMXT docs so `pmxt_relay/` stays VPS-only and local PC download guidance lives in the local workflow docs

## Why
The raw downloader and timing output had drifted from the docs, and the relay docs had started to describe a PC-side one-off downloader workflow that does not belong in the VPS relay subtree.

## Impact
Users get more legible raw-download progress, cleaner completed-hour timing lines, and docs that separate VPS relay infrastructure from local download workflows.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
- `uv run python backtests/polymarket_quote_tick_pmxt_ema_crossover.py`
- `printf '8\\n' | make backtest`
