### PR TITLE
[codex] Fix backtest runner helper imports

### DIFF
--- a/_script_helpers.py
+++ b/_script_helpers.py
@@ -1,0 +1,9 @@
+from backtests._script_helpers import ensure_repo_root
+from backtests._script_helpers import parse_bool_env
+from backtests._script_helpers import parse_csv_env
+
+__all__ = [
+    "ensure_repo_root",
+    "parse_bool_env",
+    "parse_csv_env",
+]

--- a/main.py
+++ b/main.py
@@ -564,13 +564,16 @@ def _load_runner(backtest: dict[str, Any]) -> Any:
 
     module = importlib.util.module_from_spec(spec)
     prior_module = sys.modules.get(module_name)
+    prior_sys_path = list(sys.path)
 
     try:
+        sys.path.insert(0, str(runner_path.parent))
         sys.modules[module_name] = module
         spec.loader.exec_module(module)
     except Exception as exc:
         raise RuntimeError(f"could not import {relative_path}: {exc}") from exc
     finally:
+        sys.path[:] = prior_sys_path
         if prior_module is None:
             sys.modules.pop(module_name, None)
         else:

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -35,6 +35,7 @@ SCRIPT_ENTRYPOINT_PATHS = [
 ]
 
 REPO_BOOTSTRAP_HELPERS = {
+    Path("_script_helpers.py"),
     Path("backtests/_script_helpers.py"),
     Path("scripts/_script_helpers.py"),
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -291,6 +291,52 @@ def test_load_runner_defers_import_failure_until_selection(
         main_module._load_runner(discovered[0])
 
 
+def test_load_runner_supports_runner_local_script_helpers(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path
+    backtests_root = project_root / "backtests"
+    backtests_root.mkdir()
+    (backtests_root / "__init__.py").write_text("", encoding="utf-8")
+    (backtests_root / "_script_helpers.py").write_text(
+        'HELPER_VALUE = "helper-ok"\n',
+        encoding="utf-8",
+    )
+    (backtests_root / "helper_runner.py").write_text(
+        'NAME = "helper_runner"\n'
+        'DESCRIPTION = "Uses a local helper shim"\n'
+        "from _script_helpers import HELPER_VALUE\n"
+        "\n"
+        "def run() -> str:\n"
+        "    return HELPER_VALUE\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(main_module, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(main_module, "BACKTESTS_ROOT", backtests_root)
+    normalized_sys_path = [
+        entry
+        for entry in sys.path
+        if Path(entry or ".").resolve() not in {project_root, backtests_root}
+    ]
+    monkeypatch.setattr(sys, "path", normalized_sys_path)
+
+    discovered = main_module.discover()
+    prior_helper_module = sys.modules.get("_script_helpers")
+
+    try:
+        sys.modules.pop("_script_helpers", None)
+        runner = main_module._load_runner(discovered[0])
+        assert runner() == "helper-ok"
+        assert str(backtests_root) not in sys.path
+    finally:
+        if prior_helper_module is None:
+            sys.modules.pop("_script_helpers", None)
+        else:
+            sys.modules["_script_helpers"] = prior_helper_module
+
+
 def test_filter_backtests_matches_name_description_and_path() -> None:
     backtests = [
         {


### PR DESCRIPTION
## What changed
- fixed `main.py` runner loading so menu-selected backtests temporarily prepend their own directory to `sys.path` before import
- restored the repo-root `_script_helpers.py` compatibility shim, which module-imported backtest runners still rely on
- added focused regression coverage for the menu loader and helper shim layout

## Root cause
The prior organization cleanup deleted the repo-root `_script_helpers.py` shim and exposed a latent mismatch between two runner-loading modes:
- direct script execution worked because Python starts with the runner directory on `sys.path`
- `make backtest` / `main.py` imports runners by file location, which did not emulate that script-local path

That made menu-selected runners fail with `No module named '_script_helpers'`.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `PYTHONWARNINGS=error uv run pytest tests/ -q`
- `printf '14\n' | make backtest`
- `uv run python backtests/polymarket_quote_tick_pmxt_spread_capture.py`
