### PR TITLE
[codex] restore nautilus info output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,9 @@ The latter is not automatically a code bug.
 
 - Timing/progress output should stay enabled by default in `main.py`.
 - `BACKTEST_ENABLE_TIMING=0` is the explicit quiet opt-out.
+- Nautilus backtest output should stay enabled by default in the repo layer.
+- The default repo-layer `nautilus_log_level` is `INFO`; do not downgrade it to `WARNING` or quieter unless the user explicitly asks for that behavior.
+- Treat changes that hide Nautilus runner output by default as a regression, not a cleanup.
 - Direct script runners must work both as package imports and as direct script execution via `uv run python path/to/script.py`.
 - Use the shared `_script_helpers` bootstrap pattern for repo-root imports instead of one-off `sys.path` hacks.
 

--- a/backtests/_shared/_backtest_runtime.py
+++ b/backtests/_shared/_backtest_runtime.py
@@ -229,7 +229,7 @@ def run_market_backtest(
     liquidity_consumption: bool = False,
     queue_position: bool = False,
     latency_model: Any | None = None,
-    nautilus_log_level: str = "WARNING",
+    nautilus_log_level: str = "INFO",
     requested_start_ns: int | None = None,
     requested_end_ns: int | None = None,
 ) -> dict[str, Any]:

--- a/backtests/_shared/_polymarket_quote_tick_pmxt_runner.py
+++ b/backtests/_shared/_polymarket_quote_tick_pmxt_runner.py
@@ -64,7 +64,7 @@ async def run_single_market_pmxt_backtest(
     end_time: pd.Timestamp | datetime | str | None = None,
     data_sources: Sequence[str] = (),
     execution: ExecutionModelConfig | None = None,
-    nautilus_log_level: str = "WARNING",
+    nautilus_log_level: str = "INFO",
 ) -> dict[str, Any] | None:
     strategy_factory = resolve_strategy_factory(
         strategy_factory=strategy_factory,

--- a/backtests/_shared/_prediction_market_backtest.py
+++ b/backtests/_shared/_prediction_market_backtest.py
@@ -143,7 +143,7 @@ class PredictionMarketBacktest:
         default_lookback_hours: float | None = None,
         default_start_time: pd.Timestamp | datetime | str | None = None,
         default_end_time: pd.Timestamp | datetime | str | None = None,
-        nautilus_log_level: str = "WARNING",
+        nautilus_log_level: str = "INFO",
         execution: ExecutionModelConfig | None = None,
     ) -> None:
         self.name = name

--- a/tests/test_polymarket_pmxt_multi_runner.py
+++ b/tests/test_polymarket_pmxt_multi_runner.py
@@ -100,4 +100,4 @@ def test_multi_sim_pmxt_runner_defaults_to_warning_log_level(
     )
 
     assert len(results) == 1
-    assert captured["nautilus_log_level"] == "WARNING"
+    assert captured["nautilus_log_level"] == "INFO"

--- a/tests/test_polymarket_pmxt_runner.py
+++ b/tests/test_polymarket_pmxt_runner.py
@@ -76,7 +76,7 @@ def test_pmxt_runner_uses_l2_execution_settings(monkeypatch):
     assert captured["liquidity_consumption"] is True
     assert captured["queue_position"] is False
     assert captured["latency_model"] is None
-    assert captured["nautilus_log_level"] == "WARNING"
+    assert captured["nautilus_log_level"] == "INFO"
     assert captured["price_attr"] == "mid_price"
     assert captured["count_key"] == "quotes"
     assert captured["data_count"] == 2


### PR DESCRIPTION
## What changed
- restored the shared repo-layer Nautilus backtest default log level from `WARNING` to `INFO`
- updated the PMXT runner tests to assert the visible default
- added an explicit `AGENTS.md` invariant that Nautilus backtest output must stay enabled by default and that downgrading it is a regression unless the user explicitly asks

## Why
Backtest runs had become artificially quiet because the shared runner layer was defaulting Nautilus logging to `WARNING`. That hid the normal Nautilus engine banner and runtime logs from both direct-script and menu-driven backtests.

## Impact
Backtests once again emit the expected Nautilus `INFO` output by default, which makes end-to-end runner behavior visible during normal use.

## Root cause
The repo layer, not the vendored Nautilus subtree, had drifted to `nautilus_log_level="WARNING"` in the shared backtest entrypoints.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`
- `uv run python backtests/kalshi_trade_tick_breakout.py`
- `printf '1\\n' | uv run python main.py`
