### PR TITLE
[codex] Trim stale root README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,10 @@ make install
 make backtest
 ```
 
-The repo now uses one unified backtest launcher in `main.py`. `make backtest`
-opens the interactive runner menu when `Textual` is available on a real TTY,
-and falls back to the numbered console menu otherwise.
-
-![Unified backtest runner](docs/assets/backtests-menu-textual.png)
-
-Timing output stays on by default in the unified menu and direct script
-entrypoints. PMXT filtered cache is also enabled by default under
-`~/.cache/nautilus_trader/pmxt`, so rerunning the same PMXT market window
-should usually be much faster than the first load.
-
-PMXT-backed multi-market runs also keep the source-resolution and report-output
-details visible in the terminal so you can tell what actually loaded, what
-settled, and which HTML artifacts were written.
-
-![PMXT multi-run terminal output](docs/assets/pmxt-multi-run-output.png)
+Timing output stays enabled by default for `make backtest` and direct script
+runners; set `BACKTEST_ENABLE_TIMING=0` to opt out. The local PMXT filtered
+cache is also enabled by default, so repeated PMXT windows should usually load
+faster after the first run.
 
 ## Table of Contents
 


### PR DESCRIPTION
## What changed
- removed the longer unified-runner screenshot section from the root README
- kept a shorter root-level note that timing output and PMXT cache stay enabled by default

## Why
The root README was carrying more runner detail than needed, but the repo still expects the root README to state the default timing and PMXT cache behavior.

## Impact
The root README is shorter and less repetitive, while still preserving the operational defaults readers need to know.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`