### PR TITLE
[codex] Sync root README and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Repository Notes For Agents
 
+## Appendix
+1. DO NOT TOUCH OTHER PARTS OF THE ROOT README. ONLY TOUCH TABLE OF CONTENTS. ALL OTHER DOCUMENTATION CHANGES GET FILED AWAY, DO NOT BLOAT ROOT README. ONLY CHANGE TOC TO BE IN SYNC WITH DOCS.
+
 ## Keep Scope Tight
 
 - Treat subtree updates in `nautilus_pm/` as separate work. Do not mix an upstream subtree pull with normal bugfix/docs PRs.

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ make install
 make backtest
 ```
 
-Timing output stays enabled by default for `make backtest` and direct script
-runners; set `BACKTEST_ENABLE_TIMING=0` to opt out. The local PMXT filtered
-cache is also enabled by default, so repeated PMXT windows should usually load
-faster after the first run.
 
 ## Table of Contents
 


### PR DESCRIPTION
## What changed
- added a root-level agent note that root README edits should stay limited to keeping the table of contents in sync with the docs
- removed the extra root README timing and PMXT cache paragraph so the root README stays lean

## Why
These changes align the repo instructions and the root README with the narrower scope you want for top-level documentation.

## Impact
The root README is trimmed back to the intended scope, and `AGENTS.md` now states that constraint explicitly for future edits.

## Validation
- `uv run ruff check --exclude nautilus_pm .`
- `uv run ruff format --check --exclude nautilus_pm .`
- `uv run pytest tests/ -q`