### PR TITLE
Fix docs workflow branch trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [main]
+    branches: [v2]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"
@@ -10,7 +10,7 @@ on:
       - "docs_overrides/**"
       - "mkdocs.yml"
   pull_request:
-    branches: [main]
+    branches: [v2]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"


### PR DESCRIPTION
## Summary
- The docs deploy workflow (`docs.yml`) still triggered on `branches: [main]`, which was removed when `v2` became the active branch
- Updates both `push` and `pull_request` triggers to `branches: [v2]`

## Test plan
- [ ] Verify the workflow runs on merge to v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)