### PR TITLE
Disable per-market HTML and downsample artifacts on multi-market runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - Joint portfolio multi replay runners
 - Growing support for statistical optimizers
 - New aggregate charts
+- Massive improvements charting gen speed
 
 Looking for the old version? That was renamed to [Version 1](https://github.com/evan-kolberg/prediction-market-backtesting/tree/v1)
 

--- a/backtests/kalshi_trade_tick_breakout.py
+++ b/backtests/kalshi_trade_tick_breakout.py
@@ -32,12 +32,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import Kalshi, Native, TradeTick
 
 
-NAME = "kalshi_trade_tick_breakout"
-
-DESCRIPTION = "Volatility breakout strategy on a single Kalshi market using trade ticks"
-
-EMIT_HTML = True
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "equity",
     "market_pnl",
@@ -93,8 +87,8 @@ REPORT = MarketReportConfig(
 
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="kalshi_trade_tick_breakout",
+    description="Volatility breakout strategy on a single Kalshi market using trade ticks",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -104,8 +98,8 @@ EXPERIMENT = build_replay_experiment(
     min_price_range=0.03,
     report=REPORT,
     empty_message="No Kalshi breakout sims met the trade-tick requirements.",
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=True,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
 )
 

--- a/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
@@ -27,12 +27,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import Kalshi, Native, TradeTick
 
 
-NAME = "kalshi_trade_tick_independent_multi_replay_runner"
-
-DESCRIPTION = "Independent breakout backtests on a fixed Kalshi basket using trade ticks"
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "equity",
     "market_pnl",
@@ -49,7 +43,9 @@ DETAIL_PLOT_PANELS = (
     "total_brier_advantage",
     "brier_advantage",
 )
-SUMMARY_REPORT_PATH = f"output/{NAME}_independent_aggregate.html"
+SUMMARY_REPORT_PATH = (
+    "output/kalshi_trade_tick_independent_multi_replay_runner_independent_aggregate.html"
+)
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -117,8 +113,8 @@ REPORT = MarketReportConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="kalshi_trade_tick_independent_multi_replay_runner",
+    description="Independent breakout backtests on a fixed Kalshi basket using trade ticks",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -129,8 +125,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="independent",

--- a/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
@@ -31,7 +31,7 @@ NAME = "kalshi_trade_tick_independent_multi_replay_runner"
 
 DESCRIPTION = "Independent breakout backtests on a fixed Kalshi basket using trade ticks"
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "equity",

--- a/backtests/kalshi_trade_tick_joint_portfolio_runner.py
+++ b/backtests/kalshi_trade_tick_joint_portfolio_runner.py
@@ -27,12 +27,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import Kalshi, Native, TradeTick
 
 
-NAME = "kalshi_trade_tick_joint_portfolio_runner"
-
-DESCRIPTION = "Joint-portfolio breakout backtest on a fixed Kalshi basket using trade ticks"
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "equity",
     "market_pnl",
@@ -49,7 +43,7 @@ DETAIL_PLOT_PANELS = (
     "total_brier_advantage",
     "brier_advantage",
 )
-SUMMARY_REPORT_PATH = f"output/{NAME}_joint_portfolio.html"
+SUMMARY_REPORT_PATH = "output/kalshi_trade_tick_joint_portfolio_runner_joint_portfolio.html"
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -117,8 +111,8 @@ REPORT = MarketReportConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="kalshi_trade_tick_joint_portfolio_runner",
+    description="Joint-portfolio breakout backtest on a fixed Kalshi basket using trade ticks",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -129,8 +123,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="joint_portfolio",

--- a/backtests/kalshi_trade_tick_joint_portfolio_runner.py
+++ b/backtests/kalshi_trade_tick_joint_portfolio_runner.py
@@ -31,7 +31,7 @@ NAME = "kalshi_trade_tick_joint_portfolio_runner"
 
 DESCRIPTION = "Joint-portfolio breakout backtest on a fixed Kalshi basket using trade ticks"
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "equity",

--- a/backtests/polymarket_quote_tick_ema_crossover.py
+++ b/backtests/polymarket_quote_tick_ema_crossover.py
@@ -31,12 +31,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
 
 
-NAME = "polymarket_quote_tick_ema_crossover"
-
-DESCRIPTION = "EMA crossover momentum on a single Polymarket market using PMXT L2 data"
-
-EMIT_HTML = True
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -108,8 +102,8 @@ EXECUTION = ExecutionModelConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_quote_tick_ema_crossover",
+    description="EMA crossover momentum on a single Polymarket market using PMXT L2 data",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -120,8 +114,8 @@ EXPERIMENT = build_replay_experiment(
     execution=EXECUTION,
     report=REPORT,
     empty_message="No PMXT EMA crossover sims met the quote-tick requirements.",
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=True,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
 )
 

--- a/backtests/polymarket_quote_tick_ema_optimizer.py
+++ b/backtests/polymarket_quote_tick_ema_optimizer.py
@@ -32,14 +32,6 @@ from prediction_market_extensions.backtesting.optimizers import ParameterSearchC
 from prediction_market_extensions.backtesting.optimizers import ParameterSearchWindow
 
 
-NAME = "polymarket_quote_tick_ema_optimizer"
-
-DESCRIPTION = "Random-search EMA optimizer with explicit train and holdout windows on PMXT L2 data"
-MARKET_SLUG = "will-ludvig-aberg-win-the-2026-masters-tournament"
-
-EMIT_HTML = True
-CHART_OUTPUT_PATH = "output"
-
 DATA = MarketDataConfig(
     platform=Polymarket,
     data_type=QuoteTick,
@@ -51,7 +43,9 @@ DATA = MarketDataConfig(
     ),
 )
 
-BASE_REPLAY = QuoteReplay(market_slug=MARKET_SLUG, token_index=0)
+BASE_REPLAY = QuoteReplay(
+    market_slug="will-ludvig-aberg-win-the-2026-masters-tournament", token_index=0
+)
 
 TRAIN_WINDOWS = (
     ParameterSearchWindow(
@@ -111,7 +105,7 @@ EXECUTION = ExecutionModelConfig(
 )
 
 PARAMETER_SEARCH = ParameterSearchConfig(
-    name=NAME,
+    name="polymarket_quote_tick_ema_optimizer",
     data=DATA,
     base_replay=BASE_REPLAY,
     strategy_spec=STRATEGY_SPEC,
@@ -127,8 +121,8 @@ PARAMETER_SEARCH = ParameterSearchConfig(
     min_price_range=0.005,
     min_fills_per_window=1,
     execution=EXECUTION,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=True,
+    chart_output_path="output",
 )
 
 
@@ -136,7 +130,13 @@ SEARCH = PARAMETER_SEARCH
 OPTIMIZER = PARAMETER_SEARCH
 OPTIMIZATION = PARAMETER_SEARCH
 
-EXPERIMENT = ParameterSearchExperiment(name=NAME, description=DESCRIPTION, parameter_search=SEARCH)
+EXPERIMENT = ParameterSearchExperiment(
+    name="polymarket_quote_tick_ema_optimizer",
+    description=(
+        "Random-search EMA optimizer with explicit train and holdout windows on PMXT L2 data"
+    ),
+    parameter_search=SEARCH,
+)
 
 
 @timing_harness

--- a/backtests/polymarket_quote_tick_independent_25_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_25_replay_runner.py
@@ -33,7 +33,7 @@ NAME = "polymarket_quote_tick_independent_25_replay_runner"
 
 DESCRIPTION = "Independent PMXT quote-tick backtests using 25 varied historical replays"
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",

--- a/backtests/polymarket_quote_tick_independent_25_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_25_replay_runner.py
@@ -29,12 +29,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
 
 
-NAME = "polymarket_quote_tick_independent_25_replay_runner"
-
-DESCRIPTION = "Independent PMXT quote-tick backtests using 25 varied historical replays"
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -52,7 +46,9 @@ DETAIL_PLOT_PANELS = (
     "total_brier_advantage",
     "brier_advantage",
 )
-SUMMARY_REPORT_PATH = f"output/{NAME}_independent_aggregate.html"
+SUMMARY_REPORT_PATH = (
+    "output/polymarket_quote_tick_independent_25_replay_runner_independent_aggregate.html"
+)
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -292,8 +288,8 @@ EXECUTION = ExecutionModelConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_quote_tick_independent_25_replay_runner",
+    description="Independent PMXT quote-tick backtests using 25 varied historical replays",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -305,8 +301,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="independent",

--- a/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
@@ -29,12 +29,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
 
 
-NAME = "polymarket_quote_tick_independent_multi_replay_runner"
-
-DESCRIPTION = "Independent PMXT quote-tick backtests using varied historical replays"
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -52,7 +46,9 @@ DETAIL_PLOT_PANELS = (
     "total_brier_advantage",
     "brier_advantage",
 )
-SUMMARY_REPORT_PATH = f"output/{NAME}_independent_aggregate.html"
+SUMMARY_REPORT_PATH = (
+    "output/polymarket_quote_tick_independent_multi_replay_runner_independent_aggregate.html"
+)
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -172,8 +168,8 @@ EXECUTION = ExecutionModelConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_quote_tick_independent_multi_replay_runner",
+    description="Independent PMXT quote-tick backtests using varied historical replays",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -185,8 +181,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="independent",

--- a/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
@@ -33,7 +33,7 @@ NAME = "polymarket_quote_tick_independent_multi_replay_runner"
 
 DESCRIPTION = "Independent PMXT quote-tick backtests using varied historical replays"
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",

--- a/backtests/polymarket_quote_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_quote_tick_joint_portfolio_runner.py
@@ -29,12 +29,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
 
 
-NAME = "polymarket_quote_tick_joint_portfolio_runner"
-
-DESCRIPTION = "Joint-portfolio PMXT quote-tick backtest using varied historical replays"
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -52,7 +46,7 @@ DETAIL_PLOT_PANELS = (
     "total_brier_advantage",
     "brier_advantage",
 )
-SUMMARY_REPORT_PATH = f"output/{NAME}_joint_portfolio.html"
+SUMMARY_REPORT_PATH = "output/polymarket_quote_tick_joint_portfolio_runner_joint_portfolio.html"
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -172,8 +166,8 @@ REPORT = MarketReportConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_quote_tick_joint_portfolio_runner",
+    description="Joint-portfolio PMXT quote-tick backtest using varied historical replays",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -185,8 +179,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="joint_portfolio",

--- a/backtests/polymarket_quote_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_quote_tick_joint_portfolio_runner.py
@@ -33,7 +33,7 @@ NAME = "polymarket_quote_tick_joint_portfolio_runner"
 
 DESCRIPTION = "Joint-portfolio PMXT quote-tick backtest using varied historical replays"
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",

--- a/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
@@ -33,7 +33,7 @@ DESCRIPTION = (
     "Independent VWAP-reversion backtests on a fixed Polymarket basket pinned to market close"
 )
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",

--- a/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
@@ -27,14 +27,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import Native, Polymarket, TradeTick
 
 
-NAME = "polymarket_trade_tick_independent_multi_replay_runner"
-
-DESCRIPTION = (
-    "Independent VWAP-reversion backtests on a fixed Polymarket basket pinned to market close"
-)
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -52,7 +44,9 @@ DETAIL_PLOT_PANELS = (
     "total_brier_advantage",
     "brier_advantage",
 )
-SUMMARY_REPORT_PATH = f"output/{NAME}_independent_aggregate.html"
+SUMMARY_REPORT_PATH = (
+    "output/polymarket_trade_tick_independent_multi_replay_runner_independent_aggregate.html"
+)
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -142,8 +136,10 @@ REPORT = MarketReportConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_trade_tick_independent_multi_replay_runner",
+    description=(
+        "Independent VWAP-reversion backtests on a fixed Polymarket basket pinned to market close"
+    ),
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -154,8 +150,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message="No fixed Polymarket basket sims met the trade-tick requirements.",
     partial_message="Completed {completed} of {total} fixed basket sims.",
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="independent",

--- a/backtests/polymarket_trade_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_trade_tick_joint_portfolio_runner.py
@@ -33,7 +33,7 @@ DESCRIPTION = (
     "Joint-portfolio VWAP-reversion backtest on a fixed Polymarket basket pinned to market close"
 )
 
-EMIT_HTML = True
+EMIT_HTML = False
 CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",

--- a/backtests/polymarket_trade_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_trade_tick_joint_portfolio_runner.py
@@ -27,14 +27,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import Native, Polymarket, TradeTick
 
 
-NAME = "polymarket_trade_tick_joint_portfolio_runner"
-
-DESCRIPTION = (
-    "Joint-portfolio VWAP-reversion backtest on a fixed Polymarket basket pinned to market close"
-)
-
-EMIT_HTML = False
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -75,7 +67,7 @@ DATA = MarketDataConfig(
 
 FIXED_LOOKBACK_DAYS = 7
 
-SUMMARY_REPORT_PATH = f"output/{NAME}_joint_portfolio.html"
+SUMMARY_REPORT_PATH = "output/polymarket_trade_tick_joint_portfolio_runner_joint_portfolio.html"
 EMPTY_MESSAGE = (
     "No fixed joint-portfolio Polymarket basket replays met the trade-tick requirements."
 )
@@ -145,8 +137,10 @@ REPORT = MarketReportConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_trade_tick_joint_portfolio_runner",
+    description=(
+        "Joint-portfolio VWAP-reversion backtest on a fixed Polymarket basket pinned to market close"
+    ),
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -157,8 +151,8 @@ EXPERIMENT = build_replay_experiment(
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="joint_portfolio",

--- a/backtests/polymarket_trade_tick_vwap_reversion.py
+++ b/backtests/polymarket_trade_tick_vwap_reversion.py
@@ -29,12 +29,6 @@ from prediction_market_extensions.backtesting._timing_harness import timing_harn
 from prediction_market_extensions.backtesting.data_sources import Native, Polymarket, TradeTick
 
 
-NAME = "polymarket_trade_tick_vwap_reversion"
-
-DESCRIPTION = "VWAP dislocation mean-reversion on a single Polymarket market"
-
-EMIT_HTML = True
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "total_equity",
     "equity",
@@ -96,8 +90,8 @@ REPORT = MarketReportConfig(
 
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_trade_tick_vwap_reversion",
+    description="VWAP dislocation mean-reversion on a single Polymarket market",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -107,8 +101,8 @@ EXPERIMENT = build_replay_experiment(
     min_price_range=0.005,
     report=REPORT,
     empty_message="No Polymarket VWAP-reversion sims met the trade-tick requirements.",
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=True,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
 )
 

--- a/docs/backtests.md
+++ b/docs/backtests.md
@@ -105,11 +105,6 @@ from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
 
-NAME = "polymarket_quote_tick_ema_crossover"
-DESCRIPTION = "EMA crossover momentum on one Polymarket market"
-EMIT_HTML = True
-CHART_OUTPUT_PATH = "output"
-
 DATA = MarketDataConfig(
     platform=Polymarket,
     data_type=QuoteTick,
@@ -162,8 +157,8 @@ EXECUTION = ExecutionModelConfig(
 )
 
 EXPERIMENT = build_replay_experiment(
-    name=NAME,
-    description=DESCRIPTION,
+    name="polymarket_quote_tick_ema_crossover",
+    description="EMA crossover momentum on one Polymarket market",
     data=DATA,
     replays=REPLAYS,
     strategy_configs=STRATEGY_CONFIGS,
@@ -174,8 +169,8 @@ EXPERIMENT = build_replay_experiment(
     execution=EXECUTION,
     report=REPORT,
     empty_message="No sims met the quote-tick requirements.",
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=True,
+    chart_output_path="output",
 )
 
 @timing_harness
@@ -185,10 +180,6 @@ def run() -> None:
 
 Every public runner should expose:
 
-- `NAME`
-- `DESCRIPTION`
-- `EMIT_HTML`
-- `CHART_OUTPUT_PATH`
 - `DETAIL_PLOT_PANELS` when the runner emits per-sim legacy HTML charts
 - `SUMMARY_REPORT_PATH` when the runner emits one aggregate multi-market HTML page
 - `SUMMARY_PLOT_PANELS` when the runner emits an aggregate multi-market HTML page
@@ -201,23 +192,26 @@ Every public runner should expose:
 - `EXPERIMENT`
 - `run()`
 
-Use `CHART_OUTPUT_PATH="output"` for the normal public-runner default. The
-shared runner layer resolves that relative path from the repo root so it lands
-under this repo's `output/` directory consistently.
+The runner's `name`, `description`, `emit_html`, and `chart_output_path` are
+passed as literal kwargs directly into `build_replay_experiment(...)` rather
+than being exposed as top-level module constants. Use
+`chart_output_path="output"` for the normal public-runner default. The shared
+runner layer resolves that relative path from the repo root so it lands under
+this repo's `output/` directory consistently.
 
 Optimizer runners are the one deliberate variant in that contract. Parameter
 search runners expose `BASE_REPLAY`, `TRAIN_WINDOWS`, `HOLDOUT_WINDOWS`,
 `STRATEGY_SPEC`, `PARAMETER_GRID`, and `PARAMETER_SEARCH` instead of `REPLAYS`
-plus chart-summary report fields. They still keep `NAME`, `DESCRIPTION`,
-`EMIT_HTML`, `CHART_OUTPUT_PATH`, `DATA`, `EXECUTION`, `EXPERIMENT`, and
-`run()` at top level so the menu, tests, and direct runner path stay uniform.
+plus chart-summary report fields. They still keep `DATA`, `EXECUTION`,
+`EXPERIMENT`, and `run()` at top level so the menu, tests, and direct runner
+path stay uniform.
 
 ## HTML And Report Modes
 
 The repo-layer runner contract distinguishes two different output shapes:
 
 - per-sim legacy chart:
-  controlled by `EMIT_HTML`, `CHART_OUTPUT_PATH`, and `DETAIL_PLOT_PANELS`
+  controlled by `emit_html`, `chart_output_path`, and `DETAIL_PLOT_PANELS`
 - aggregate multi-market report:
   controlled by `REPORT.summary_report=True`, `SUMMARY_REPORT_PATH`, and
   `SUMMARY_PLOT_PANELS`
@@ -231,7 +225,7 @@ Those are not interchangeable:
 The corresponding runner patterns are:
 
 - single-market runner:
-  `EMIT_HTML = True`, `CHART_OUTPUT_PATH = "output"`, and
+  `emit_html=True`, `chart_output_path="output"`, and
   `DETAIL_PLOT_PANELS = (...)`
 - joint-portfolio runner:
   the single-market settings plus `SUMMARY_REPORT_PATH`,
@@ -263,8 +257,6 @@ Panel selection guidance lives in [`plotting.md`](plotting.md#scaling-model).
 Minimal shapes:
 
 ```python
-EMIT_HTML = True
-CHART_OUTPUT_PATH = "output"
 DETAIL_PLOT_PANELS = (
     "equity",
     "market_pnl",
@@ -284,7 +276,7 @@ DETAIL_PLOT_PANELS = (
 ```
 
 ```python
-SUMMARY_REPORT_PATH = f"output/{NAME}_joint_portfolio.html"
+SUMMARY_REPORT_PATH = "output/polymarket_quote_tick_joint_portfolio_runner_joint_portfolio.html"
 SUMMARY_PLOT_PANELS = (
     "total_equity",
     "total_drawdown",
@@ -304,8 +296,8 @@ REPORT = MarketReportConfig(
 
 EXPERIMENT = build_replay_experiment(
     ...,
-    emit_html=EMIT_HTML,
-    chart_output_path=CHART_OUTPUT_PATH,
+    emit_html=False,
+    chart_output_path="output",
     detail_plot_panels=DETAIL_PLOT_PANELS,
     return_summary_series=True,
     multi_replay_mode="joint_portfolio",
@@ -316,7 +308,7 @@ Practical constraints:
 
 - `SUMMARY_REPORT_PATH` depends on summary-series data, so the experiment must
   opt into `return_summary_series=True`
-- `CHART_OUTPUT_PATH` templates may reference only `{name}` and `{market_id}`
+- `chart_output_path` templates may reference only `{name}` and `{market_id}`
 - panel lists are ordered tuples of stable ids, so inclusion and layout order
   are explicit in the runner file
 - known-but-unavailable panels are skipped; unknown panel ids raise immediately
@@ -348,7 +340,7 @@ The public optimizer example is:
 - [`backtests/polymarket_quote_tick_ema_optimizer.py`](https://github.com/evan-kolberg/prediction-market-backtesting/blob/v2/backtests/polymarket_quote_tick_ema_optimizer.py)
 
 That runner is intentionally research-oriented. It writes leaderboard and
-summary artifacts under `output/` by default and keeps `EMIT_HTML = False` so
+summary artifacts under `output/` by default and keeps `emit_html=False` so
 one parameter sweep does not emit one legacy chart per trial.
 
 ## Designing Good Runner Files
@@ -422,7 +414,7 @@ uv run python backtests/polymarket_quote_tick_joint_portfolio_runner.py
 uv run python backtests/polymarket_quote_tick_independent_multi_replay_runner.py
 ```
 
-When a runner keeps `CHART_OUTPUT_PATH="output"`, those direct commands still
+When a runner keeps `chart_output_path="output"`, those direct commands still
 write into this repo's `output/` directory. The shared runner layer resolves
 that relative path from the repo root rather than from your shell's current
 working directory.
@@ -432,7 +424,7 @@ pin absolute sample windows; public Kalshi trade-tick runners also pin
 `end_time` so the bundled market stays directly runnable. Native trade-tick
 runners without that pin still use rolling lookbacks. If you want a different
 market, window, cash value, vendor source priority, or chart behavior, edit
-`DATA`, `REPLAYS`, `STRATEGY_CONFIGS`, `EMIT_HTML`, or `CHART_OUTPUT_PATH` in
+`DATA`, `REPLAYS`, `STRATEGY_CONFIGS`, or the `emit_html` / `chart_output_path` kwargs in
 the runner file, or copy the file into
 `backtests/private/` and customize it there.
 
@@ -482,8 +474,9 @@ definition. The file itself should carry the actual values.
 
 Use these top-level objects as the edit surface:
 
-- `EMIT_HTML` to skip per-run HTML output when you are sweeping many runners
-- `CHART_OUTPUT_PATH` for an explicit file, directory, or `{name}` /
+- the `emit_html` kwarg on `build_replay_experiment(...)` to skip per-run HTML
+  output when you are sweeping many runners
+- the `chart_output_path` kwarg for an explicit file, directory, or `{name}` /
   `{market_id}` template
 - `DETAIL_PLOT_PANELS` for explicit per-sim panel inclusion and ordering
 - `SUMMARY_REPORT_PATH` for one aggregate HTML report when the runner should

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -14,9 +14,10 @@ overall?"
 
 Every public runner now exposes explicit plotting controls at top level:
 
-- `EMIT_HTML` turns per-run HTML generation on or off in the file itself
-- `CHART_OUTPUT_PATH` keeps the destination explicit instead of hiding it in
-  shared defaults
+- the `emit_html` kwarg on `build_replay_experiment(...)` turns per-run HTML
+  generation on or off in the file itself
+- the `chart_output_path` kwarg keeps the destination explicit instead of
+  hiding it in shared defaults
 - `DETAIL_PLOT_PANELS` chooses which per-sim panels render and in what order
 - `SUMMARY_PLOT_PANELS` chooses which aggregate multi-market panels render and
   in what order when a runner emits a summary report
@@ -118,7 +119,7 @@ the selected `SUMMARY_PLOT_PANELS` do not include panels that render them.
 There are two distinct HTML/report modes in the repo layer:
 
 - per-sim legacy chart:
-  enabled by `EMIT_HTML = True` and written under `CHART_OUTPUT_PATH`
+  enabled by `emit_html=True` and written under `chart_output_path`
 - aggregate multi-market report:
   enabled by `REPORT.summary_report=True` plus `SUMMARY_REPORT_PATH`; this is a
   true aggregate report built from summary series, not a pasted-together page
@@ -126,17 +127,17 @@ There are two distinct HTML/report modes in the repo layer:
 Typical public-runner combinations:
 
 - single-market runner:
-  `EMIT_HTML=True`, `CHART_OUTPUT_PATH`, and `DETAIL_PLOT_PANELS`
+  `emit_html=True`, `chart_output_path="output"`, and `DETAIL_PLOT_PANELS`
 - joint-portfolio basket runner:
-  `EMIT_HTML=False` (no per-replay detail charts), summary-only via
+  `emit_html=False` (no per-replay detail charts), summary-only via
   `SUMMARY_REPORT_PATH` and `multi_replay_mode="joint_portfolio"`
 - independent basket runner:
-  `EMIT_HTML=False` (no per-replay detail charts), summary-only via
+  `emit_html=False` (no per-replay detail charts), summary-only via
   `SUMMARY_REPORT_PATH` and `multi_replay_mode="independent"`
 
-Multi-market runners default to `EMIT_HTML=False` because per-replay detail
+Multi-market runners default to `emit_html=False` because per-replay detail
 charts are expensive to generate and rarely needed when the summary report is
-the primary output. Set `EMIT_HTML=True` on a multi-market runner if you need
+the primary output. Set `emit_html=True` on a multi-market runner if you need
 per-replay drilldown charts.
 
 This gives users a fast, focused artifact:
@@ -144,7 +145,7 @@ This gives users a fast, focused artifact:
 - the basket summary stays readable because it is built from summary-series data
 - single-market runners keep rich, execution-focused detail charts
 - if per-replay drilldown is needed on a multi-market runner, re-enable
-  `EMIT_HTML=True` for that run
+  `emit_html=True` for that run
 
 Important runtime details:
 
@@ -164,7 +165,7 @@ contract details live in [`backtests.md`](backtests.md#html-and-report-modes).
 ## Output Paths
 
 Public runners now spell the default destination out as
-`CHART_OUTPUT_PATH="output"`. The shared runner layer resolves that relative
+`chart_output_path="output"`. The shared runner layer resolves that relative
 path from the repo root, so it consistently lands in this repo's `output/`
 directory instead of depending on the shell's current working directory.
 
@@ -178,16 +179,16 @@ uv run python backtests/polymarket_quote_tick_ema_crossover.py
 The generated HTML lands under `prediction-market-backtesting/output/`, not
 under whichever directory you launched the command from.
 
-The shared runner layer still accepts `CHART_OUTPUT_PATH=None` as a legacy
+The shared runner layer still accepts `chart_output_path=None` as a legacy
 shorthand for the same repo-root `output/` destination, but public runner files
 should be explicit.
 
 If you want to override that, set:
 
-- `CHART_OUTPUT_PATH="output/custom.html"` for one explicit file path
-- `CHART_OUTPUT_PATH="output/charts"` for one explicit directory
-- `CHART_OUTPUT_PATH="output/{name}_{market_id}.html"` for an explicit template
-- `CHART_OUTPUT_PATH="/absolute/path/to/charts"` for a true absolute path
+- `chart_output_path="output/custom.html"` for one explicit file path
+- `chart_output_path="output/charts"` for one explicit directory
+- `chart_output_path="output/{name}_{market_id}.html"` for an explicit template
+- `chart_output_path="/absolute/path/to/charts"` for a true absolute path
 
 Only `{name}` and `{market_id}` are valid template placeholders.
 
@@ -206,7 +207,7 @@ Charts are written to `output/`, typically with names like:
 
 The default naming rules are:
 
-- `CHART_OUTPUT_PATH="output"`:
+- `chart_output_path="output"`:
   `output/<runner_name>_<market_or_sim_label>_legacy.html`
 - `SUMMARY_REPORT_PATH="output/<runner_name>_joint_portfolio.html"`:
   one shared-account report spanning the whole basket
@@ -254,7 +255,7 @@ The clearest multi-market plotting runner files:
 - [`backtests/polymarket_quote_tick_independent_25_replay_runner.py`](https://github.com/evan-kolberg/prediction-market-backtesting/blob/v2/backtests/polymarket_quote_tick_independent_25_replay_runner.py)
 
 Those runners now write one basket summary chart under `output/` (per-replay
-detail charts are off by default via `EMIT_HTML=False`):
+detail charts are off by default via `emit_html=False`):
 
 - `output/kalshi_trade_tick_joint_portfolio_runner_joint_portfolio.html`
 - `output/polymarket_trade_tick_independent_multi_replay_runner_independent_aggregate.html`

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -102,6 +102,13 @@ downsampling the same data produces under 1 MB. The `test_downsample_html_size`
 test suite enforces that a 100 K-bar backtest stays under 5 MB and that
 doubling bar count does not meaningfully increase file size.
 
+When building summary series for multi-market reports, the artifact pipeline
+also downsamples price points to 5 000 before constructing dense equity curves.
+This avoids rebuilding full-resolution portfolio timelines (often 300K–600K
+points per market) that would be downsampled again in the chart layer anyway.
+This early downsampling reduces artifact build time from minutes to seconds on
+large baskets.
+
 Summary reports built by the aggregate and joint-portfolio report paths also
 skip serializing per-market price series, fill events, and overlay curves when
 the selected `SUMMARY_PLOT_PANELS` do not include panels that render them.
@@ -119,20 +126,25 @@ There are two distinct HTML/report modes in the repo layer:
 Typical public-runner combinations:
 
 - single-market runner:
-  `EMIT_HTML`, `CHART_OUTPUT_PATH`, and `DETAIL_PLOT_PANELS`
+  `EMIT_HTML=True`, `CHART_OUTPUT_PATH`, and `DETAIL_PLOT_PANELS`
 - joint-portfolio basket runner:
-  per-replay legacy charts plus `SUMMARY_REPORT_PATH` and
-  `multi_replay_mode="joint_portfolio"`
+  `EMIT_HTML=False` (no per-replay detail charts), summary-only via
+  `SUMMARY_REPORT_PATH` and `multi_replay_mode="joint_portfolio"`
 - independent basket runner:
-  per-replay legacy charts plus `SUMMARY_REPORT_PATH` and
-  `multi_replay_mode="independent"`
+  `EMIT_HTML=False` (no per-replay detail charts), summary-only via
+  `SUMMARY_REPORT_PATH` and `multi_replay_mode="independent"`
 
-This gives users two clean artifacts instead of one overloaded one:
+Multi-market runners default to `EMIT_HTML=False` because per-replay detail
+charts are expensive to generate and rarely needed when the summary report is
+the primary output. Set `EMIT_HTML=True` on a multi-market runner if you need
+per-replay drilldown charts.
 
-- detail charts stay rich and execution-focused for one replay
+This gives users a fast, focused artifact:
+
 - the basket summary stays readable because it is built from summary-series data
-- large baskets still keep drilldown, because each replay can keep its own
-  full-detail HTML artifact
+- single-market runners keep rich, execution-focused detail charts
+- if per-replay drilldown is needed on a multi-market runner, re-enable
+  `EMIT_HTML=True` for that run
 
 Important runtime details:
 
@@ -241,15 +253,12 @@ The clearest multi-market plotting runner files:
 - [`backtests/polymarket_quote_tick_independent_multi_replay_runner.py`](https://github.com/evan-kolberg/prediction-market-backtesting/blob/v2/backtests/polymarket_quote_tick_independent_multi_replay_runner.py)
 - [`backtests/polymarket_quote_tick_independent_25_replay_runner.py`](https://github.com/evan-kolberg/prediction-market-backtesting/blob/v2/backtests/polymarket_quote_tick_independent_25_replay_runner.py)
 
-Those runners now write one per-market legacy chart per replay and one basket
-summary chart under `output/`, typically with names like:
+Those runners now write one basket summary chart under `output/` (per-replay
+detail charts are off by default via `EMIT_HTML=False`):
 
-- `output/kalshi_trade_tick_joint_portfolio_runner_<market>_legacy.html`
-- `output/polymarket_trade_tick_independent_multi_replay_runner_<market>_legacy.html`
 - `output/kalshi_trade_tick_joint_portfolio_runner_joint_portfolio.html`
 - `output/polymarket_trade_tick_independent_multi_replay_runner_independent_aggregate.html`
 
-The PMXT basket example runners write per-replay detail charts plus one summary
-chart:
+The PMXT basket example runners write one summary chart:
 
 - `output/polymarket_quote_tick_joint_portfolio_runner_joint_portfolio.html`

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -19,6 +19,10 @@ No repo-level open issues are tracked here right now.
 
 ## Recently Fixed
 
+- [x] multi-market runners now default to `EMIT_HTML=False` and the artifact
+  pipeline downsamples price points to 5 000 before building dense equity
+  curves, cutting wall time from ~320s to ~26s on an 8-market basket
+  [PR#84](https://github.com/evan-kolberg/prediction-market-backtesting/pull/84)
 - [x] HTML chart files are now downsampled to ~5 000 points before Bokeh
   serialization, reducing a 446 K-bar chart from 31 MB to under 1 MB;
   redundant ColumnDataSource columns and intermediate DataFrames were also

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -82,7 +82,7 @@ uv run python backtests/polymarket_quote_tick_independent_multi_replay_runner.py
 ```
 
 Those direct runs write HTML artifacts into the repo-local `output/` directory
-when the runner keeps `CHART_OUTPUT_PATH="output"`.
+when the runner keeps `chart_output_path="output"`.
 
 For a research-oriented notebook example, select
 `backtests/generic_optimizer_research.ipynb` from the menu. It targets any

--- a/main.py
+++ b/main.py
@@ -4,10 +4,13 @@
 Discovers runnable modules in flat runner entrypoints under `backtests/` and
 `backtests/private/` and presents an interactive menu. Each backtest file must expose:
 
-    NAME        str   — display name shown in the menu
-    DESCRIPTION str   — one-line description shown in the menu
-    EXPERIMENT  object — manifest executed by the shared experiment dispatcher
+    EXPERIMENT  object — manifest executed by the shared experiment dispatcher,
+                         constructed with explicit `name=` and `description=` kwargs
     run()       sync or async — optional thin entry point called when selected
+
+The display name and one-line description are pulled from the `name=` and
+`description=` kwargs of the EXPERIMENT constructor call via AST scanning so the
+menu does not need to import each runner module on startup.
 
 Run via:
     uv run python main.py
@@ -120,6 +123,25 @@ def _has_assignment(module_ast: ast.Module, target_name: str) -> bool:
     return False
 
 
+def _experiment_constructor_kwargs(module_ast: ast.Module) -> dict[str, str] | None:
+    """Extract `name=`/`description=` literal kwargs from the EXPERIMENT assignment call."""
+    for node in module_ast.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        if "EXPERIMENT" not in _assignment_targets(node):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        kwargs: dict[str, str] = {}
+        for keyword in node.value.keywords:
+            if keyword.arg in {"name", "description"}:
+                literal = _literal_string(keyword.value)
+                if literal is not None:
+                    kwargs[keyword.arg] = literal
+        return kwargs
+    return None
+
+
 def _has_run_entrypoint(module_ast: ast.Module) -> bool:
     for node in module_ast.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run":
@@ -152,19 +174,14 @@ def _load_runner_metadata(path: Path) -> dict[str, Any] | None:
 
     name = path.stem
     description = ""
-    for node in module_ast.body:
-        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
-            continue
-        targets = _assignment_targets(node)
-        if not targets:
-            continue
-        literal = _literal_string(node.value)
-        if literal is None:
-            continue
-        if "NAME" in targets:
-            name = literal
-        if "DESCRIPTION" in targets:
-            description = literal
+    experiment_kwargs = _experiment_constructor_kwargs(module_ast)
+    if experiment_kwargs is not None:
+        kw_name = experiment_kwargs.get("name")
+        kw_description = experiment_kwargs.get("description")
+        if kw_name:
+            name = kw_name
+        if kw_description:
+            description = kw_description
 
     return {
         "name": name,

--- a/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
+++ b/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
@@ -136,6 +136,39 @@ def extract_price_points(
     return points
 
 
+def downsample_price_points(
+    points: list[PricePoint], max_points: int = 5000
+) -> list[PricePoint]:
+    """Stride-based downsampling that preserves first, last, and price extrema."""
+    n = len(points)
+    if n <= max_points:
+        return points
+
+    prices = [p for _, p in points]
+    must_keep = {0, n - 1}
+    # Preserve global min/max price indices
+    min_idx = 0
+    max_idx = 0
+    for i, p in enumerate(prices):
+        if p < prices[min_idx]:
+            min_idx = i
+        if p > prices[max_idx]:
+            max_idx = i
+    must_keep.add(min_idx)
+    must_keep.add(max_idx)
+
+    budget = max(100, max_points - len(must_keep))
+    stride = max(1, n // budget)
+    selected = sorted(must_keep | set(range(0, n, stride)))
+    if len(selected) > max_points:
+        strided = set(range(0, n, stride))
+        remaining = max_points - len(must_keep)
+        stride2 = max(1, len(strided) // remaining) if remaining > 0 else n
+        selected = sorted(must_keep | set(list(sorted(strided))[::stride2]))
+
+    return [points[i] for i in selected]
+
+
 def _probability_frame(points: Sequence[PricePoint]) -> pd.DataFrame:
     rows: list[tuple[pd.Timestamp, float]] = []
     for ts_raw, price in points:

--- a/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
+++ b/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
@@ -136,9 +136,7 @@ def extract_price_points(
     return points
 
 
-def downsample_price_points(
-    points: list[PricePoint], max_points: int = 5000
-) -> list[PricePoint]:
+def downsample_price_points(points: list[PricePoint], max_points: int = 5000) -> list[PricePoint]:
     """Stride-based downsampling that preserves first, last, and price extrema."""
     n = len(points)
     if n <= max_points:

--- a/prediction_market_extensions/backtesting/prediction_market/artifacts.py
+++ b/prediction_market_extensions/backtesting/prediction_market/artifacts.py
@@ -20,6 +20,9 @@ from prediction_market_extensions.adapters.prediction_market.backtest_utils impo
     build_market_prices,
 )
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
+    downsample_price_points,
+)
+from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_price_points,
 )
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
@@ -136,6 +139,7 @@ class PredictionMarketArtifactBuilder:
                 loaded_sim.records,
                 price_attr="mid_price" if self.data_type == "quote_tick" else "price",
             )
+            price_points = downsample_price_points(price_points, max_points=5000)
             market_prices_by_market_id[loaded_sim.market_id] = build_market_prices(
                 price_points, resample_rule=self.chart_resample_rule
             )
@@ -178,10 +182,16 @@ class PredictionMarketArtifactBuilder:
         fills_report: pd.DataFrame,
         include_portfolio_series: bool,
     ) -> dict[str, Any]:
+        needs_detail_chart = self.emit_html or self.return_chart_layout
+        summary_only = self.return_summary_series and not needs_detail_chart
+
         price_points = extract_price_points(
             loaded_sim.records,
             price_attr="mid_price" if self.data_type == "quote_tick" else "price",
         )
+        if summary_only:
+            price_points = downsample_price_points(price_points, max_points=5000)
+
         market_prices = build_market_prices(price_points, resample_rule=self.chart_resample_rule)
         user_probabilities, market_probabilities, outcomes = build_brier_inputs(
             price_points,
@@ -192,7 +202,7 @@ class PredictionMarketArtifactBuilder:
 
         chart_layout = None
         chart_title = f"{self.name}:{loaded_sim.market_id} legacy chart"
-        if self.emit_html or self.return_chart_layout:
+        if needs_detail_chart:
             output_path = self.resolve_chart_output_path(market_id=loaded_sim.market_id)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             try:

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -86,7 +86,7 @@ def test_direct_script_entrypoints_import_without_repo_root_on_sys_path(
 
     globals_dict = runpy.run_path(str(script_path), run_name="__script_test__")
 
-    assert "NAME" in globals_dict
+    assert "EXPERIMENT" in globals_dict
     assert "run" in globals_dict
 
 
@@ -143,12 +143,6 @@ def test_public_runner_modules_expose_metadata_contract(
 
     globals_dict = runpy.run_path(str(script_path), run_name="__script_test__")
 
-    assert isinstance(globals_dict.get("NAME"), str) and globals_dict["NAME"]
-    assert isinstance(globals_dict.get("DESCRIPTION"), str) and globals_dict["DESCRIPTION"]
-    assert isinstance(globals_dict.get("EMIT_HTML"), bool)
-    assert "CHART_OUTPUT_PATH" in globals_dict
-    assert isinstance(globals_dict["CHART_OUTPUT_PATH"], str)
-    assert globals_dict["CHART_OUTPUT_PATH"]
     if "DATA" in globals_dict:
         data = globals_dict["DATA"]
         assert getattr(data, "platform", None) in {"kalshi", "polymarket"}
@@ -157,28 +151,20 @@ def test_public_runner_modules_expose_metadata_contract(
         assert isinstance(getattr(data, "sources", ()), tuple)
     if "EXPERIMENT" in globals_dict:
         experiment = globals_dict["EXPERIMENT"]
+        assert isinstance(getattr(experiment, "name", None), str) and experiment.name
+        assert isinstance(getattr(experiment, "description", None), str) and experiment.description
         optimization = getattr(experiment, "optimization", None)
-        if optimization is not None:
-            assert getattr(optimization, "emit_html", None) == globals_dict["EMIT_HTML"]
-            assert (
-                getattr(optimization, "chart_output_path", object())
-                == globals_dict["CHART_OUTPUT_PATH"]
-            )
-        else:
-            assert getattr(experiment, "emit_html", None) == globals_dict["EMIT_HTML"]
-            assert (
-                getattr(experiment, "chart_output_path", object())
-                == globals_dict["CHART_OUTPUT_PATH"]
-            )
+        target = optimization if optimization is not None else experiment
+        assert isinstance(getattr(target, "emit_html", None), bool)
+        assert isinstance(getattr(target, "chart_output_path", None), str)
+        assert target.chart_output_path
     parameter_search = globals_dict.get(
         "PARAMETER_SEARCH", globals_dict.get("OPTIMIZER", globals_dict.get("OPTIMIZATION"))
     )
     if parameter_search is not None:
-        assert getattr(parameter_search, "emit_html", None) == globals_dict["EMIT_HTML"]
-        assert (
-            getattr(parameter_search, "chart_output_path", object())
-            == globals_dict["CHART_OUTPUT_PATH"]
-        )
+        assert isinstance(getattr(parameter_search, "emit_html", None), bool)
+        assert isinstance(getattr(parameter_search, "chart_output_path", None), str)
+        assert parameter_search.chart_output_path
     assert callable(globals_dict.get("run"))
 
 
@@ -246,8 +232,6 @@ def test_pmxt_single_market_quote_tick_runners_expose_explicit_experiment_consta
     assert replays[0].market_slug
     assert replays[0].start_time
     assert replays[0].end_time
-    assert globals_dict["EMIT_HTML"] is True
-    assert globals_dict["CHART_OUTPUT_PATH"] == "output"
     assert experiment.initial_cash == 100.0
     assert experiment.min_quotes == 500
     assert experiment.min_price_range == 0.005
@@ -270,13 +254,11 @@ def test_pmxt_quote_tick_independent_runners_expose_explicit_summary_contract(
     report = globals_dict["REPORT"]
     experiment = globals_dict["EXPERIMENT"]
 
-    assert globals_dict["NAME"] == relative_path.stem
+    assert experiment.name == relative_path.stem
     assert data.platform == "polymarket"
     assert data.data_type == "quote_tick"
     assert data.vendor == "pmxt"
     assert len(replays) > 1
-    assert globals_dict["EMIT_HTML"] is False
-    assert globals_dict["CHART_OUTPUT_PATH"] == "output"
     assert isinstance(globals_dict["SUMMARY_PLOT_PANELS"], tuple)
     assert globals_dict["SUMMARY_PLOT_PANELS"]
     assert report.summary_report is True
@@ -302,11 +284,12 @@ def test_pmxt_quote_tick_joint_runners_expose_explicit_summary_contract(
     experiment = globals_dict["EXPERIMENT"]
     report = globals_dict["REPORT"]
 
-    assert globals_dict["NAME"] == relative_path.stem
+    assert experiment.name == relative_path.stem
     assert report.summary_report is True
     assert report.summary_report_path == globals_dict["SUMMARY_REPORT_PATH"]
     assert experiment.return_summary_series is True
     assert experiment.multi_replay_mode == "joint_portfolio"
+    assert experiment.emit_html is False
     assert experiment.chart_output_path == "output"
 
 
@@ -348,8 +331,6 @@ def test_pmxt_quote_tick_optimizer_runners_expose_explicit_search_configuration(
     assert parameter_search.data is data
     assert parameter_search.base_replay is base_replay
     assert parameter_search.strategy_spec is globals_dict["STRATEGY_SPEC"]
-    assert globals_dict["EMIT_HTML"] is True
-    assert globals_dict["CHART_OUTPUT_PATH"] == "output"
     assert parameter_search.emit_html is True
     assert parameter_search.chart_output_path == "output"
     assert dict(parameter_search.parameter_grid) == parameter_grid
@@ -374,8 +355,8 @@ def test_trade_tick_independent_runners_emit_summary_contract(
     experiment = globals_dict["EXPERIMENT"]
     report = globals_dict["REPORT"]
 
-    assert globals_dict["EMIT_HTML"] is False
-    assert globals_dict["CHART_OUTPUT_PATH"] == "output"
+    assert experiment.emit_html is False
+    assert experiment.chart_output_path == "output"
     assert experiment.return_summary_series is True
     assert experiment.multi_replay_mode == "independent"
     assert report.summary_report is True
@@ -395,8 +376,8 @@ def test_trade_tick_joint_runners_emit_summary_contract(
     experiment = globals_dict["EXPERIMENT"]
     report = globals_dict["REPORT"]
 
-    assert globals_dict["EMIT_HTML"] is False
-    assert globals_dict["CHART_OUTPUT_PATH"] == "output"
+    assert experiment.emit_html is False
+    assert experiment.chart_output_path == "output"
     assert experiment.return_summary_series is True
     assert experiment.multi_replay_mode == "joint_portfolio"
     assert report.summary_report is True

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -275,7 +275,7 @@ def test_pmxt_quote_tick_independent_runners_expose_explicit_summary_contract(
     assert data.data_type == "quote_tick"
     assert data.vendor == "pmxt"
     assert len(replays) > 1
-    assert globals_dict["EMIT_HTML"] is True
+    assert globals_dict["EMIT_HTML"] is False
     assert globals_dict["CHART_OUTPUT_PATH"] == "output"
     assert isinstance(globals_dict["SUMMARY_PLOT_PANELS"], tuple)
     assert globals_dict["SUMMARY_PLOT_PANELS"]
@@ -284,7 +284,7 @@ def test_pmxt_quote_tick_independent_runners_expose_explicit_summary_contract(
     assert report.summary_plot_panels == globals_dict["SUMMARY_PLOT_PANELS"]
     assert experiment.return_summary_series is True
     assert experiment.multi_replay_mode == "independent"
-    assert experiment.emit_html is True
+    assert experiment.emit_html is False
     assert experiment.chart_output_path == "output"
     assert experiment.detail_plot_panels == globals_dict["DETAIL_PLOT_PANELS"]
 
@@ -374,7 +374,7 @@ def test_trade_tick_independent_runners_emit_summary_contract(
     experiment = globals_dict["EXPERIMENT"]
     report = globals_dict["REPORT"]
 
-    assert globals_dict["EMIT_HTML"] is True
+    assert globals_dict["EMIT_HTML"] is False
     assert globals_dict["CHART_OUTPUT_PATH"] == "output"
     assert experiment.return_summary_series is True
     assert experiment.multi_replay_mode == "independent"
@@ -395,7 +395,7 @@ def test_trade_tick_joint_runners_emit_summary_contract(
     experiment = globals_dict["EXPERIMENT"]
     report = globals_dict["REPORT"]
 
-    assert globals_dict["EMIT_HTML"] is True
+    assert globals_dict["EMIT_HTML"] is False
     assert globals_dict["CHART_OUTPUT_PATH"] == "output"
     assert experiment.return_summary_series is True
     assert experiment.multi_replay_mode == "joint_portfolio"

--- a/tests/test_kalshi_backtests.py
+++ b/tests/test_kalshi_backtests.py
@@ -65,7 +65,7 @@ def test_kalshi_single_runner_builds_expected_trade_tick_strategy(
     assert isinstance(strategy, TradeTickBreakoutStrategy)
     assert isinstance(strategy.config, TradeTickBreakoutConfig)
     assert module.REPLAYS == (EXPECTED_SINGLE_REPLAY,)
-    assert module.EXPERIMENT.name == module.NAME
+    assert module.EXPERIMENT.name == "kalshi_trade_tick_breakout"
     assert module.EXPERIMENT.data == module.DATA
     assert module.EXPERIMENT.replays == module.REPLAYS
     assert module.EXPERIMENT.initial_cash == 100.0

--- a/tests/test_kalshi_ema_crossover.py
+++ b/tests/test_kalshi_ema_crossover.py
@@ -10,10 +10,18 @@ import backtests.kalshi_trade_tick_breakout as strat
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _chart_path() -> Path:
+    return (
+        REPO_ROOT
+        / "output"
+        / f"kalshi_trade_tick_breakout_{strat.REPLAYS[0].market_ticker}_legacy.html"
+    )
+
+
 @pytest.fixture(autouse=True)
 def _clean_chart_output():
     """Keep the repo-root chart artifact deterministic across test runs."""
-    chart = REPO_ROOT / "output" / f"{strat.NAME}_{strat.REPLAYS[0].market_ticker}_legacy.html"
+    chart = _chart_path()
     chart.unlink(missing_ok=True)
     yield
     chart.unlink(missing_ok=True)
@@ -23,6 +31,6 @@ def test_full_run_produces_legacy_chart():
     """Full pipeline runs without error and writes a legacy HTML chart."""
     strat.run()
 
-    chart = REPO_ROOT / "output" / f"{strat.NAME}_{strat.REPLAYS[0].market_ticker}_legacy.html"
+    chart = _chart_path()
     assert chart.exists(), "Legacy chart not created"
     assert chart.stat().st_size > 0, "Legacy chart file is empty"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -226,8 +226,7 @@ def test_discover_reads_metadata_without_importing_modules(tmp_path: Path, monke
     backtests_root.mkdir()
     (backtests_root / "__init__.py").write_text("", encoding="utf-8")
     (backtests_root / "demo_runner.py").write_text(
-        'NAME = "custom_demo"\n'
-        'DESCRIPTION = "Demo runner"\n'
+        'EXPERIMENT = build_replay_experiment(name="custom_demo", description="Demo runner")\n'
         'raise RuntimeError("should not import during discovery")\n'
         "def run() -> None:\n"
         "    pass\n",

--- a/tests/test_polymarket_trade_tick_multi_runner.py
+++ b/tests/test_polymarket_trade_tick_multi_runner.py
@@ -186,8 +186,11 @@ def test_trade_tick_independent_runner_uses_run_experiment(
 
     module.run()
 
-    assert module.CHART_OUTPUT_PATH == "output"
-    assert module.SUMMARY_REPORT_PATH == f"output/{module.NAME}_independent_aggregate.html"
+    assert module.EXPERIMENT.chart_output_path == "output"
+    assert (
+        module.SUMMARY_REPORT_PATH
+        == "output/polymarket_trade_tick_independent_multi_replay_runner_independent_aggregate.html"
+    )
     assert module.REPORT.summary_report is True
     assert module.REPORT.summary_report_path == module.SUMMARY_REPORT_PATH
     assert module.EXPERIMENT.chart_output_path == "output"

--- a/tests/test_quote_tick_runner_contract.py
+++ b/tests/test_quote_tick_runner_contract.py
@@ -19,7 +19,7 @@ EXPECTED_PMXT_LATENCY = {
     "cancel_latency_ms": 5.0,
 }
 EXPECTED_RUNNER_EMIT_HTML = True
-EXPECTED_MULTI_RUNNER_EMIT_HTML = True
+EXPECTED_MULTI_RUNNER_EMIT_HTML = False
 EXPECTED_OPTIMIZER_EMIT_HTML = True
 EXPECTED_CHART_OUTPUT_PATH = "output"
 EXPECTED_DETAIL_PLOT_PANELS = (
@@ -176,7 +176,7 @@ def test_quote_tick_joint_runner_uses_explicit_summary_plot_contract() -> None:
 def test_quote_tick_25_sim_runner_uses_explicit_summary_plot_contract() -> None:
     module = _import_runner(RUNNER_25)
 
-    assert module.EMIT_HTML is EXPECTED_RUNNER_EMIT_HTML
+    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
     assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
     assert module.DETAIL_PLOT_PANELS == EXPECTED_DETAIL_PLOT_PANELS

--- a/tests/test_quote_tick_runner_contract.py
+++ b/tests/test_quote_tick_runner_contract.py
@@ -19,8 +19,6 @@ EXPECTED_PMXT_LATENCY = {
     "cancel_latency_ms": 5.0,
 }
 EXPECTED_RUNNER_EMIT_HTML = True
-EXPECTED_MULTI_RUNNER_EMIT_HTML = False
-EXPECTED_OPTIMIZER_EMIT_HTML = True
 EXPECTED_CHART_OUTPUT_PATH = "output"
 EXPECTED_DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -118,8 +116,6 @@ def _assert_latency_model(latency_model) -> None:
 def test_quote_tick_single_runner_uses_expected_runtime_contract() -> None:
     module = _import_runner(SINGLE_RUNNER)
 
-    assert module.EMIT_HTML is EXPECTED_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
     assert module.EXECUTION.queue_position is True
     _assert_latency_model(module.EXECUTION.latency_model)
@@ -135,8 +131,6 @@ def test_quote_tick_single_runner_uses_expected_runtime_contract() -> None:
 def test_quote_tick_independent_runner_uses_explicit_summary_plot_contract() -> None:
     module = _import_runner(INDEPENDENT_MULTI_RUNNER)
 
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
     assert module.DETAIL_PLOT_PANELS == EXPECTED_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_MULTI_SIM_SUMMARY_PLOT_PANELS
@@ -160,8 +154,6 @@ def test_quote_tick_independent_runner_uses_explicit_summary_plot_contract() -> 
 def test_quote_tick_joint_runner_uses_explicit_summary_plot_contract() -> None:
     module = _import_runner(JOINT_MULTI_RUNNER)
 
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
     assert module.DETAIL_PLOT_PANELS == EXPECTED_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_MULTI_SIM_SUMMARY_PLOT_PANELS
@@ -176,8 +168,6 @@ def test_quote_tick_joint_runner_uses_explicit_summary_plot_contract() -> None:
 def test_quote_tick_25_sim_runner_uses_explicit_summary_plot_contract() -> None:
     module = _import_runner(RUNNER_25)
 
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
     assert module.DETAIL_PLOT_PANELS == EXPECTED_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_25_SIM_SUMMARY_PLOT_PANELS
@@ -201,8 +191,6 @@ def test_quote_tick_25_sim_runner_uses_explicit_summary_plot_contract() -> None:
 def test_quote_tick_optimizer_runner_inline_explicit_search_controls() -> None:
     module = _import_runner(OPTIMIZER_RUNNER)
 
-    assert module.EMIT_HTML is EXPECTED_OPTIMIZER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DATA.sources == EXPECTED_PMXT_SOURCES
     assert module.EXECUTION.queue_position is True
     _assert_latency_model(module.EXECUTION.latency_model)

--- a/tests/test_trade_tick_runner_contract.py
+++ b/tests/test_trade_tick_runner_contract.py
@@ -147,8 +147,6 @@ def test_kalshi_trade_tick_single_runner_uses_expected_runtime_contract() -> Non
     module = _import_runner(KALSHI_SINGLE_RUNNER)
 
     assert module.DATA.sources == EXPECTED_KALSHI_TRADE_SOURCES
-    assert module.EMIT_HTML is EXPECTED_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DETAIL_PLOT_PANELS == EXPECTED_KALSHI_DETAIL_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_EMIT_HTML
     assert module.EXPERIMENT.chart_output_path == EXPECTED_CHART_OUTPUT_PATH
@@ -161,8 +159,6 @@ def test_kalshi_trade_tick_independent_runner_uses_expected_runtime_contract() -
     module = _import_runner(KALSHI_INDEPENDENT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_KALSHI_TRADE_SOURCES
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DETAIL_PLOT_PANELS == EXPECTED_KALSHI_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_MULTI_RUNNER_EMIT_HTML
@@ -180,8 +176,6 @@ def test_kalshi_trade_tick_joint_runner_uses_expected_runtime_contract() -> None
     module = _import_runner(KALSHI_JOINT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_KALSHI_TRADE_SOURCES
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DETAIL_PLOT_PANELS == EXPECTED_KALSHI_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.return_summary_series is True
@@ -193,8 +187,6 @@ def test_polymarket_trade_tick_single_runner_uses_expected_runtime_contract() ->
     module = _import_runner(POLYMARKET_SINGLE_RUNNER)
 
     assert module.DATA.sources == EXPECTED_POLYMARKET_TRADE_SOURCES
-    assert module.EMIT_HTML is EXPECTED_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DETAIL_PLOT_PANELS == EXPECTED_POLYMARKET_DETAIL_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_EMIT_HTML
     assert module.EXPERIMENT.chart_output_path == EXPECTED_CHART_OUTPUT_PATH
@@ -206,8 +198,6 @@ def test_polymarket_trade_tick_independent_runner_uses_fixed_replay_windows() ->
     module = _import_runner(POLYMARKET_INDEPENDENT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_POLYMARKET_TRADE_SOURCES
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DETAIL_PLOT_PANELS == EXPECTED_POLYMARKET_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_MULTI_RUNNER_EMIT_HTML
@@ -226,8 +216,6 @@ def test_polymarket_trade_tick_joint_runner_uses_fixed_replay_windows() -> None:
     module = _import_runner(POLYMARKET_JOINT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_POLYMARKET_TRADE_SOURCES
-    assert module.EMIT_HTML is EXPECTED_MULTI_RUNNER_EMIT_HTML
-    assert module.CHART_OUTPUT_PATH == EXPECTED_CHART_OUTPUT_PATH
     assert module.DETAIL_PLOT_PANELS == EXPECTED_POLYMARKET_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.return_summary_series is True

--- a/tests/test_trade_tick_runner_contract.py
+++ b/tests/test_trade_tick_runner_contract.py
@@ -8,7 +8,7 @@ from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 
 EXPECTED_INITIAL_CASH = 100.0
 EXPECTED_EMIT_HTML = True
-EXPECTED_MULTI_RUNNER_EMIT_HTML = True
+EXPECTED_MULTI_RUNNER_EMIT_HTML = False
 EXPECTED_CHART_OUTPUT_PATH = "output"
 EXPECTED_KALSHI_DETAIL_PLOT_PANELS = (
     "equity",


### PR DESCRIPTION
## Summary

- **Disable per-market HTML** on all 7 multi-market runners (independent + joint portfolio). Summary charts are still generated.
- **Downsample price points early** in the artifact pipeline before dense equity curve construction, avoiding O(N) work on millions of raw records that ultimately get downsampled to 5000 points for the summary chart anyway.
- Add `downsample_price_points()` utility (stride-based, preserves first/last/extrema) to `backtest_utils.py`.
- Update contract tests to reflect the new `emit_html=False` default for multi-market runners.
- **Inline `NAME` / `DESCRIPTION` / `EMIT_HTML` / `CHART_OUTPUT_PATH`** as literal kwargs into `build_replay_experiment(...)` across all 11 runner files. The lazy `main.py` menu now reads `name=` / `description=` from the `EXPERIMENT = ...` AST node instead of scanning for top-level constants.
- Update `docs/backtests.md`, `docs/plotting.md`, `docs/setup.md` to reflect the new runner contract.

### Performance

Profiled on `polymarket_quote_tick_joint_portfolio_runner` (8 markets, 2.97M events):

| Phase | Before | After |
|---|---|---|
| `build_market_artifacts` | 145s | <1s |
| `build_joint_portfolio_artifacts` | 122s | <1s |
| `_finalize_replay_results` (summary chart) | 37s | 14s |
| **Total wall time** | **~320s** | **~26s** |

The bottleneck was dense equity curve construction from full-resolution price points (~300K–600K per market) that were ultimately downsampled to 5000 points for the summary chart. Early downsampling eliminates this redundant work.

## Test plan (5/5)

- [x] `uv run pytest tests/` — 322 passed, 1 skipped
- [x] `time uv run python backtests/polymarket_quote_tick_joint_portfolio_runner.py` — 26s (was 320s)
- [x] Summary chart HTML still generated, visually comparable (~330KB)
- [x] `kalshi_trade_tick_breakout.py` end-to-end run produces a 1.4MB single-market detail chart — full-res detail charts unaffected
- [x] Docs (backtests.md / plotting.md / setup.md) updated to reflect inlined kwargs

🤖 Generated with [Claude Code](https://claude.com/claude-code)