### PR TITLE
chore: ruff-driven cleanups across relay, adapters, and plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Environment
 .env
+.uv-cache/
 
 # Python
 __pycache__/
@@ -24,6 +25,10 @@ data/
 
 # Output
 output/
+kalshi_catalog/
+
+# Local relay runtime
+.pmxt-relay/
 
 # Temp
 .tmp/
@@ -39,4 +44,4 @@ crates/*/uv.lock
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
-
+.benchmarks/

--- a/backtests/kalshi_trade_tick_breakout.py
+++ b/backtests/kalshi_trade_tick_breakout.py
@@ -23,14 +23,15 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import Kalshi, Native, TradeTick
-
 
 DETAIL_PLOT_PANELS = (
     "equity",
@@ -69,7 +70,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:TradeTickBreakoutStrategy",
         "config_path": "strategies:TradeTickBreakoutConfig",
         "config": {
-            "trade_size": Decimal("1"),
+            "trade_size": Decimal(1),
             "window": 60,
             "breakout_std": 1.35,
             "max_entry_price": 0.9,

--- a/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
@@ -18,14 +18,15 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import Kalshi, Native, TradeTick
-
 
 DETAIL_PLOT_PANELS = (
     "equity",
@@ -92,7 +93,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:TradeTickBreakoutStrategy",
         "config_path": "strategies:TradeTickBreakoutConfig",
         "config": {
-            "trade_size": Decimal("1"),
+            "trade_size": Decimal(1),
             "window": 60,
             "breakout_std": 1.35,
             "max_entry_price": 0.9,

--- a/backtests/kalshi_trade_tick_joint_portfolio_runner.py
+++ b/backtests/kalshi_trade_tick_joint_portfolio_runner.py
@@ -18,14 +18,15 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import Kalshi, Native, TradeTick
-
 
 DETAIL_PLOT_PANELS = (
     "equity",
@@ -90,7 +91,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:TradeTickBreakoutStrategy",
         "config_path": "strategies:TradeTickBreakoutConfig",
         "config": {
-            "trade_size": Decimal("1"),
+            "trade_size": Decimal(1),
             "window": 60,
             "breakout_std": 1.35,
             "max_entry_price": 0.9,

--- a/backtests/polymarket_quote_tick_ema_crossover.py
+++ b/backtests/polymarket_quote_tick_ema_crossover.py
@@ -20,16 +20,19 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -74,7 +77,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:QuoteTickEMACrossoverStrategy",
         "config_path": "strategies:QuoteTickEMACrossoverConfig",
         "config": {
-            "trade_size": Decimal("5"),
+            "trade_size": Decimal(5),
             "fast_period": 64,
             "slow_period": 256,
             "entry_buffer": 0.0005,

--- a/backtests/polymarket_quote_tick_ema_optimizer.py
+++ b/backtests/polymarket_quote_tick_ema_optimizer.py
@@ -20,17 +20,22 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
-from prediction_market_extensions.backtesting._experiments import ParameterSearchExperiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
+from prediction_market_extensions.backtesting._experiments import (
+    ParameterSearchExperiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
-from prediction_market_extensions.backtesting.optimizers import ParameterSearchConfig
-from prediction_market_extensions.backtesting.optimizers import ParameterSearchWindow
-
+from prediction_market_extensions.backtesting.optimizers import (
+    ParameterSearchConfig,
+    ParameterSearchWindow,
+)
 
 DATA = MarketDataConfig(
     platform=Polymarket,
@@ -77,7 +82,7 @@ STRATEGY_SPEC = {
     "strategy_path": "strategies:QuoteTickEMACrossoverStrategy",
     "config_path": "strategies:QuoteTickEMACrossoverConfig",
     "config": {
-        "trade_size": Decimal("5"),
+        "trade_size": Decimal(5),
         "fast_period": "__SEARCH__:fast_period",
         "slow_period": "__SEARCH__:slow_period",
         "entry_buffer": "__SEARCH__:entry_buffer",

--- a/backtests/polymarket_quote_tick_independent_25_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_25_replay_runner.py
@@ -18,16 +18,19 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -256,7 +259,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:QuoteTickVWAPReversionStrategy",
         "config_path": "strategies:QuoteTickVWAPReversionConfig",
         "config": {
-            "trade_size": Decimal("5"),
+            "trade_size": Decimal(5),
             "vwap_window": 30,
             "entry_threshold": 0.0015,
             "exit_threshold": 0.0003,

--- a/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
@@ -18,16 +18,19 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -136,7 +139,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:QuoteTickVWAPReversionStrategy",
         "config_path": "strategies:QuoteTickVWAPReversionConfig",
         "config": {
-            "trade_size": Decimal("5"),
+            "trade_size": Decimal(5),
             "vwap_window": 30,
             "entry_threshold": 0.0015,
             "exit_threshold": 0.0003,

--- a/backtests/polymarket_quote_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_quote_tick_joint_portfolio_runner.py
@@ -18,16 +18,19 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import PMXT, Polymarket, QuoteTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -120,7 +123,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:QuoteTickVWAPReversionStrategy",
         "config_path": "strategies:QuoteTickVWAPReversionConfig",
         "config": {
-            "trade_size": Decimal("5"),
+            "trade_size": Decimal(5),
             "vwap_window": 30,
             "entry_threshold": 0.0015,
             "exit_threshold": 0.0003,

--- a/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
@@ -18,14 +18,15 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import Native, Polymarket, TradeTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -115,7 +116,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:TradeTickVWAPReversionStrategy",
         "config_path": "strategies:TradeTickVWAPReversionConfig",
         "config": {
-            "trade_size": Decimal("100"),
+            "trade_size": Decimal(100),
             "vwap_window": 80,
             "entry_threshold": 0.02,
             "exit_threshold": 0.004,

--- a/backtests/polymarket_trade_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_trade_tick_joint_portfolio_runner.py
@@ -18,14 +18,15 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import Native, Polymarket, TradeTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -116,7 +117,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:TradeTickVWAPReversionStrategy",
         "config_path": "strategies:TradeTickVWAPReversionConfig",
         "config": {
-            "trade_size": Decimal("100"),
+            "trade_size": Decimal(100),
             "vwap_window": 80,
             "entry_threshold": 0.02,
             "exit_threshold": 0.004,

--- a/backtests/polymarket_trade_tick_vwap_reversion.py
+++ b/backtests/polymarket_trade_tick_vwap_reversion.py
@@ -20,14 +20,15 @@ else:
 
 ensure_repo_root(__file__)
 
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._experiments import run_experiment
+from prediction_market_extensions.backtesting._experiments import (
+    build_replay_experiment,
+    run_experiment,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._timing_harness import timing_harness
 from prediction_market_extensions.backtesting.data_sources import Native, Polymarket, TradeTick
-
 
 DETAIL_PLOT_PANELS = (
     "total_equity",
@@ -71,7 +72,7 @@ STRATEGY_CONFIGS = [
         "strategy_path": "strategies:TradeTickVWAPReversionStrategy",
         "config_path": "strategies:TradeTickVWAPReversionConfig",
         "config": {
-            "trade_size": Decimal("100"),
+            "trade_size": Decimal(100),
             "vwap_window": 30,
             "entry_threshold": 0.0015,
             "exit_threshold": 0.0003,

--- a/backtests/sitecustomize.py
+++ b/backtests/sitecustomize.py
@@ -4,7 +4,6 @@ import importlib
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))

--- a/main.py
+++ b/main.py
@@ -19,8 +19,8 @@ Run via:
 
 from __future__ import annotations
 
-import asyncio
 import ast
+import asyncio
 import importlib
 import importlib.util
 import inspect
@@ -31,8 +31,7 @@ import sys
 import time
 from functools import cache
 from pathlib import Path
-from string import ascii_lowercase
-from string import ascii_uppercase
+from string import ascii_lowercase, ascii_uppercase
 from typing import Any, ClassVar
 
 from prediction_market_extensions import install_commission_patch

--- a/main.py
+++ b/main.py
@@ -29,11 +29,11 @@ import re
 import subprocess
 import sys
 import time
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 from string import ascii_lowercase
 from string import ascii_uppercase
-from typing import Any
+from typing import Any, ClassVar
 
 from prediction_market_extensions import install_commission_patch
 
@@ -303,7 +303,7 @@ def _assign_shortcuts(backtests: list[dict[str, Any]]) -> dict[str, str | None]:
     return shortcuts
 
 
-@lru_cache(maxsize=None)
+@cache
 def _runner_file_preview(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8")
@@ -401,7 +401,7 @@ if TEXTUAL_AVAILABLE:
         }
         """
 
-        BINDINGS = [
+        BINDINGS: ClassVar[list[Binding]] = [
             Binding("q", "quit", "Quit"),
             Binding("slash", "focus_filter", "Filter", key_display="/"),
             Binding("escape", "dismiss_filter", "Back"),

--- a/pmxt_relay/__main__.py
+++ b/pmxt_relay/__main__.py
@@ -1,5 +1,4 @@
 from pmxt_relay.cli import main
 
-
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
-from datetime import timezone
-import re
-import time
-from collections import defaultdict, deque
 import json
 import os
-from pathlib import Path
+import re
 import shutil
 import subprocess
 import threading
+import time
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from pathlib import Path
 from xml.sax.saxutils import escape
 
 from aiohttp import web

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -141,8 +141,7 @@ def _disk_percent(path: Path) -> float:
 
 
 def _system_metrics_snapshot(config: RelayConfig) -> dict[str, float]:
-    global _SYSTEM_METRICS_CACHE
-    global _SYSTEM_METRICS_CACHE_AT
+    global _SYSTEM_METRICS_CACHE, _SYSTEM_METRICS_CACHE_AT
 
     now = time.monotonic()
     with _SYSTEM_METRICS_CACHE_LOCK:

--- a/pmxt_relay/archive.py
+++ b/pmxt_relay/archive.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import re
 from urllib.parse import urlencode
-from urllib.request import Request
-from urllib.request import urlopen
-
+from urllib.request import Request, urlopen
 
 ARCHIVE_LINK_RE = re.compile(r"/dumps/(polymarket_orderbook_\d{4}-\d{2}-\d{2}T\d{2}\.parquet)")
 

--- a/pmxt_relay/cli.py
+++ b/pmxt_relay/cli.py
@@ -71,9 +71,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "sync-once":
         worker = RelayWorker(config)
         try:
-            adopted = worker._adopt_local_raw_hours()  # noqa: SLF001
-            discovered = worker._discover_archive_hours()  # noqa: SLF001
-            mirrored = worker._mirror_pending_hours()  # noqa: SLF001
+            adopted = worker._adopt_local_raw_hours()
+            discovered = worker._discover_archive_hours()
+            mirrored = worker._mirror_pending_hours()
             print(
                 json.dumps(
                     {"adopted": adopted, "discovered": discovered, "mirrored": mirrored},

--- a/pmxt_relay/config.py
+++ b/pmxt_relay/config.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-import uuid
 
 
 def _env_int(name: str, default: int) -> int:

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -5,6 +5,7 @@ import logging
 import sqlite3
 import threading
 import time
+from contextlib import suppress
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
@@ -91,10 +92,8 @@ class RelayIndex:
         self.close()
 
     def __del__(self) -> None:
-        try:
+        with suppress(Exception):
             self.close()
-        except Exception:
-            pass
 
     def initialize(
         self,
@@ -190,10 +189,8 @@ class RelayIndex:
         return not self._REQUIRED_ARCHIVE_COLUMNS.issubset(archive_columns)
 
     def _rollback_quietly(self) -> None:
-        try:
+        with suppress(sqlite3.Error):
             self._conn.rollback()
-        except sqlite3.Error:
-            pass
 
     def _run_with_lock_retry(
         self, operation, *, swallow_after_secs: float | None = None, default=None

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -6,12 +6,10 @@ import sqlite3
 import threading
 import time
 from contextlib import suppress
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from pmxt_relay.storage import parse_archive_hour
-
 
 LOG = logging.getLogger(__name__)
 _LOCKED_ERROR_SNIPPETS = (

--- a/pmxt_relay/raw_mirror_verifier.py
+++ b/pmxt_relay/raw_mirror_verifier.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import asdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import aiohttp
 import pyarrow.parquet as pq
 
-from pmxt_relay.archive import extract_archive_filenames
-from pmxt_relay.archive import fetch_archive_page
+from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
 from pmxt_relay.storage import raw_relative_path
 
 

--- a/pmxt_relay/storage.py
+++ b/pmxt_relay/storage.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import re
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-
 
 ARCHIVE_FILENAME_RE = re.compile(r"^polymarket_orderbook_(\d{4}-\d{2}-\d{2}T\d{2})\.parquet$")
 

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -5,19 +5,14 @@ import os
 import shutil
 import time
 from contextlib import suppress
-from datetime import UTC
-from datetime import datetime
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from urllib.error import HTTPError
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
-from pmxt_relay.archive import extract_archive_filenames
-from pmxt_relay.archive import fetch_archive_page
+from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
 from pmxt_relay.config import RelayConfig
 from pmxt_relay.index_db import RelayIndex
 from pmxt_relay.storage import raw_relative_path
-
 
 LOG = logging.getLogger(__name__)
 _MIRROR_404_QUARANTINE_AFTER = 3
@@ -196,7 +191,7 @@ class RelayWorker:
         for row in self._index.list_hours_needing_mirror():
             try:
                 self._mirror_hour(row)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 next_error_count = int(row["error_count"] or 0) + 1
                 if self._should_quarantine_error(exc, error_count=next_error_count):
                     next_retry_at = self._quarantine_retry_at()
@@ -303,7 +298,7 @@ class RelayWorker:
                 last_modified = response.headers.get("Last-Modified")
                 length_value = response.headers.get("Content-Length")
                 content_length = int(length_value) if length_value else None
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             head_error = (
                 f"HEAD {source_url} failed with {exc.code}"
                 if isinstance(exc, HTTPError)

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import time
+from contextlib import suppress
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -70,10 +71,8 @@ class RelayWorker:
         self.close()
 
     def __del__(self) -> None:
-        try:
+        with suppress(Exception):
             self.close()
-        except Exception:
-            pass
 
     def run_forever(self) -> None:
         try:

--- a/prediction_market_extensions/__init__.py
+++ b/prediction_market_extensions/__init__.py
@@ -13,7 +13,8 @@ def install_commission_patch() -> None:
 
     This is the only startup hook required. Call once at process start.
     """
-    from prediction_market_extensions.adapters.polymarket import parsing as pm_parsing
     import nautilus_trader.adapters.polymarket.common.parsing as upstream_parsing
+
+    from prediction_market_extensions.adapters.polymarket import parsing as pm_parsing
 
     upstream_parsing.calculate_commission = pm_parsing.calculate_commission

--- a/prediction_market_extensions/adapters/kalshi/data.py
+++ b/prediction_market_extensions/adapters/kalshi/data.py
@@ -20,33 +20,34 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
-from prediction_market_extensions.adapters.kalshi.config import KalshiDataClientConfig
-from prediction_market_extensions.adapters.kalshi.providers import KalshiInstrumentProvider
-from nautilus_trader.data.messages import RequestBars
-from nautilus_trader.data.messages import RequestInstrument
-from nautilus_trader.data.messages import RequestInstruments
-from nautilus_trader.data.messages import RequestQuoteTicks
-from nautilus_trader.data.messages import RequestTradeTicks
-from nautilus_trader.data.messages import SubscribeBars
-from nautilus_trader.data.messages import SubscribeInstrumentClose
-from nautilus_trader.data.messages import SubscribeInstrumentStatus
-from nautilus_trader.data.messages import SubscribeOrderBook
-from nautilus_trader.data.messages import SubscribeQuoteTicks
-from nautilus_trader.data.messages import SubscribeTradeTicks
-from nautilus_trader.data.messages import UnsubscribeBars
-from nautilus_trader.data.messages import UnsubscribeInstrumentClose
-from nautilus_trader.data.messages import UnsubscribeInstrumentStatus
-from nautilus_trader.data.messages import UnsubscribeOrderBook
-from nautilus_trader.data.messages import UnsubscribeQuoteTicks
-from nautilus_trader.data.messages import UnsubscribeTradeTicks
+from nautilus_trader.data.messages import (
+    RequestBars,
+    RequestInstrument,
+    RequestInstruments,
+    RequestQuoteTicks,
+    RequestTradeTicks,
+    SubscribeBars,
+    SubscribeInstrumentClose,
+    SubscribeInstrumentStatus,
+    SubscribeOrderBook,
+    SubscribeQuoteTicks,
+    SubscribeTradeTicks,
+    UnsubscribeBars,
+    UnsubscribeInstrumentClose,
+    UnsubscribeInstrumentStatus,
+    UnsubscribeOrderBook,
+    UnsubscribeQuoteTicks,
+    UnsubscribeTradeTicks,
+)
 from nautilus_trader.live.data_client import LiveMarketDataClient
 from nautilus_trader.model.identifiers import ClientId
 
+from prediction_market_extensions.adapters.kalshi.config import KalshiDataClientConfig
+from prediction_market_extensions.adapters.kalshi.providers import KalshiInstrumentProvider
 
 if TYPE_CHECKING:
     from nautilus_trader.cache.cache import Cache
-    from nautilus_trader.common.component import LiveClock
-    from nautilus_trader.common.component import MessageBus
+    from nautilus_trader.common.component import LiveClock, MessageBus
 
 KALSHI_CLIENT_ID = "KALSHI"
 

--- a/prediction_market_extensions/adapters/kalshi/factories.py
+++ b/prediction_market_extensions/adapters/kalshi/factories.py
@@ -17,16 +17,15 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from nautilus_trader.live.factories import LiveDataClientFactory
+
 from prediction_market_extensions.adapters.kalshi.config import KalshiDataClientConfig
 from prediction_market_extensions.adapters.kalshi.data import KalshiDataClient
 from prediction_market_extensions.adapters.kalshi.providers import KalshiInstrumentProvider
-from nautilus_trader.live.factories import LiveDataClientFactory
-
 
 if TYPE_CHECKING:
     from nautilus_trader.cache.cache import Cache
-    from nautilus_trader.common.component import LiveClock
-    from nautilus_trader.common.component import MessageBus
+    from nautilus_trader.common.component import LiveClock, MessageBus
 
 
 class KalshiLiveDataClientFactory(LiveDataClientFactory):

--- a/prediction_market_extensions/adapters/kalshi/fee_model.py
+++ b/prediction_market_extensions/adapters/kalshi/fee_model.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 import math
 from decimal import Decimal
 
-from prediction_market_extensions.adapters.kalshi.providers import KALSHI_TAKER_FEE_RATE
 from nautilus_trader.backtest.config import FeeModelConfig
 from nautilus_trader.backtest.models import FeeModel
 from nautilus_trader.model.objects import Money
+
+from prediction_market_extensions.adapters.kalshi.providers import KALSHI_TAKER_FEE_RATE
 
 
 class KalshiProportionalFeeModelConfig(FeeModelConfig, frozen=True):

--- a/prediction_market_extensions/adapters/kalshi/loaders.py
+++ b/prediction_market_extensions/adapters/kalshi/loaders.py
@@ -21,7 +21,7 @@ Provides a data loader for historical Kalshi prediction market data.
 from __future__ import annotations
 
 import hashlib
-from typing import Any
+from typing import Any, ClassVar
 
 import msgspec
 import pandas as pd
@@ -68,9 +68,9 @@ class KalshiDataLoader:
         HTTP client to use for requests. If not provided, a new client is created.
     """
 
-    _INTERVAL_MAP: dict[str, int] = {"Minutes1": 1, "Hours1": 60, "Days1": 1440}
+    _INTERVAL_MAP: ClassVar[dict[str, int]] = {"Minutes1": 1, "Hours1": 60, "Days1": 1440}
 
-    _INTERVAL_TO_AGGREGATION: dict[str, BarAggregation] = {
+    _INTERVAL_TO_AGGREGATION: ClassVar[dict[str, BarAggregation]] = {
         "Minutes1": BarAggregation.MINUTE,
         "Hours1": BarAggregation.HOUR,
         "Days1": BarAggregation.DAY,

--- a/prediction_market_extensions/adapters/kalshi/loaders.py
+++ b/prediction_market_extensions/adapters/kalshi/loaders.py
@@ -25,22 +25,17 @@ from typing import Any, ClassVar
 
 import msgspec
 import pandas as pd
-
-from prediction_market_extensions.adapters.kalshi.providers import KALSHI_REST_BASE
-from prediction_market_extensions.adapters.kalshi.providers import market_dict_to_instrument
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.core.datetime import secs_to_nanos
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarSpecification
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import TradeTick
-from nautilus_trader.model.enums import AggregationSource
-from nautilus_trader.model.enums import AggressorSide
-from nautilus_trader.model.enums import BarAggregation
-from nautilus_trader.model.enums import PriceType
+from nautilus_trader.model.data import Bar, BarSpecification, BarType, TradeTick
+from nautilus_trader.model.enums import AggregationSource, AggressorSide, BarAggregation, PriceType
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.instruments import BinaryOption
 
+from prediction_market_extensions.adapters.kalshi.providers import (
+    KALSHI_REST_BASE,
+    market_dict_to_instrument,
+)
 
 KALSHI_HTTP_RATE_LIMIT_RPS = 20  # Basic tier
 

--- a/prediction_market_extensions/adapters/kalshi/market_selection.py
+++ b/prediction_market_extensions/adapters/kalshi/market_selection.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
-
 
 GAME_TITLE_PATTERN = re.compile(r"\bvs\.?(?=\s)|\bat\b", re.IGNORECASE)
 DERIVATIVE_MARKET_PATTERN = re.compile(r"SPREAD|TOTAL", re.IGNORECASE)

--- a/prediction_market_extensions/adapters/kalshi/providers.py
+++ b/prediction_market_extensions/adapters/kalshi/providers.py
@@ -22,18 +22,14 @@ import logging
 import math
 from datetime import datetime
 
-from prediction_market_extensions.adapters.kalshi.config import KalshiDataClientConfig
 from nautilus_trader.common.providers import InstrumentProvider
 from nautilus_trader.core.datetime import dt_to_unix_nanos
 from nautilus_trader.model.enums import AssetClass
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 from nautilus_trader.model.instruments import BinaryOption
-from nautilus_trader.model.objects import Currency
-from nautilus_trader.model.objects import Price
-from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.objects import Currency, Price, Quantity
 
+from prediction_market_extensions.adapters.kalshi.config import KalshiDataClientConfig
 
 _log = logging.getLogger(__name__)
 

--- a/prediction_market_extensions/adapters/kalshi/research.py
+++ b/prediction_market_extensions/adapters/kalshi/research.py
@@ -18,29 +18,29 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from collections.abc import Mapping
 from collections import defaultdict
-from datetime import UTC
-from datetime import datetime
-from datetime import timedelta
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import msgspec
 import pandas as pd
-
-from prediction_market_extensions.adapters.kalshi.loaders import KalshiDataLoader
-from prediction_market_extensions.adapters.kalshi.market_selection import end_date_utc
-from prediction_market_extensions.adapters.kalshi.market_selection import is_game_market
-from prediction_market_extensions.adapters.kalshi.market_selection import is_resolved_sports_market
-from prediction_market_extensions.adapters.kalshi.market_selection import is_sports_market
-from prediction_market_extensions.adapters.kalshi.market_selection import volume_24h
-from prediction_market_extensions.adapters.kalshi.market_selection import yes_price
-from prediction_market_extensions.adapters.kalshi.providers import KALSHI_REST_BASE
-from prediction_market_extensions.adapters.kalshi.providers import market_dict_to_instrument
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.model.data import Bar
 
+from prediction_market_extensions.adapters.kalshi.loaders import KalshiDataLoader
+from prediction_market_extensions.adapters.kalshi.market_selection import (
+    end_date_utc,
+    is_game_market,
+    is_resolved_sports_market,
+    is_sports_market,
+    volume_24h,
+    yes_price,
+)
+from prediction_market_extensions.adapters.kalshi.providers import (
+    KALSHI_REST_BASE,
+    market_dict_to_instrument,
+)
 
 MarketPredicate = Callable[[Mapping[str, Any]], bool]
 MarketSortKey = Callable[[Mapping[str, Any]], float]

--- a/prediction_market_extensions/adapters/polymarket/execution.py
+++ b/prediction_market_extensions/adapters/polymarket/execution.py
@@ -18,98 +18,107 @@
 
 import asyncio
 import json
-from collections import OrderedDict
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from typing import Any
 
 import msgspec
-from py_clob_client.client import BalanceAllowanceParams
-from py_clob_client.client import ClobClient
-from py_clob_client.client import MarketOrderArgs
-from py_clob_client.client import OpenOrderParams
-from py_clob_client.client import OrderArgs
-from py_clob_client.client import PartialCreateOrderOptions
-from py_clob_client.client import TradeParams
-from py_clob_client.clob_types import AssetType
-from py_clob_client.clob_types import PostOrdersArgs
-from py_clob_client.exceptions import PolyApiException
-
 from nautilus_trader.adapters.polymarket.common.cache import get_polymarket_trades_key
-from nautilus_trader.adapters.polymarket.common.constants import POLYMARKET_CANCEL_ALREADY_DONE
-from nautilus_trader.adapters.polymarket.common.constants import POLYMARKET_FINALIZED_TRADE_STATUSES
-from nautilus_trader.adapters.polymarket.common.constants import POLYMARKET_INVALID_API_KEY
-from nautilus_trader.adapters.polymarket.common.constants import POLYMARKET_VENUE
-from nautilus_trader.adapters.polymarket.common.constants import VALID_POLYMARKET_TIME_IN_FORCE
+from nautilus_trader.adapters.polymarket.common.constants import (
+    POLYMARKET_CANCEL_ALREADY_DONE,
+    POLYMARKET_FINALIZED_TRADE_STATUSES,
+    POLYMARKET_INVALID_API_KEY,
+    POLYMARKET_VENUE,
+    VALID_POLYMARKET_TIME_IN_FORCE,
+)
 from nautilus_trader.adapters.polymarket.common.conversion import usdce_from_units
 from nautilus_trader.adapters.polymarket.common.credentials import PolymarketWebSocketAuth
-from nautilus_trader.adapters.polymarket.common.enums import PolymarketEventType
-from nautilus_trader.adapters.polymarket.common.enums import PolymarketTradeStatus
-from nautilus_trader.adapters.polymarket.common.parsing import calculate_commission
-from prediction_market_extensions.adapters.polymarket.parsing import infer_fee_exponent
-from nautilus_trader.adapters.polymarket.common.parsing import make_composite_trade_id
-from nautilus_trader.adapters.polymarket.common.parsing import validate_ethereum_address
-from nautilus_trader.adapters.polymarket.common.symbol import get_polymarket_condition_id
-from nautilus_trader.adapters.polymarket.common.symbol import get_polymarket_instrument_id
-from nautilus_trader.adapters.polymarket.common.symbol import get_polymarket_token_id
+from nautilus_trader.adapters.polymarket.common.enums import (
+    PolymarketEventType,
+    PolymarketTradeStatus,
+)
+from nautilus_trader.adapters.polymarket.common.parsing import (
+    calculate_commission,
+    make_composite_trade_id,
+    validate_ethereum_address,
+)
+from nautilus_trader.adapters.polymarket.common.symbol import (
+    get_polymarket_condition_id,
+    get_polymarket_instrument_id,
+    get_polymarket_token_id,
+)
 from nautilus_trader.adapters.polymarket.common.types import JSON
 from nautilus_trader.adapters.polymarket.config import PolymarketExecClientConfig
 from nautilus_trader.adapters.polymarket.http.conversion import convert_tif_to_polymarket_order_type
 from nautilus_trader.adapters.polymarket.http.errors import should_retry
 from nautilus_trader.adapters.polymarket.providers import PolymarketInstrumentProvider
 from nautilus_trader.adapters.polymarket.schemas.trade import PolymarketTradeReport
-from nautilus_trader.adapters.polymarket.schemas.user import PolymarketOpenOrder
-from nautilus_trader.adapters.polymarket.schemas.user import PolymarketUserOrder
-from nautilus_trader.adapters.polymarket.schemas.user import PolymarketUserTrade
-from nautilus_trader.adapters.polymarket.websocket.client import PolymarketWebSocketChannel
-from nautilus_trader.adapters.polymarket.websocket.client import PolymarketWebSocketClient
+from nautilus_trader.adapters.polymarket.schemas.user import (
+    PolymarketOpenOrder,
+    PolymarketUserOrder,
+    PolymarketUserTrade,
+)
+from nautilus_trader.adapters.polymarket.websocket.client import (
+    PolymarketWebSocketChannel,
+    PolymarketWebSocketClient,
+)
 from nautilus_trader.adapters.polymarket.websocket.types import USER_WS_MESSAGE
 from nautilus_trader.cache.cache import Cache
-from nautilus_trader.common.component import LiveClock
-from nautilus_trader.common.component import MessageBus
-from nautilus_trader.common.enums import LogColor
-from nautilus_trader.common.enums import LogLevel
-from nautilus_trader.core.datetime import millis_to_nanos
-from nautilus_trader.core.datetime import nanos_to_secs
-from nautilus_trader.core.datetime import secs_to_nanos
-from nautilus_trader.core.nautilus_pyo3 import HttpClient
-from nautilus_trader.core.nautilus_pyo3 import HttpResponse
+from nautilus_trader.common.component import LiveClock, MessageBus
+from nautilus_trader.common.enums import LogColor, LogLevel
+from nautilus_trader.core.datetime import millis_to_nanos, nanos_to_secs, secs_to_nanos
+from nautilus_trader.core.nautilus_pyo3 import HttpClient, HttpResponse
 from nautilus_trader.core.uuid import UUID4
-from nautilus_trader.execution.messages import BatchCancelOrders
-from nautilus_trader.execution.messages import CancelAllOrders
-from nautilus_trader.execution.messages import CancelOrder
-from nautilus_trader.execution.messages import GenerateFillReports
-from nautilus_trader.execution.messages import GenerateOrderStatusReport
-from nautilus_trader.execution.messages import GenerateOrderStatusReports
-from nautilus_trader.execution.messages import GeneratePositionStatusReports
-from nautilus_trader.execution.messages import QueryAccount
-from nautilus_trader.execution.messages import SubmitOrder
-from nautilus_trader.execution.messages import SubmitOrderList
-from nautilus_trader.execution.reports import FillReport
-from nautilus_trader.execution.reports import OrderStatusReport
-from nautilus_trader.execution.reports import PositionStatusReport
+from nautilus_trader.execution.messages import (
+    BatchCancelOrders,
+    CancelAllOrders,
+    CancelOrder,
+    GenerateFillReports,
+    GenerateOrderStatusReport,
+    GenerateOrderStatusReports,
+    GeneratePositionStatusReports,
+    QueryAccount,
+    SubmitOrder,
+    SubmitOrderList,
+)
+from nautilus_trader.execution.reports import FillReport, OrderStatusReport, PositionStatusReport
 from nautilus_trader.live.execution_client import LiveExecutionClient
 from nautilus_trader.live.retry import RetryManagerPool
 from nautilus_trader.model.currencies import USDC_POS
-from nautilus_trader.model.enums import AccountType
-from nautilus_trader.model.enums import ContingencyType
-from nautilus_trader.model.enums import LiquiditySide
-from nautilus_trader.model.enums import OmsType
-from nautilus_trader.model.enums import OrderSide
-from nautilus_trader.model.enums import OrderStatus
-from nautilus_trader.model.enums import OrderType
-from nautilus_trader.model.enums import PositionSide
-from nautilus_trader.model.enums import TimeInForce
-from nautilus_trader.model.enums import order_side_to_str
-from nautilus_trader.model.identifiers import AccountId
-from nautilus_trader.model.identifiers import ClientId
-from nautilus_trader.model.identifiers import ClientOrderId
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import TradeId
-from nautilus_trader.model.identifiers import VenueOrderId
-from nautilus_trader.model.objects import AccountBalance
-from nautilus_trader.model.objects import Money
-from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.enums import (
+    AccountType,
+    ContingencyType,
+    LiquiditySide,
+    OmsType,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    PositionSide,
+    TimeInForce,
+    order_side_to_str,
+)
+from nautilus_trader.model.identifiers import (
+    AccountId,
+    ClientId,
+    ClientOrderId,
+    InstrumentId,
+    TradeId,
+    VenueOrderId,
+)
+from nautilus_trader.model.objects import AccountBalance, Money, Quantity
 from nautilus_trader.model.orders import Order
+from py_clob_client.client import (
+    BalanceAllowanceParams,
+    ClobClient,
+    MarketOrderArgs,
+    OpenOrderParams,
+    OrderArgs,
+    PartialCreateOrderOptions,
+    TradeParams,
+)
+from py_clob_client.clob_types import AssetType, PostOrdersArgs
+from py_clob_client.exceptions import PolyApiException
+
+from prediction_market_extensions.adapters.polymarket.parsing import infer_fee_exponent
 
 
 class PolymarketExecutionClient(LiveExecutionClient):
@@ -338,7 +347,7 @@ class PolymarketExecutionClient(LiveExecutionClient):
 
     # -- EXECUTION REPORTS ------------------------------------------------------------------------
 
-    async def generate_order_status_reports(  # noqa: C901
+    async def generate_order_status_reports(
         self, command: GenerateOrderStatusReports
     ) -> list[OrderStatusReport]:
         self._log.debug("Requesting OrderStatusReports...")
@@ -1391,14 +1400,13 @@ class PolymarketExecutionClient(LiveExecutionClient):
                     "resubmit with `quote_quantity=True`",
                 )
                 return
-        else:
-            if order.is_quote_quantity:
-                self._deny_market_order_quantity(
-                    order,
-                    "Polymarket market SELL orders require base-denominated quantities; "
-                    "resubmit with `quote_quantity=False`",
-                )
-                return
+        elif order.is_quote_quantity:
+            self._deny_market_order_quantity(
+                order,
+                "Polymarket market SELL orders require base-denominated quantities; "
+                "resubmit with `quote_quantity=False`",
+            )
+            return
 
         amount = float(order.quantity)
         order_type = convert_tif_to_polymarket_order_type(order.time_in_force)

--- a/prediction_market_extensions/adapters/polymarket/fee_model.py
+++ b/prediction_market_extensions/adapters/polymarket/fee_model.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from prediction_market_extensions.adapters.polymarket.parsing import calculate_commission
 from nautilus_trader.backtest.models import FeeModel
 from nautilus_trader.model.objects import Money
+
+from prediction_market_extensions.adapters.polymarket.parsing import calculate_commission
 
 
 class PolymarketFeeModel(FeeModel):

--- a/prediction_market_extensions/adapters/polymarket/gamma_markets.py
+++ b/prediction_market_extensions/adapters/polymarket/gamma_markets.py
@@ -258,7 +258,7 @@ def normalize_gamma_market_to_clob_format(gamma_market: dict[str, Any]) -> dict[
         }
         tokens.append(token_entry)
 
-    normalized = {
+    return {
         # Core identifiers
         "condition_id": gamma_market.get("conditionId"),
         "question_id": gamma_market.get("questionID"),
@@ -299,7 +299,6 @@ def normalize_gamma_market_to_clob_format(gamma_market: dict[str, Any]) -> dict[
         # Preserve original data for reference
         "_gamma_original": gamma_market,
     }
-    return normalized
 
 
 async def list_markets(

--- a/prediction_market_extensions/adapters/polymarket/gamma_markets.py
+++ b/prediction_market_extensions/adapters/polymarket/gamma_markets.py
@@ -35,10 +35,7 @@ from math import ceil
 from typing import Any
 
 import msgspec
-
-from nautilus_trader.core.nautilus_pyo3 import HttpClient
-from nautilus_trader.core.nautilus_pyo3 import HttpResponse
-
+from nautilus_trader.core.nautilus_pyo3 import HttpClient, HttpResponse
 
 DEFAULT_GAMMA_BASE_URL = os.getenv("GAMMA_API_URL", "https://gamma-api.polymarket.com")
 

--- a/prediction_market_extensions/adapters/polymarket/loaders.py
+++ b/prediction_market_extensions/adapters/polymarket/loaders.py
@@ -21,15 +21,12 @@ Provides data loaders for historical Polymarket data from various APIs.
 
 from __future__ import annotations
 
-from decimal import Decimal
-from decimal import InvalidOperation
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import msgspec
 import pandas as pd
-
 from nautilus_trader.adapters.polymarket.common.constants import POLYMARKET_HTTP_RATE_LIMIT
-from prediction_market_extensions.adapters.polymarket.gamma_markets import infer_gamma_token_winners
 from nautilus_trader.adapters.polymarket.common.parsing import parse_polymarket_instrument
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.core.correctness import PyCondition
@@ -38,6 +35,8 @@ from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.enums import AggressorSide
 from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.instruments import BinaryOption
+
+from prediction_market_extensions.adapters.polymarket.gamma_markets import infer_gamma_token_winners
 
 
 class PolymarketDataLoader:

--- a/prediction_market_extensions/adapters/polymarket/market_selection.py
+++ b/prediction_market_extensions/adapters/polymarket/market_selection.py
@@ -19,12 +19,10 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import msgspec
-
 
 SPORT_TEXT_PATTERN = re.compile(
     r"\bnba\b|\bwnba\b|\bnfl\b|\bmlb\b|\bnhl\b|\bncaa\b|\bcbb\b|\bsoccer\b|\bfootball\b|"

--- a/prediction_market_extensions/adapters/polymarket/parsing.py
+++ b/prediction_market_extensions/adapters/polymarket/parsing.py
@@ -28,8 +28,7 @@ via ``prediction_market_extensions.install_commission_patch()``.
 
 from __future__ import annotations
 
-from decimal import Decimal
-from decimal import ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal
 
 
 def basis_points_as_decimal(basis_points: Decimal) -> Decimal:

--- a/prediction_market_extensions/adapters/polymarket/pmxt.py
+++ b/prediction_market_extensions/adapters/polymarket/pmxt.py
@@ -19,6 +19,7 @@ from contextlib import suppress
 from datetime import UTC
 from io import BytesIO
 from pathlib import Path
+from typing import ClassVar
 from urllib.parse import quote
 from urllib.request import Request
 from urllib.request import urlopen
@@ -85,8 +86,8 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
     """
 
     _PMXT_BASE_URL = "https://r2.pmxt.dev"
-    _PMXT_REMOTE_COLUMNS = ["market_id", "update_type", "data"]
-    _PMXT_COLUMNS = ["update_type", "data"]
+    _PMXT_REMOTE_COLUMNS: ClassVar[list[str]] = ["market_id", "update_type", "data"]
+    _PMXT_COLUMNS: ClassVar[list[str]] = ["update_type", "data"]
     _PMXT_CACHE_DIR_ENV = "PMXT_CACHE_DIR"
     _PMXT_DISABLE_CACHE_ENV = "PMXT_DISABLE_CACHE"
     _PMXT_LOCAL_ARCHIVE_DIR_ENV = "PMXT_LOCAL_ARCHIVE_DIR"

--- a/prediction_market_extensions/adapters/polymarket/pmxt.py
+++ b/prediction_market_extensions/adapters/polymarket/pmxt.py
@@ -10,19 +10,15 @@ import re
 import shutil
 import tempfile
 import time
-from collections.abc import Callable
-from collections.abc import Iterator
-from concurrent.futures import Future
-from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
-from contextlib import suppress
+from collections.abc import Callable, Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager, suppress
 from datetime import UTC
 from io import BytesIO
 from pathlib import Path
 from typing import ClassVar
 from urllib.parse import quote
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 import fsspec
 import msgspec
@@ -32,16 +28,16 @@ import pyarrow.compute as pc
 import pyarrow.dataset as ds
 import pyarrow.fs as pafs
 import pyarrow.parquet as pq
-
 from nautilus_trader.adapters.polymarket.common.enums import PolymarketOrderSide
 from nautilus_trader.adapters.polymarket.loaders import PolymarketDataLoader
-from nautilus_trader.adapters.polymarket.schemas.book import PolymarketBookLevel
-from nautilus_trader.adapters.polymarket.schemas.book import PolymarketBookSnapshot
-from nautilus_trader.adapters.polymarket.schemas.book import PolymarketQuote
-from nautilus_trader.adapters.polymarket.schemas.book import PolymarketQuotes
+from nautilus_trader.adapters.polymarket.schemas.book import (
+    PolymarketBookLevel,
+    PolymarketBookSnapshot,
+    PolymarketQuote,
+    PolymarketQuotes,
+)
 from nautilus_trader.model.book import OrderBook
-from nautilus_trader.model.data import OrderBookDeltas
-from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import OrderBookDeltas, QuoteTick
 from nautilus_trader.model.enums import BookType
 
 
@@ -706,7 +702,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         total_bytes: int | None = None
         if "://" in source:
             try:
-                with urlopen(Request(source, method="HEAD")) as response:  # noqa: S310
+                with urlopen(Request(source, method="HEAD")) as response:
                     total_bytes = self._content_length_from_response(response)
             except Exception:
                 total_bytes = None
@@ -721,7 +717,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
 
     def _download_to_file_with_progress(self, url: str, destination: Path) -> int | None:
         destination.parent.mkdir(parents=True, exist_ok=True)
-        with urlopen(url) as response, destination.open("wb") as handle:  # noqa: S310
+        with urlopen(url) as response, destination.open("wb") as handle:
             total_bytes = self._content_length_from_response(response)
             downloaded_bytes = 0
             last_emit = 0.0
@@ -769,7 +765,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         return total_bytes
 
     def _download_payload_with_progress(self, url: str) -> bytes | None:
-        with urlopen(url) as response:  # noqa: S310
+        with urlopen(url) as response:
             total_bytes = self._content_length_from_response(response)
             downloaded_bytes = 0
             last_emit = 0.0

--- a/prediction_market_extensions/adapters/polymarket/research.py
+++ b/prediction_market_extensions/adapters/polymarket/research.py
@@ -17,31 +17,27 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Mapping
-from datetime import UTC
-from datetime import datetime
-from datetime import timedelta
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import pandas as pd
 import msgspec
-
+import pandas as pd
 from nautilus_trader.adapters.polymarket.common.gamma_markets import list_markets
-from prediction_market_extensions.adapters.polymarket.market_selection import closed_time_utc
-from prediction_market_extensions.adapters.polymarket.market_selection import end_date_utc
-from prediction_market_extensions.adapters.polymarket.market_selection import event_start_utc
-from prediction_market_extensions.adapters.polymarket.market_selection import is_game_market
-from prediction_market_extensions.adapters.polymarket.market_selection import (
-    is_resolved_sports_market,
-)
-from prediction_market_extensions.adapters.polymarket.market_selection import is_sports_market
-from prediction_market_extensions.adapters.polymarket.market_selection import volume_24h
-from prediction_market_extensions.adapters.polymarket.market_selection import yes_price
 from nautilus_trader.adapters.polymarket.loaders import PolymarketDataLoader
 from nautilus_trader.core import nautilus_pyo3
 from nautilus_trader.model.data import TradeTick
 
+from prediction_market_extensions.adapters.polymarket.market_selection import (
+    closed_time_utc,
+    end_date_utc,
+    event_start_utc,
+    is_game_market,
+    is_resolved_sports_market,
+    is_sports_market,
+    volume_24h,
+    yes_price,
+)
 
 MarketPredicate = Callable[[Mapping[str, Any]], bool]
 MarketSortKey = Callable[[Mapping[str, Any]], float]

--- a/prediction_market_extensions/adapters/prediction_market/__init__.py
+++ b/prediction_market_extensions/adapters/prediction_market/__init__.py
@@ -22,13 +22,15 @@ Shared prediction-market adapter helpers.
 from prediction_market_extensions.adapters.prediction_market.fill_model import (
     PredictionMarketTakerFillModel,
 )
-from prediction_market_extensions.adapters.prediction_market.replay import HistoricalReplayAdapter
-from prediction_market_extensions.adapters.prediction_market.replay import LoadedReplay
-from prediction_market_extensions.adapters.prediction_market.replay import ReplayAdapterKey
-from prediction_market_extensions.adapters.prediction_market.replay import ReplayCoverageStats
-from prediction_market_extensions.adapters.prediction_market.replay import ReplayEngineProfile
-from prediction_market_extensions.adapters.prediction_market.replay import ReplayLoadRequest
-from prediction_market_extensions.adapters.prediction_market.replay import ReplayWindow
+from prediction_market_extensions.adapters.prediction_market.replay import (
+    HistoricalReplayAdapter,
+    LoadedReplay,
+    ReplayAdapterKey,
+    ReplayCoverageStats,
+    ReplayEngineProfile,
+    ReplayLoadRequest,
+    ReplayWindow,
+)
 
 __all__ = [
     "HistoricalReplayAdapter",

--- a/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
+++ b/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
@@ -162,7 +162,7 @@ def downsample_price_points(points: list[PricePoint], max_points: int = 5000) ->
         strided = set(range(0, n, stride))
         remaining = max_points - len(must_keep)
         stride2 = max(1, len(strided) // remaining) if remaining > 0 else n
-        selected = sorted(must_keep | set(list(sorted(strided))[::stride2]))
+        selected = sorted(must_keep | set(sorted(strided)[::stride2]))
 
     return [points[i] for i in selected]
 

--- a/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
+++ b/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
@@ -17,12 +17,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 
 import pandas as pd
-
 
 PricePoint = tuple[object, float]
 _DEFAULT_TS_ATTRS = ("ts_event", "ts_init")

--- a/prediction_market_extensions/adapters/prediction_market/fill_model.py
+++ b/prediction_market_extensions/adapters/prediction_market/fill_model.py
@@ -8,13 +8,10 @@ from __future__ import annotations
 from decimal import Decimal
 
 from nautilus_trader.backtest.models import FillModel
-from nautilus_trader.core.rust.model import BookType
-from nautilus_trader.core.rust.model import OrderSide
-from nautilus_trader.core.rust.model import OrderType
+from nautilus_trader.core.rust.model import BookType, OrderSide, OrderType
 from nautilus_trader.model.book import OrderBook
 from nautilus_trader.model.data import BookOrder
 from nautilus_trader.model.objects import Quantity
-
 
 _KALSHI_ORDER_TICK = Decimal("0.01")
 _UNLIMITED_BOOK_SIZE = 1_000_000

--- a/prediction_market_extensions/adapters/prediction_market/replay.py
+++ b/prediction_market_extensions/adapters/prediction_market/replay.py
@@ -17,19 +17,14 @@
 
 from __future__ import annotations
 
-from abc import ABC
-from abc import abstractmethod
-from collections.abc import Mapping
-from collections.abc import Sequence
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any
 
-from nautilus_trader.model.enums import AccountType
-from nautilus_trader.model.enums import BookType
-from nautilus_trader.model.enums import OmsType
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.enums import AccountType, BookType, OmsType
+from nautilus_trader.model.identifiers import InstrumentId, Venue
 
 
 @dataclass(frozen=True)

--- a/prediction_market_extensions/adapters/prediction_market/research.py
+++ b/prediction_market_extensions/adapters/prediction_market/research.py
@@ -19,30 +19,28 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from nautilus_trader.analysis.reporter import ReportProvider
+from nautilus_trader.backtest.config import BacktestEngineConfig
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.model.enums import AccountType, BookType, OmsType
+from nautilus_trader.model.identifiers import TraderId, Venue
+from nautilus_trader.model.objects import Currency, Money
+from nautilus_trader.risk.config import RiskEngineConfig
+from nautilus_trader.trading.strategy import Strategy
 
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     _timestamp_to_naive_utc_datetime,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     build_brier_inputs,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     build_market_prices,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_price_points,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_realized_pnl,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     infer_realized_outcome,
 )
 from prediction_market_extensions.adapters.prediction_market.fill_model import (
@@ -51,34 +49,21 @@ from prediction_market_extensions.adapters.prediction_market.fill_model import (
 from prediction_market_extensions.analysis import legacy_plot_adapter as legacy_plot_adapter
 from prediction_market_extensions.analysis.legacy_backtesting.models import (
     DEFAULT_SUMMARY_PLOT_PANELS,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_ALLOCATION
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_CASH_EQUITY
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_DRAWDOWN
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_EQUITY
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_MARKET_PNL
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_ROLLING_SHARPE
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
+    PANEL_ALLOCATION,
+    PANEL_BRIER_ADVANTAGE,
+    PANEL_CASH_EQUITY,
+    PANEL_DRAWDOWN,
+    PANEL_EQUITY,
+    PANEL_MARKET_PNL,
+    PANEL_ROLLING_SHARPE,
     PANEL_TOTAL_BRIER_ADVANTAGE,
+    PANEL_YES_PRICE,
+    normalize_plot_panels,
 )
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_YES_PRICE
-from prediction_market_extensions.analysis.legacy_backtesting.models import normalize_plot_panels
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_BRIER_ADVANTAGE
-from prediction_market_extensions.analysis.legacy_plot_adapter import build_legacy_backtest_layout
-from prediction_market_extensions.analysis.legacy_plot_adapter import save_legacy_backtest_layout
-from nautilus_trader.analysis.reporter import ReportProvider
-from nautilus_trader.backtest.config import BacktestEngineConfig
-from nautilus_trader.backtest.engine import BacktestEngine
-from nautilus_trader.config import LoggingConfig
-from nautilus_trader.model.enums import AccountType
-from nautilus_trader.model.enums import BookType
-from nautilus_trader.model.enums import OmsType
-from nautilus_trader.model.identifiers import TraderId
-from nautilus_trader.model.identifiers import Venue
-from nautilus_trader.model.objects import Currency
-from nautilus_trader.model.objects import Money
-from nautilus_trader.risk.config import RiskEngineConfig
-from nautilus_trader.trading.strategy import Strategy
+from prediction_market_extensions.analysis.legacy_plot_adapter import (
+    build_legacy_backtest_layout,
+    save_legacy_backtest_layout,
+)
 
 
 def _extract_account_pnl_series(engine: BacktestEngine) -> pd.Series:

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -344,7 +344,7 @@ def _build_dataframes(
             recs = market_prices[mid]
             if not recs:
                 continue
-            ts_list, price_list = zip(*recs)
+            ts_list, price_list = zip(*recs, strict=True)
             dt_arr = pd.to_datetime(list(ts_list))
             mkt = pd.DataFrame({"datetime": dt_arr, "price": list(price_list)})
             mkt = mkt.sort_values("datetime").drop_duplicates("datetime", keep="last")
@@ -512,7 +512,7 @@ def _build_allocation_data(
     for mid in pos_qty:
         recs = market_prices.get(mid, []) if mid in expensive_set else []
         if recs:
-            ts_list, pr_list = zip(*recs)
+            ts_list, pr_list = zip(*recs, strict=True)
             ts_arr = pd.to_datetime(list(ts_list)).values.astype("datetime64[ns]")
             pr_arr = np.array(pr_list, dtype=float)
             order = np.argsort(ts_arr)
@@ -1860,7 +1860,9 @@ return this.labels[index] || "";
         if other_col:
             legend_items.append(LegendItem(label="Other", renderers=[renderers[-2]]))
         # Show top positions by peak value
-        for r_obj, lbl in list(zip(renderers, stack_labels))[: MAX_LEGEND - len(legend_items)]:
+        for r_obj, lbl in list(zip(renderers, stack_labels, strict=False))[
+            : MAX_LEGEND - len(legend_items)
+        ]:
             if lbl in ("Cash", "Other"):
                 continue
             legend_items.append(LegendItem(label=lbl, renderers=[r_obj]))

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -321,9 +321,7 @@ def _build_dataframes(
         # --- select markets: all traded first, then random sample ---
         traded_ids = set(fills_df["market_id"]) if not fills_df.empty else set()
         # Always include every traded market
-        traded_with_data = [
-            mid for mid in traded_ids if market_prices.get(mid)
-        ]
+        traded_with_data = [mid for mid in traded_ids if market_prices.get(mid)]
         non_traded = [mid for mid in market_prices if mid not in traded_ids and market_prices[mid]]
         # Fill remaining budget with a random spread of non-traded markets
         budget = max(0, max_markets - len(traded_with_data))
@@ -471,7 +469,9 @@ def _build_allocation_data(
             pos_changes[mid] = np.zeros(n_bars)
         if f["action"] == "buy" and f["side"] == "yes":
             pos_changes[mid][bar_idx] += f["quantity"]
-        elif (f["action"] == "sell" and f["side"] == "yes") or (f["action"] == "buy" and f["side"] == "no"):
+        elif (f["action"] == "sell" and f["side"] == "yes") or (
+            f["action"] == "buy" and f["side"] == "no"
+        ):
             pos_changes[mid][bar_idx] -= f["quantity"]
         elif f["action"] == "sell" and f["side"] == "no":
             pos_changes[mid][bar_idx] += f["quantity"]

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -24,8 +24,7 @@ from __future__ import annotations
 import os
 import random
 import sys
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from colorsys import hls_to_rgb, rgb_to_hls
 from functools import partial
 from itertools import cycle
@@ -58,37 +57,31 @@ from bokeh.transform import factor_cmap
 
 from prediction_market_extensions.analysis.legacy_backtesting.models import (
     DEFAULT_DETAIL_PLOT_PANELS,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import normalize_plot_panels
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_ALLOCATION
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_BRIER_ADVANTAGE
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_CASH_EQUITY
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_DRAWDOWN
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_EQUITY
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_MARKET_PNL
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_MONTHLY_RETURNS
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_PERIODIC_PNL
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_ROLLING_SHARPE
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
+    PANEL_ALLOCATION,
+    PANEL_BRIER_ADVANTAGE,
+    PANEL_CASH_EQUITY,
+    PANEL_DRAWDOWN,
+    PANEL_EQUITY,
+    PANEL_MARKET_PNL,
+    PANEL_MONTHLY_RETURNS,
+    PANEL_PERIODIC_PNL,
+    PANEL_ROLLING_SHARPE,
     PANEL_TOTAL_BRIER_ADVANTAGE,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
     PANEL_TOTAL_CASH_EQUITY,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
     PANEL_TOTAL_DRAWDOWN,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_TOTAL_EQUITY
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
+    PANEL_TOTAL_EQUITY,
     PANEL_TOTAL_ROLLING_SHARPE,
+    PANEL_YES_PRICE,
+    normalize_plot_panels,
 )
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_YES_PRICE
 from prediction_market_extensions.analysis.legacy_backtesting.progress import PinnedProgress
 
 try:
     from bokeh.models import CustomJSTickFormatter
 except ImportError:
-    from bokeh.models import FuncTickFormatter as CustomJSTickFormatter  # type: ignore[no-redef, attr-defined]
+    from bokeh.models import (
+        FuncTickFormatter as CustomJSTickFormatter,  # type: ignore[no-redef, attr-defined]
+    )
 
 if TYPE_CHECKING:
     from prediction_market_extensions.analysis.legacy_backtesting.models import BacktestResult
@@ -329,7 +322,7 @@ def _build_dataframes(
         traded_ids = set(fills_df["market_id"]) if not fills_df.empty else set()
         # Always include every traded market
         traded_with_data = [
-            mid for mid in traded_ids if mid in market_prices and market_prices[mid]
+            mid for mid in traded_ids if market_prices.get(mid)
         ]
         non_traded = [mid for mid in market_prices if mid not in traded_ids and market_prices[mid]]
         # Fill remaining budget with a random spread of non-traded markets
@@ -478,9 +471,7 @@ def _build_allocation_data(
             pos_changes[mid] = np.zeros(n_bars)
         if f["action"] == "buy" and f["side"] == "yes":
             pos_changes[mid][bar_idx] += f["quantity"]
-        elif f["action"] == "sell" and f["side"] == "yes":
-            pos_changes[mid][bar_idx] -= f["quantity"]
-        elif f["action"] == "buy" and f["side"] == "no":
+        elif (f["action"] == "sell" and f["side"] == "yes") or (f["action"] == "buy" and f["side"] == "no"):
             pos_changes[mid][bar_idx] -= f["quantity"]
         elif f["action"] == "sell" and f["side"] == "no":
             pos_changes[mid][bar_idx] += f["quantity"]

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -416,7 +416,7 @@ def _downsample(
         must_list = sorted(must_keep)
         remaining_budget = max_points - len(must_list)
         stride2 = max(1, len(strided) // remaining_budget) if remaining_budget > 0 else n
-        thinned_strided = set(list(sorted(strided))[::stride2])
+        thinned_strided = set(sorted(strided)[::stride2])
         selected = sorted(must_keep | thinned_strided)
 
     idx_arr = np.array(selected)
@@ -591,8 +591,7 @@ def _build_allocation_data(
     if other_ids:
         col_data["Other"] = np.sum([pos_values[m] for m in other_ids], axis=0)
     col_data["Cash"] = np.maximum(eq["cash"].values, 0.0)
-    alloc = pd.DataFrame(col_data, index=eq.index)
-    return alloc
+    return pd.DataFrame(col_data, index=eq.index)
 
 
 # ---------------------------------------------------------------------------

--- a/prediction_market_extensions/analysis/legacy_plot_adapter.py
+++ b/prediction_market_extensions/analysis/legacy_plot_adapter.py
@@ -211,8 +211,7 @@ def _extract_account_report(engine: Any) -> pd.DataFrame:
         raise ValueError("Account report has no valid timestamps.")
 
     frame.index = frame.index.tz_convert("UTC").tz_localize(None)
-    frame = frame.groupby(frame.index).last().sort_index()
-    return frame
+    return frame.groupby(frame.index).last().sort_index()
 
 
 def _infer_market_side(models_module: Any, market_id: str) -> Any:
@@ -349,10 +348,8 @@ def _build_dense_timeline(
 ) -> pd.DatetimeIndex:
     timeline: set[datetime] = set()
     for points in market_prices.values():
-        for ts, _ in points:
-            timeline.add(ts)
-    for fill in fills:
-        timeline.add(fill.timestamp)
+        timeline.update(ts for ts, _ in points)
+    timeline.update(fill.timestamp for fill in fills)
     return pd.DatetimeIndex(sorted(timeline))
 
 
@@ -1044,8 +1041,7 @@ def _remove_yes_price_profitability_legend_items(fig: Any) -> set[Any]:
         for item in list(getattr(legend, "items", [])):
             lower = _legend_item_label_text(item).lower()
             if "profitable" in lower or "losing" in lower:
-                for renderer in getattr(item, "renderers", []):
-                    renderers_to_drop.add(renderer)
+                renderers_to_drop.update(getattr(item, "renderers", []))
                 continue
             kept_items.append(item)
         legend.items = kept_items

--- a/prediction_market_extensions/analysis/legacy_plot_adapter.py
+++ b/prediction_market_extensions/analysis/legacy_plot_adapter.py
@@ -26,24 +26,21 @@ from __future__ import annotations
 
 import importlib
 import re
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pandas as pd
+from nautilus_trader.analysis.reporter import ReportProvider
 
 from prediction_market_extensions.analysis.legacy_backtesting.models import (
     DEFAULT_DETAIL_PLOT_PANELS,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_BRIER_ADVANTAGE
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
+    PANEL_BRIER_ADVANTAGE,
     PANEL_TOTAL_BRIER_ADVANTAGE,
+    normalize_plot_panels,
 )
-from prediction_market_extensions.analysis.legacy_backtesting.models import normalize_plot_panels
-from nautilus_trader.analysis.reporter import ReportProvider
 
 
 def _parse_float(value: Any, default: float = 0.0) -> float:
@@ -661,8 +658,7 @@ def _brier_unavailable_reason(
 
 def _build_brier_placeholder_panel(message: str) -> Any:
     try:
-        from bokeh.models import Label
-        from bokeh.models import Span
+        from bokeh.models import Label, Span
         from bokeh.plotting import figure
     except ImportError as exc:  # pragma: no cover - runtime dependency
         raise ImportError("Bokeh is required for legacy chart rendering.") from exc
@@ -725,12 +721,14 @@ def _build_brier_timeseries_panel(
         return None
 
     try:
-        from bokeh.models import ColumnDataSource
-        from bokeh.models import HoverTool
-        from bokeh.models import NumeralTickFormatter
-        from bokeh.models import Range1d
-        from bokeh.models import Span
-        from bokeh.models import WheelZoomTool
+        from bokeh.models import (
+            ColumnDataSource,
+            HoverTool,
+            NumeralTickFormatter,
+            Range1d,
+            Span,
+            WheelZoomTool,
+        )
         from bokeh.plotting import figure
     except ImportError as exc:  # pragma: no cover - runtime dependency
         raise ImportError("Bokeh is required for legacy chart rendering.") from exc
@@ -1077,9 +1075,7 @@ def _remove_yes_price_profitability_connectors(layout: Any) -> None:
 
 def _standardize_periodic_pnl_panel(layout: Any) -> None:
     try:
-        from bokeh.models import ColumnDataSource
-        from bokeh.models import HoverTool
-        from bokeh.models import NumeralTickFormatter
+        from bokeh.models import ColumnDataSource, HoverTool, NumeralTickFormatter
     except ImportError:
         return
 
@@ -1152,7 +1148,7 @@ def _relabel_market_pnl_panel(layout: Any, axis_label: str = "Market P&L") -> No
         tool.tooltips = updated
 
 
-def _build_multi_market_brier_panel(  # noqa: C901
+def _build_multi_market_brier_panel(
     brier_frames: Mapping[str, pd.DataFrame],
     *,
     axis_label: str = "Cumulative Brier Advantage",
@@ -1167,12 +1163,14 @@ def _build_multi_market_brier_panel(  # noqa: C901
         return None
 
     try:
-        from bokeh.models import ColumnDataSource
-        from bokeh.models import HoverTool
-        from bokeh.models import NumeralTickFormatter
-        from bokeh.models import Range1d
-        from bokeh.models import Span
-        from bokeh.models import WheelZoomTool
+        from bokeh.models import (
+            ColumnDataSource,
+            HoverTool,
+            NumeralTickFormatter,
+            Range1d,
+            Span,
+            WheelZoomTool,
+        )
         from bokeh.palettes import Category10
         from bokeh.plotting import figure
     except ImportError as exc:  # pragma: no cover - runtime dependency
@@ -1374,8 +1372,7 @@ def _save_layout(layout: Any, output_path: Path, title: str) -> None:
     Persist the final Bokeh layout after all adapter-level cleanup.
     """
     try:
-        from bokeh.io import output_file
-        from bokeh.io import save
+        from bokeh.io import output_file, save
     except ImportError as exc:  # pragma: no cover - runtime dependency
         raise ImportError("Bokeh is required for legacy chart rendering.") from exc
 

--- a/prediction_market_extensions/analysis/tearsheet.py
+++ b/prediction_market_extensions/analysis/tearsheet.py
@@ -717,8 +717,7 @@ def create_tearsheet_from_stats(
     if output_path:
         fig.write_html(output_path)
         return None
-    else:
-        return fig.to_html()
+    return fig.to_html()
 
 
 def create_equity_curve(

--- a/prediction_market_extensions/analysis/tearsheet.py
+++ b/prediction_market_extensions/analysis/tearsheet.py
@@ -28,18 +28,14 @@ from __future__ import annotations
 import numbers
 from collections.abc import Callable
 from difflib import get_close_matches
-from typing import TYPE_CHECKING
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
-
 from nautilus_trader.analysis import TearsheetChart
 from nautilus_trader.core.correctness import PyCondition
 from nautilus_trader.core.datetime import format_optional_iso8601
 from nautilus_trader.core.nautilus_pyo3 import NAUTILUS_VERSION
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-
+from nautilus_trader.model.data import Bar, BarType
 
 if TYPE_CHECKING:
     from nautilus_trader.backtest.engine import BacktestEngine
@@ -222,7 +218,7 @@ def _prepare_brier_advantage_data(
     return frame
 
 
-def _extract_account_equity_series(  # noqa: C901
+def _extract_account_equity_series(
     engine: BacktestEngine | None,
 ) -> tuple[pd.Series, str | None]:
     """
@@ -436,7 +432,7 @@ def list_charts() -> list[str]:
     return list(_CHART_REGISTRY.keys())
 
 
-def create_tearsheet(  # noqa: C901
+def create_tearsheet(
     engine: BacktestEngine,
     output_path: str | None = "tearsheet.html",
     title: str = "NautilusTrader Backtest Results",
@@ -1419,7 +1415,7 @@ def _create_tearsheet_figure(
     return fig
 
 
-def _create_stats_table(  # noqa: C901
+def _create_stats_table(
     stats_pnls: dict[str, Any] | dict[str, dict[str, Any]],
     stats_returns: dict[str, Any],
     stats_general: dict[str, Any],
@@ -2183,7 +2179,7 @@ def create_bars_with_fills(
     return fig
 
 
-def _render_bars_with_fills(  # noqa: C901
+def _render_bars_with_fills(
     fig: go.Figure,
     row: int,
     col: int,

--- a/prediction_market_extensions/backtesting/_artifact_paths.py
+++ b/prediction_market_extensions/backtesting/_artifact_paths.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 
 
 def sanitize_chart_label(value: object, *, default: str) -> str:

--- a/prediction_market_extensions/backtesting/_backtest_runtime.py
+++ b/prediction_market_extensions/backtesting/_backtest_runtime.py
@@ -6,43 +6,33 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from nautilus_trader.backtest.config import BacktestEngineConfig
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.common.component import is_backtest_force_stop
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.model.enums import AccountType, BookType, OmsType
+from nautilus_trader.model.identifiers import TraderId, Venue
+from nautilus_trader.model.objects import Currency, Money
+from nautilus_trader.risk.config import RiskEngineConfig
+from nautilus_trader.trading.strategy import Strategy
 
 from prediction_market_extensions.adapters.prediction_market import (
     research as prediction_market_research,
 )
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     build_brier_inputs,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     build_market_prices,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_price_points,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_realized_pnl,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     infer_realized_outcome,
 )
 from prediction_market_extensions.adapters.prediction_market.fill_model import (
     PredictionMarketTakerFillModel,
 )
-from prediction_market_extensions.analysis.legacy_plot_adapter import build_legacy_backtest_layout
-from prediction_market_extensions.analysis.legacy_plot_adapter import save_legacy_backtest_layout
-from nautilus_trader.backtest.config import BacktestEngineConfig
-from nautilus_trader.backtest.engine import BacktestEngine
-from nautilus_trader.common.component import is_backtest_force_stop
-from nautilus_trader.config import LoggingConfig
-from nautilus_trader.model.enums import AccountType
-from nautilus_trader.model.enums import BookType
-from nautilus_trader.model.enums import OmsType
-from nautilus_trader.model.identifiers import TraderId
-from nautilus_trader.model.identifiers import Venue
-from nautilus_trader.model.objects import Currency
-from nautilus_trader.model.objects import Money
-from nautilus_trader.risk.config import RiskEngineConfig
-from nautilus_trader.trading.strategy import Strategy
+from prediction_market_extensions.analysis.legacy_plot_adapter import (
+    build_legacy_backtest_layout,
+    save_legacy_backtest_layout,
+)
 
 
 def _record_timestamp_ns(record: object) -> int | None:

--- a/prediction_market_extensions/backtesting/_execution_config.py
+++ b/prediction_market_extensions/backtesting/_execution_config.py
@@ -5,7 +5,6 @@ from math import isfinite
 
 from nautilus_trader.backtest.models import LatencyModel
 
-
 _NANOS_PER_MILLISECOND = 1_000_000
 
 

--- a/prediction_market_extensions/backtesting/_experiments.py
+++ b/prediction_market_extensions/backtesting/_experiments.py
@@ -1,31 +1,28 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
-from typing import Literal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 
 from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
+    MarketReportConfig,
     PredictionMarketBacktest,
-)
-from prediction_market_extensions.backtesting._prediction_market_backtest import (
     finalize_market_results,
 )
-from prediction_market_extensions.backtesting._result_policies import ResultPolicy
 from prediction_market_extensions.backtesting._replay_specs import ReplaySpec
+from prediction_market_extensions.backtesting._result_policies import ResultPolicy
 from prediction_market_extensions.backtesting._strategy_configs import StrategyConfigSpec
-from prediction_market_extensions.backtesting.optimizers import ParameterSearchConfig
-from prediction_market_extensions.backtesting.optimizers import ParameterSearchSummary
-from prediction_market_extensions.backtesting.optimizers import run_parameter_search
+from prediction_market_extensions.backtesting.optimizers import (
+    ParameterSearchConfig,
+    ParameterSearchSummary,
+    run_parameter_search,
+)
 
 if TYPE_CHECKING:
     from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig

--- a/prediction_market_extensions/backtesting/_independent_multi_replay_runner.py
+++ b/prediction_market_extensions/backtesting/_independent_multi_replay_runner.py
@@ -5,15 +5,14 @@ from typing import Any
 
 from prediction_market_extensions.backtesting._artifact_paths import (
     resolve_independent_replay_detail_chart_output_path,
+    sanitize_chart_label,
 )
-from prediction_market_extensions.backtesting._artifact_paths import sanitize_chart_label
 from prediction_market_extensions.backtesting._isolated_replay_runner import (
     run_single_replay_backtest_in_subprocess,
 )
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
     PredictionMarketBacktest,
 )
-
 
 _DEFAULT_PREDICTION_MARKET_BACKTEST_RUN_ASYNC = PredictionMarketBacktest.run_async
 

--- a/prediction_market_extensions/backtesting/_market_data_config.py
+++ b/prediction_market_extensions/backtesting/_market_data_config.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from prediction_market_extensions.backtesting.data_sources import MarketDataType
-from prediction_market_extensions.backtesting.data_sources import MarketDataVendor
-from prediction_market_extensions.backtesting.data_sources import MarketPlatform
+from prediction_market_extensions.backtesting.data_sources import (
+    MarketDataType,
+    MarketDataVendor,
+    MarketPlatform,
+)
 
 
 @dataclass(frozen=True)

--- a/prediction_market_extensions/backtesting/_market_data_support.py
+++ b/prediction_market_extensions/backtesting/_market_data_support.py
@@ -1,22 +1,13 @@
-from prediction_market_extensions.backtesting.data_sources.registry import MarketDataKey
-from prediction_market_extensions.backtesting.data_sources.registry import MarketDataSupport
 from prediction_market_extensions.backtesting.data_sources.registry import (
+    MarketDataKey,
+    MarketDataSupport,
     build_single_market_replay,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     register_market_data_support,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     resolve_market_data_support,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import resolve_replay_adapter
-from prediction_market_extensions.backtesting.data_sources.registry import (
+    resolve_replay_adapter,
     supported_market_data_keys,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     unregister_market_data_support,
 )
-
 
 __all__ = [
     "MarketDataKey",

--- a/prediction_market_extensions/backtesting/_notebook_runner.py
+++ b/prediction_market_extensions/backtesting/_notebook_runner.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from prediction_market_extensions.backtesting._notebook_support import find_updated_html_artifacts
-from prediction_market_extensions.backtesting._notebook_support import partition_html_artifacts
-from prediction_market_extensions.backtesting._notebook_support import snapshot_html_artifacts
+from prediction_market_extensions.backtesting._notebook_support import (
+    find_updated_html_artifacts,
+    partition_html_artifacts,
+    snapshot_html_artifacts,
+)
 
 AUTO_EMBED_CELL_MARKER = "<!-- prediction-market-backtesting:auto-embedded-html -->"
 NOTEBOOK_METADATA_KEY = "prediction_market_backtest"

--- a/prediction_market_extensions/backtesting/_notebook_support.py
+++ b/prediction_market_extensions/backtesting/_notebook_support.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 import importlib
 import os
 import sys
-from collections.abc import Mapping
-from collections.abc import Sequence
-from contextlib import contextmanager
-from contextlib import ExitStack
-from contextlib import redirect_stderr
-from contextlib import redirect_stdout
+from collections.abc import Mapping, Sequence
+from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -178,9 +174,7 @@ def display_html_artifacts(
         print("No new HTML artifacts were detected under output/.")
         return
 
-    from IPython.display import HTML
-    from IPython.display import Markdown
-    from IPython.display import display
+    from IPython.display import HTML, Markdown, display
 
     primary, additional = partition_html_artifacts(html_artifacts)
     primary_html = primary[-1]

--- a/prediction_market_extensions/backtesting/_optimizer.py
+++ b/prediction_market_extensions/backtesting/_optimizer.py
@@ -821,7 +821,7 @@ def _final_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[int, float,
 
 
 def _params_dict(params: ParameterValues) -> dict[str, Any]:
-    return {name: value for name, value in params}
+    return dict(params)
 
 
 def _json_safe(value: Any) -> Any:

--- a/prediction_market_extensions/backtesting/_optimizer.py
+++ b/prediction_market_extensions/backtesting/_optimizer.py
@@ -7,22 +7,15 @@ import multiprocessing
 import pickle
 import tempfile
 import traceback
-from collections.abc import Callable
-from collections.abc import Mapping
-from collections.abc import Sequence
-from dataclasses import dataclass
-from dataclasses import field
-from dataclasses import replace
-from datetime import UTC
-from datetime import datetime
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
 from itertools import product
 from pathlib import Path
 from random import Random
 from statistics import median
 from types import MappingProxyType
-from typing import Any
-from typing import Literal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
 from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig
@@ -690,7 +683,7 @@ def _evaluate_window(
                 )
             )
         results = _coerce_results(raw_results)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return _WindowEvaluation(
             window_name=window.name,
             score=config.invalid_score,
@@ -1196,6 +1189,7 @@ def run_parameter_search(
 
 __all__ = [
     "OPTIMIZER_TYPE_PARAMETER_SEARCH",
+    "SEARCH_PLACEHOLDER_PREFIX",
     "OptimizationConfig",
     "OptimizationLeaderboardRow",
     "OptimizationSummary",
@@ -1204,7 +1198,6 @@ __all__ = [
     "ParameterSearchLeaderboardRow",
     "ParameterSearchSummary",
     "ParameterSearchWindow",
-    "SEARCH_PLACEHOLDER_PREFIX",
     "build_optimization_window_backtest",
     "build_parameter_search_window_backtest",
     "run_parameter_optimization",

--- a/prediction_market_extensions/backtesting/_prediction_market_backtest.py
+++ b/prediction_market_extensions/backtesting/_prediction_market_backtest.py
@@ -1,44 +1,45 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
-
-from prediction_market_extensions.adapters.prediction_market import LoadedReplay
-from prediction_market_extensions.adapters.prediction_market import ReplayCoverageStats
-from prediction_market_extensions.adapters.prediction_market import ReplayLoadRequest
-from prediction_market_extensions.adapters.prediction_market import ReplayWindow
-from prediction_market_extensions.adapters.prediction_market.fill_model import (
-    PredictionMarketTakerFillModel,
-)
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
 from nautilus_trader.common.component import is_backtest_force_stop
 from nautilus_trader.config import LoggingConfig
 from nautilus_trader.config import StrategyFactory as NautilusStrategyFactory
 from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import TraderId
+from nautilus_trader.model.identifiers import InstrumentId, TraderId
 from nautilus_trader.model.objects import Money
 from nautilus_trader.risk.config import RiskEngineConfig
 from nautilus_trader.trading.strategy import Strategy
 
+from prediction_market_extensions.adapters.prediction_market import (
+    LoadedReplay,
+    ReplayCoverageStats,
+    ReplayLoadRequest,
+    ReplayWindow,
+)
+from prediction_market_extensions.adapters.prediction_market.fill_model import (
+    PredictionMarketTakerFillModel,
+)
+from prediction_market_extensions.analysis.legacy_plot_adapter import DEFAULT_DETAIL_PLOT_PANELS
 from prediction_market_extensions.backtesting._backtest_runtime import build_backtest_run_state
 from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
 from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig
-from prediction_market_extensions.backtesting._replay_specs import MarketSimConfig
-from prediction_market_extensions.backtesting._replay_specs import ReplaySpec
-from prediction_market_extensions.backtesting._replay_specs import coerce_legacy_market_sim_config
+from prediction_market_extensions.backtesting._replay_specs import (
+    MarketSimConfig,
+    ReplaySpec,
+    coerce_legacy_market_sim_config,
+)
 from prediction_market_extensions.backtesting._strategy_configs import (
+    StrategyConfigSpec,
     build_importable_strategy_configs,
 )
-from prediction_market_extensions.backtesting._strategy_configs import StrategyConfigSpec
 from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     RunnerKalshiDataLoader,
 )
@@ -50,13 +51,11 @@ from prediction_market_extensions.backtesting.data_sources.polymarket_native imp
 )
 from prediction_market_extensions.backtesting.data_sources.registry import resolve_replay_adapter
 from prediction_market_extensions.backtesting.prediction_market import (
+    MarketReportConfig,
     PredictionMarketArtifactBuilder,
+    finalize_market_results,
+    run_reported_backtest,
 )
-from prediction_market_extensions.backtesting.prediction_market import MarketReportConfig
-from prediction_market_extensions.backtesting.prediction_market import finalize_market_results
-from prediction_market_extensions.backtesting.prediction_market import run_reported_backtest
-from prediction_market_extensions.analysis.legacy_plot_adapter import DEFAULT_DETAIL_PLOT_PANELS
-
 
 KalshiDataLoader = RunnerKalshiDataLoader
 PolymarketDataLoader = RunnerPolymarketDataLoader

--- a/prediction_market_extensions/backtesting/_prediction_market_runner.py
+++ b/prediction_market_extensions/backtesting/_prediction_market_runner.py
@@ -1,30 +1,27 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
-
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import Strategy
 
 from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._experiments import ReplayExperiment
-from prediction_market_extensions.backtesting._experiments import run_replay_experiment_async
+from prediction_market_extensions.backtesting._experiments import (
+    ReplayExperiment,
+    run_replay_experiment_async,
+)
+from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._result_policies import ResultPolicy
-from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig
 from prediction_market_extensions.backtesting._strategy_configs import StrategyConfigSpec
 from prediction_market_extensions.backtesting.data_sources.registry import (
     build_single_market_replay,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     resolve_market_data_support,
 )
-
 
 type StrategyFactory = Callable[[InstrumentId], Strategy]
 

--- a/prediction_market_extensions/backtesting/_replay_specs.py
+++ b/prediction_market_extensions/backtesting/_replay_specs.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pandas as pd
 
-
 type TimestampLike = pd.Timestamp | str | object
 
 

--- a/prediction_market_extensions/backtesting/_result_policies.py
+++ b/prediction_market_extensions/backtesting/_result_policies.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
-from typing import Protocol
+from typing import Any, Protocol
 
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     compute_binary_settlement_pnl,
 )
-
 
 type Results = list[dict[str, Any]]
 type SettlementPnlFn = Callable[[object, object], float | None]

--- a/prediction_market_extensions/backtesting/_strategy_configs.py
+++ b/prediction_market_extensions/backtesting/_strategy_configs.py
@@ -22,7 +22,9 @@ def _normalized_config(
     if instrument_ids is None or instrument_ids == "__PRIMARY_INSTRUMENTS__":
         config["instrument_ids"] = [instrument_id]
 
-    if ("instrument_id" not in config and "instrument_ids" not in config) or config.get("instrument_id") in _PRIMARY_INSTRUMENT_SENTINELS:
+    if ("instrument_id" not in config and "instrument_ids" not in config) or config.get(
+        "instrument_id"
+    ) in _PRIMARY_INSTRUMENT_SENTINELS:
         config["instrument_id"] = instrument_id
 
     return config

--- a/prediction_market_extensions/backtesting/_strategy_configs.py
+++ b/prediction_market_extensions/backtesting/_strategy_configs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any
 
@@ -9,7 +8,6 @@ from nautilus_trader.config import ImportableStrategyConfig
 from nautilus_trader.config import StrategyFactory as NautilusStrategyFactory
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import Strategy
-
 
 type StrategyConfigSpec = Mapping[str, Any]
 
@@ -24,9 +22,7 @@ def _normalized_config(
     if instrument_ids is None or instrument_ids == "__PRIMARY_INSTRUMENTS__":
         config["instrument_ids"] = [instrument_id]
 
-    if "instrument_id" not in config and "instrument_ids" not in config:
-        config["instrument_id"] = instrument_id
-    elif config.get("instrument_id") in _PRIMARY_INSTRUMENT_SENTINELS:
+    if ("instrument_id" not in config and "instrument_ids" not in config) or config.get("instrument_id") in _PRIMARY_INSTRUMENT_SENTINELS:
         config["instrument_id"] = instrument_id
 
     return config

--- a/prediction_market_extensions/backtesting/_timing_harness.py
+++ b/prediction_market_extensions/backtesting/_timing_harness.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import os
-from inspect import isawaitable
-from inspect import iscoroutinefunction
-from collections.abc import Awaitable
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import ParamSpec
-from typing import TypeVar
-
+from inspect import isawaitable, iscoroutinefunction
+from typing import ParamSpec, TypeVar
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/prediction_market_extensions/backtesting/_timing_test.py
+++ b/prediction_market_extensions/backtesting/_timing_test.py
@@ -201,6 +201,7 @@ def install_timing() -> None:
     _installed = True
 
     from tqdm import tqdm
+
     from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
 
     try:

--- a/prediction_market_extensions/backtesting/data_sources/__init__.py
+++ b/prediction_market_extensions/backtesting/data_sources/__init__.py
@@ -1,126 +1,83 @@
 """Shared backtest data-source helpers."""
 
-from prediction_market_extensions.backtesting.data_sources.data_types import Bar
-from prediction_market_extensions.backtesting.data_sources.data_types import BAR_DATA
-from prediction_market_extensions.backtesting.data_sources.data_types import MarketDataType
-from prediction_market_extensions.backtesting.data_sources.data_types import QuoteTick
-from prediction_market_extensions.backtesting.data_sources.data_types import QUOTE_TICK_DATA
-from prediction_market_extensions.backtesting.data_sources.data_types import TradeTick
-from prediction_market_extensions.backtesting.data_sources.data_types import TRADE_TICK_DATA
+from prediction_market_extensions.backtesting.data_sources.data_types import (
+    BAR_DATA,
+    QUOTE_TICK_DATA,
+    TRADE_TICK_DATA,
+    Bar,
+    MarketDataType,
+    QuoteTick,
+    TradeTick,
+)
 from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     KALSHI_REST_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     KalshiNativeDataSourceSelection,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     KalshiNativeLoaderConfig,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     RunnerKalshiDataLoader,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     configured_kalshi_native_data_source,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
+    resolve_kalshi_native_data_source_selection,
     resolve_kalshi_native_loader_config,
 )
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
-    resolve_kalshi_native_data_source_selection,
+from prediction_market_extensions.backtesting.data_sources.platforms import (
+    KALSHI_PLATFORM,
+    POLYMARKET_PLATFORM,
+    Kalshi,
+    MarketPlatform,
+    Polymarket,
 )
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_CACHE_DIR_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_DATA_SOURCE_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_DISABLE_CACHE_ENV
 from prediction_market_extensions.backtesting.data_sources.pmxt import (
+    PMXT_CACHE_DIR_ENV,
+    PMXT_DATA_SOURCE_ENV,
+    PMXT_DISABLE_CACHE_ENV,
     PMXT_DISABLE_REMOTE_ARCHIVE_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_LOCAL_RAWS_DIR_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_REMOTE_BASE_URL_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_RAW_ROOT_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_RELAY_BASE_URL_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXTDataSourceSelection
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXTLoaderConfig
-from prediction_market_extensions.backtesting.data_sources.pmxt import (
+    PMXT_LOCAL_RAWS_DIR_ENV,
+    PMXT_RAW_ROOT_ENV,
+    PMXT_RELAY_BASE_URL_ENV,
+    PMXT_REMOTE_BASE_URL_ENV,
+    PMXTDataSourceSelection,
+    PMXTLoaderConfig,
     RunnerPolymarketPMXTDataLoader,
+    configured_pmxt_data_source,
+    resolve_pmxt_data_source_selection,
+    resolve_pmxt_loader_config,
 )
-from prediction_market_extensions.backtesting.data_sources.pmxt import configured_pmxt_data_source
-from prediction_market_extensions.backtesting.data_sources.pmxt import resolve_pmxt_loader_config
 from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     POLYMARKET_CLOB_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     POLYMARKET_GAMMA_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     POLYMARKET_TRADE_API_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     PolymarketNativeDataSourceSelection,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     PolymarketNativeLoaderConfig,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     RunnerPolymarketDataLoader,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     configured_polymarket_native_data_source,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
+    resolve_polymarket_native_data_source_selection,
     resolve_polymarket_native_loader_config,
 )
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
-    resolve_polymarket_native_data_source_selection,
-)
-from prediction_market_extensions.backtesting.data_sources.platforms import Kalshi
-from prediction_market_extensions.backtesting.data_sources.platforms import KALSHI_PLATFORM
-from prediction_market_extensions.backtesting.data_sources.platforms import MarketPlatform
-from prediction_market_extensions.backtesting.data_sources.platforms import Polymarket
-from prediction_market_extensions.backtesting.data_sources.platforms import POLYMARKET_PLATFORM
-from prediction_market_extensions.backtesting.data_sources.pmxt import (
-    resolve_pmxt_data_source_selection,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import MarketDataKey
-from prediction_market_extensions.backtesting.data_sources.registry import MarketDataSupport
 from prediction_market_extensions.backtesting.data_sources.registry import (
+    MarketDataKey,
+    MarketDataSupport,
     build_single_market_replay,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     register_market_data_support,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     resolve_market_data_support,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import resolve_replay_adapter
-from prediction_market_extensions.backtesting.data_sources.registry import (
+    resolve_replay_adapter,
     supported_market_data_keys,
-)
-from prediction_market_extensions.backtesting.data_sources.registry import (
     unregister_market_data_support,
 )
 from prediction_market_extensions.backtesting.data_sources.replay_adapters import (
     BUILTIN_REPLAY_ADAPTERS,
 )
-from prediction_market_extensions.backtesting.data_sources.vendors import MarketDataVendor
-from prediction_market_extensions.backtesting.data_sources.vendors import Native
-from prediction_market_extensions.backtesting.data_sources.vendors import NATIVE_VENDOR
-from prediction_market_extensions.backtesting.data_sources.vendors import PMXT
-from prediction_market_extensions.backtesting.data_sources.vendors import PMXT_VENDOR
+from prediction_market_extensions.backtesting.data_sources.vendors import (
+    NATIVE_VENDOR,
+    PMXT,
+    PMXT_VENDOR,
+    MarketDataVendor,
+    Native,
+)
 
 __all__ = [
-    "Bar",
     "BAR_DATA",
-    "KALSHI_REST_BASE_URL_ENV",
+    "BUILTIN_REPLAY_ADAPTERS",
     "KALSHI_PLATFORM",
-    "Kalshi",
-    "KalshiNativeDataSourceSelection",
-    "KalshiNativeLoaderConfig",
-    "MarketDataKey",
-    "MarketDataType",
-    "MarketPlatform",
-    "MarketDataSupport",
-    "MarketDataVendor",
-    "Native",
+    "KALSHI_REST_BASE_URL_ENV",
     "NATIVE_VENDOR",
     "PMXT",
     "PMXT_CACHE_DIR_ENV",
@@ -128,39 +85,48 @@ __all__ = [
     "PMXT_DISABLE_CACHE_ENV",
     "PMXT_DISABLE_REMOTE_ARCHIVE_ENV",
     "PMXT_LOCAL_RAWS_DIR_ENV",
-    "PMXT_REMOTE_BASE_URL_ENV",
     "PMXT_RAW_ROOT_ENV",
     "PMXT_RELAY_BASE_URL_ENV",
-    "PMXTDataSourceSelection",
-    "PMXTLoaderConfig",
+    "PMXT_REMOTE_BASE_URL_ENV",
     "PMXT_VENDOR",
-    "POLYMARKET_PLATFORM",
     "POLYMARKET_CLOB_BASE_URL_ENV",
     "POLYMARKET_GAMMA_BASE_URL_ENV",
+    "POLYMARKET_PLATFORM",
     "POLYMARKET_TRADE_API_BASE_URL_ENV",
+    "QUOTE_TICK_DATA",
+    "TRADE_TICK_DATA",
+    "Bar",
+    "Kalshi",
+    "KalshiNativeDataSourceSelection",
+    "KalshiNativeLoaderConfig",
+    "MarketDataKey",
+    "MarketDataSupport",
+    "MarketDataType",
+    "MarketDataVendor",
+    "MarketPlatform",
+    "Native",
+    "PMXTDataSourceSelection",
+    "PMXTLoaderConfig",
     "Polymarket",
     "PolymarketNativeDataSourceSelection",
     "PolymarketNativeLoaderConfig",
     "QuoteTick",
-    "QUOTE_TICK_DATA",
     "RunnerKalshiDataLoader",
     "RunnerPolymarketDataLoader",
     "RunnerPolymarketPMXTDataLoader",
     "TradeTick",
-    "TRADE_TICK_DATA",
-    "BUILTIN_REPLAY_ADAPTERS",
     "build_single_market_replay",
     "configured_kalshi_native_data_source",
-    "configured_polymarket_native_data_source",
     "configured_pmxt_data_source",
+    "configured_polymarket_native_data_source",
     "register_market_data_support",
-    "resolve_kalshi_native_loader_config",
     "resolve_kalshi_native_data_source_selection",
+    "resolve_kalshi_native_loader_config",
     "resolve_market_data_support",
-    "resolve_polymarket_native_loader_config",
-    "resolve_polymarket_native_data_source_selection",
-    "resolve_pmxt_loader_config",
     "resolve_pmxt_data_source_selection",
+    "resolve_pmxt_loader_config",
+    "resolve_polymarket_native_data_source_selection",
+    "resolve_polymarket_native_loader_config",
     "resolve_replay_adapter",
     "supported_market_data_keys",
     "unregister_market_data_support",

--- a/prediction_market_extensions/backtesting/data_sources/_common.py
+++ b/prediction_market_extensions/backtesting/data_sources/_common.py
@@ -4,7 +4,6 @@ import re
 from pathlib import Path
 from urllib.parse import urlparse
 
-
 DISABLED_ENV_VALUES = {"", "0", "false", "no", "off", "none", "disabled"}
 
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")

--- a/prediction_market_extensions/backtesting/data_sources/data_types.py
+++ b/prediction_market_extensions/backtesting/data_sources/data_types.py
@@ -24,11 +24,11 @@ BAR_DATA = Bar
 
 
 __all__ = [
-    "Bar",
     "BAR_DATA",
+    "QUOTE_TICK_DATA",
+    "TRADE_TICK_DATA",
+    "Bar",
     "MarketDataType",
     "QuoteTick",
-    "QUOTE_TICK_DATA",
     "TradeTick",
-    "TRADE_TICK_DATA",
 ]

--- a/prediction_market_extensions/backtesting/data_sources/kalshi_native.py
+++ b/prediction_market_extensions/backtesting/data_sources/kalshi_native.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Iterator, Sequence
+from typing import Any
 
 import msgspec
 

--- a/prediction_market_extensions/backtesting/data_sources/kalshi_native.py
+++ b/prediction_market_extensions/backtesting/data_sources/kalshi_native.py
@@ -11,13 +11,13 @@ import msgspec
 
 from prediction_market_extensions.adapters.kalshi.loaders import KalshiDataLoader
 from prediction_market_extensions.adapters.kalshi.providers import market_dict_to_instrument
-
-from prediction_market_extensions.backtesting.data_sources._common import env_value
-from prediction_market_extensions.backtesting.data_sources._common import is_disabled
-from prediction_market_extensions.backtesting.data_sources._common import looks_like_local_path
-from prediction_market_extensions.backtesting.data_sources._common import normalize_urlish
-from prediction_market_extensions.backtesting.data_sources._common import trim_url_suffix
-
+from prediction_market_extensions.backtesting.data_sources._common import (
+    env_value,
+    is_disabled,
+    looks_like_local_path,
+    normalize_urlish,
+    trim_url_suffix,
+)
 
 KALSHI_REST_BASE_URL_ENV = "KALSHI_REST_BASE_URL"
 _KALSHI_REST_SUFFIXES = ("/markets/trades", "/markets", "/events", "/series")

--- a/prediction_market_extensions/backtesting/data_sources/platforms.py
+++ b/prediction_market_extensions/backtesting/data_sources/platforms.py
@@ -21,4 +21,4 @@ KALSHI_PLATFORM = Kalshi
 POLYMARKET_PLATFORM = Polymarket
 
 
-__all__ = ["Kalshi", "KALSHI_PLATFORM", "MarketPlatform", "Polymarket", "POLYMARKET_PLATFORM"]
+__all__ = ["KALSHI_PLATFORM", "POLYMARKET_PLATFORM", "Kalshi", "MarketPlatform", "Polymarket"]

--- a/prediction_market_extensions/backtesting/data_sources/pmxt.py
+++ b/prediction_market_extensions/backtesting/data_sources/pmxt.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextlib import suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Sequence
 from urllib.request import Request
 from urllib.request import urlopen
 
@@ -198,7 +198,7 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
         del hour
         # The active relay only serves raw hours, so runner code never attempts
         # any alternate relay data path here.
-        return None
+        return
 
     @classmethod
     def _resolve_source_priority(cls) -> tuple[str, ...]:

--- a/prediction_market_extensions/backtesting/data_sources/pmxt.py
+++ b/prediction_market_extensions/backtesting/data_sources/pmxt.py
@@ -3,24 +3,22 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
-import pyarrow.dataset as ds
 import pyarrow as pa
+import pyarrow.dataset as ds
 
 from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
-
-from prediction_market_extensions.backtesting.data_sources._common import DISABLED_ENV_VALUES
-from prediction_market_extensions.backtesting.data_sources._common import env_value
-from prediction_market_extensions.backtesting.data_sources._common import normalize_local_path
-from prediction_market_extensions.backtesting.data_sources._common import normalize_urlish
-
+from prediction_market_extensions.backtesting.data_sources._common import (
+    DISABLED_ENV_VALUES,
+    env_value,
+    normalize_local_path,
+    normalize_urlish,
+)
 
 PMXT_DATA_SOURCE_ENV = "PMXT_DATA_SOURCE"
 PMXT_LOCAL_RAWS_DIR_ENV = "PMXT_LOCAL_RAWS_DIR"
@@ -198,7 +196,6 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
         del hour
         # The active relay only serves raw hours, so runner code never attempts
         # any alternate relay data path here.
-        return
 
     @classmethod
     def _resolve_source_priority(cls) -> tuple[str, ...]:
@@ -329,7 +326,7 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
         with (
             urlopen(request, timeout=_PMXT_RUNNER_HTTP_TIMEOUT_SECS) as response,
             destination.open("wb") as handle,
-        ):  # noqa: S310
+        ):
             total_bytes = self._content_length_from_response(response)
             downloaded_bytes = 0
             last_emit = 0.0
@@ -378,7 +375,7 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
 
     def _download_payload_with_progress(self, url: str) -> bytes | None:
         request = Request(url, headers={"User-Agent": _PMXT_RUNNER_HTTP_USER_AGENT})
-        with urlopen(request, timeout=_PMXT_RUNNER_HTTP_TIMEOUT_SECS) as response:  # noqa: S310
+        with urlopen(request, timeout=_PMXT_RUNNER_HTTP_TIMEOUT_SECS) as response:
             total_bytes = self._content_length_from_response(response)
             downloaded_bytes = 0
             last_emit = 0.0
@@ -433,7 +430,7 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
                 source, method="HEAD", headers={"User-Agent": _PMXT_RUNNER_HTTP_USER_AGENT}
             )
             try:
-                with urlopen(request, timeout=_PMXT_RUNNER_HTTP_TIMEOUT_SECS) as response:  # noqa: S310
+                with urlopen(request, timeout=_PMXT_RUNNER_HTTP_TIMEOUT_SECS) as response:
                     total_bytes = self._content_length_from_response(response)
             except Exception:
                 total_bytes = None

--- a/prediction_market_extensions/backtesting/data_sources/polymarket_native.py
+++ b/prediction_market_extensions/backtesting/data_sources/polymarket_native.py
@@ -11,13 +11,13 @@ from urllib.parse import urlparse
 import msgspec
 
 from prediction_market_extensions.adapters.polymarket.loaders import PolymarketDataLoader
-
-from prediction_market_extensions.backtesting.data_sources._common import env_value
-from prediction_market_extensions.backtesting.data_sources._common import is_disabled
-from prediction_market_extensions.backtesting.data_sources._common import looks_like_local_path
-from prediction_market_extensions.backtesting.data_sources._common import normalize_urlish
-from prediction_market_extensions.backtesting.data_sources._common import trim_url_suffix
-
+from prediction_market_extensions.backtesting.data_sources._common import (
+    env_value,
+    is_disabled,
+    looks_like_local_path,
+    normalize_urlish,
+    trim_url_suffix,
+)
 
 POLYMARKET_GAMMA_BASE_URL_ENV = "POLYMARKET_GAMMA_BASE_URL"
 POLYMARKET_CLOB_BASE_URL_ENV = "POLYMARKET_CLOB_BASE_URL"

--- a/prediction_market_extensions/backtesting/data_sources/polymarket_native.py
+++ b/prediction_market_extensions/backtesting/data_sources/polymarket_native.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Iterator, Sequence
+from typing import Any
 from urllib.parse import urlparse
 
 import msgspec

--- a/prediction_market_extensions/backtesting/data_sources/registry.py
+++ b/prediction_market_extensions/backtesting/data_sources/registry.py
@@ -4,12 +4,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from prediction_market_extensions.adapters.prediction_market import HistoricalReplayAdapter
-
 from prediction_market_extensions.backtesting._replay_specs import ReplaySpec
 from prediction_market_extensions.backtesting.data_sources.replay_adapters import (
     BUILTIN_REPLAY_ADAPTERS,
 )
-
 
 type MarketDataKey = tuple[str, str, str]
 

--- a/prediction_market_extensions/backtesting/data_sources/registry.py
+++ b/prediction_market_extensions/backtesting/data_sources/registry.py
@@ -92,8 +92,7 @@ def supported_market_data_keys() -> tuple[MarketDataKey, ...]:
 def build_single_market_replay(
     *, support: MarketDataSupport, field_values: dict[str, Any]
 ) -> ReplaySpec:
-    replay = support.adapter.build_single_market_replay(field_values=field_values)
-    return replay
+    return support.adapter.build_single_market_replay(field_values=field_values)
 
 
 __all__ = [

--- a/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
+++ b/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
@@ -1,40 +1,35 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from importlib import import_module
 from typing import Any
 
 import pandas as pd
+from nautilus_trader.adapters.polymarket import POLYMARKET_VENUE
+from nautilus_trader.model.currencies import USD, USDC_POS
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.enums import AccountType, BookType, OmsType
+from nautilus_trader.model.identifiers import Venue
 
 from prediction_market_extensions.adapters.kalshi.fee_model import KalshiProportionalFeeModel
-from nautilus_trader.adapters.polymarket import POLYMARKET_VENUE
 from prediction_market_extensions.adapters.polymarket.fee_model import PolymarketFeeModel
-from prediction_market_extensions.adapters.prediction_market import HistoricalReplayAdapter
-from prediction_market_extensions.adapters.prediction_market import LoadedReplay
-from prediction_market_extensions.adapters.prediction_market import ReplayAdapterKey
-from prediction_market_extensions.adapters.prediction_market import ReplayCoverageStats
-from prediction_market_extensions.adapters.prediction_market import ReplayEngineProfile
-from prediction_market_extensions.adapters.prediction_market import ReplayLoadRequest
-from prediction_market_extensions.adapters.prediction_market import ReplayWindow
+from prediction_market_extensions.adapters.prediction_market import (
+    HistoricalReplayAdapter,
+    LoadedReplay,
+    ReplayAdapterKey,
+    ReplayCoverageStats,
+    ReplayEngineProfile,
+    ReplayLoadRequest,
+    ReplayWindow,
+)
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     infer_realized_outcome,
 )
-from nautilus_trader.model.currencies import USD
-from nautilus_trader.model.currencies import USDC_POS
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.enums import AccountType
-from nautilus_trader.model.enums import BookType
-from nautilus_trader.model.enums import OmsType
-from nautilus_trader.model.identifiers import Venue
-
 from prediction_market_extensions.backtesting._backtest_runtime import _record_timestamp_ns
-from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
-from prediction_market_extensions.backtesting._replay_specs import TradeReplay
+from prediction_market_extensions.backtesting._replay_specs import QuoteReplay, TradeReplay
 from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     RunnerKalshiDataLoader as KalshiDataLoader,
 )

--- a/prediction_market_extensions/backtesting/data_sources/vendors.py
+++ b/prediction_market_extensions/backtesting/data_sources/vendors.py
@@ -21,4 +21,4 @@ Native = NATIVE_VENDOR
 PMXT = PMXT_VENDOR
 
 
-__all__ = ["MarketDataVendor", "Native", "NATIVE_VENDOR", "PMXT", "PMXT_VENDOR"]
+__all__ = ["NATIVE_VENDOR", "PMXT", "PMXT_VENDOR", "MarketDataVendor", "Native"]

--- a/prediction_market_extensions/backtesting/optimizers/__init__.py
+++ b/prediction_market_extensions/backtesting/optimizers/__init__.py
@@ -1,22 +1,23 @@
-from prediction_market_extensions.backtesting._optimizer import OPTIMIZER_TYPE_PARAMETER_SEARCH
-from prediction_market_extensions.backtesting._optimizer import OptimizationConfig
-from prediction_market_extensions.backtesting._optimizer import OptimizationLeaderboardRow
-from prediction_market_extensions.backtesting._optimizer import OptimizationSummary
-from prediction_market_extensions.backtesting._optimizer import OptimizationWindow
-from prediction_market_extensions.backtesting._optimizer import ParameterSearchConfig
-from prediction_market_extensions.backtesting._optimizer import ParameterSearchLeaderboardRow
-from prediction_market_extensions.backtesting._optimizer import ParameterSearchSummary
-from prediction_market_extensions.backtesting._optimizer import ParameterSearchWindow
-from prediction_market_extensions.backtesting._optimizer import SEARCH_PLACEHOLDER_PREFIX
-from prediction_market_extensions.backtesting._optimizer import build_optimization_window_backtest
 from prediction_market_extensions.backtesting._optimizer import (
+    OPTIMIZER_TYPE_PARAMETER_SEARCH,
+    SEARCH_PLACEHOLDER_PREFIX,
+    OptimizationConfig,
+    OptimizationLeaderboardRow,
+    OptimizationSummary,
+    OptimizationWindow,
+    ParameterSearchConfig,
+    ParameterSearchLeaderboardRow,
+    ParameterSearchSummary,
+    ParameterSearchWindow,
+    build_optimization_window_backtest,
     build_parameter_search_window_backtest,
+    run_parameter_optimization,
+    run_parameter_search,
 )
-from prediction_market_extensions.backtesting._optimizer import run_parameter_optimization
-from prediction_market_extensions.backtesting._optimizer import run_parameter_search
 
 __all__ = [
     "OPTIMIZER_TYPE_PARAMETER_SEARCH",
+    "SEARCH_PLACEHOLDER_PREFIX",
     "OptimizationConfig",
     "OptimizationLeaderboardRow",
     "OptimizationSummary",
@@ -25,7 +26,6 @@ __all__ = [
     "ParameterSearchLeaderboardRow",
     "ParameterSearchSummary",
     "ParameterSearchWindow",
-    "SEARCH_PLACEHOLDER_PREFIX",
     "build_optimization_window_backtest",
     "build_parameter_search_window_backtest",
     "run_parameter_optimization",

--- a/prediction_market_extensions/backtesting/prediction_market/__init__.py
+++ b/prediction_market_extensions/backtesting/prediction_market/__init__.py
@@ -1,17 +1,12 @@
 from prediction_market_extensions.backtesting.prediction_market.artifacts import (
     PredictionMarketArtifactBuilder,
-)
-from prediction_market_extensions.backtesting.prediction_market.artifacts import (
     resolve_repo_relative_path,
 )
-from prediction_market_extensions.backtesting.prediction_market.reporting import MarketReportConfig
 from prediction_market_extensions.backtesting.prediction_market.reporting import (
+    MarketReportConfig,
     finalize_market_results,
-)
-from prediction_market_extensions.backtesting.prediction_market.reporting import (
     run_reported_backtest,
 )
-
 
 __all__ = [
     "MarketReportConfig",

--- a/prediction_market_extensions/backtesting/prediction_market/artifacts.py
+++ b/prediction_market_extensions/backtesting/prediction_market/artifacts.py
@@ -80,7 +80,7 @@ class PredictionMarketArtifactBuilder:
         result: dict[str, Any] = {
             loaded_sim.market_key: loaded_sim.market_id,
             loaded_sim.count_key: loaded_sim.count,
-            "fills": int(len(instrument_fills)),
+            "fills": len(instrument_fills),
             "pnl": float(pnl),
             "instrument_id": instrument_id,
             "outcome": loaded_sim.outcome,

--- a/prediction_market_extensions/backtesting/prediction_market/artifacts.py
+++ b/prediction_market_extensions/backtesting/prediction_market/artifacts.py
@@ -1,39 +1,30 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from nautilus_trader.backtest.engine import BacktestEngine
 
+from prediction_market_extensions.adapters.prediction_market import LoadedReplay
 from prediction_market_extensions.adapters.prediction_market import (
     research as prediction_market_research,
 )
-from prediction_market_extensions.adapters.prediction_market import LoadedReplay
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     build_brier_inputs,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     build_market_prices,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     downsample_price_points,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_price_points,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_realized_pnl,
 )
-from prediction_market_extensions.analysis.legacy_plot_adapter import build_legacy_backtest_layout
-from prediction_market_extensions.analysis.legacy_plot_adapter import save_legacy_backtest_layout
-from nautilus_trader.backtest.engine import BacktestEngine
-
+from prediction_market_extensions.analysis.legacy_plot_adapter import (
+    build_legacy_backtest_layout,
+    save_legacy_backtest_layout,
+)
 from prediction_market_extensions.backtesting._backtest_runtime import apply_backtest_run_state
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 

--- a/prediction_market_extensions/backtesting/prediction_market/reporting.py
+++ b/prediction_market_extensions/backtesting/prediction_market/reporting.py
@@ -4,17 +4,14 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from prediction_market_extensions.adapters.prediction_market.research import print_backtest_summary
 from prediction_market_extensions.adapters.prediction_market.research import (
+    print_backtest_summary,
     save_aggregate_backtest_report,
-)
-from prediction_market_extensions.adapters.prediction_market.research import (
     save_joint_portfolio_backtest_report,
 )
 from prediction_market_extensions.analysis.legacy_backtesting.models import (
     DEFAULT_SUMMARY_PLOT_PANELS,
 )
-
 from prediction_market_extensions.backtesting._backtest_runtime import (
     print_backtest_result_warnings,
 )

--- a/scripts/_pmxt_raw_download.py
+++ b/scripts/_pmxt_raw_download.py
@@ -1,25 +1,18 @@
 from __future__ import annotations
 
-from collections import Counter
-from dataclasses import asdict
-from dataclasses import dataclass
-from datetime import UTC
-from datetime import datetime
-from datetime import timedelta
-from pathlib import Path
 import os
 import time
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from urllib.error import HTTPError
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 from tqdm.auto import tqdm
 
-from pmxt_relay.archive import extract_archive_filenames
-from pmxt_relay.archive import fetch_archive_page
-from pmxt_relay.storage import parse_archive_hour
-from pmxt_relay.storage import raw_relative_path
-
+from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
+from pmxt_relay.storage import parse_archive_hour, raw_relative_path
 
 _USER_AGENT = "prediction-market-backtesting/1.0"
 _DEFAULT_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/data/Polymarket"
@@ -482,7 +475,7 @@ def download_raw_hours(
                     last_error = exc
                     if exc.code != 404:
                         continue
-                except Exception as exc:  # noqa: BLE001
+                except Exception as exc:
                     last_error = exc
                     continue
 

--- a/scripts/_pmxt_raw_download.py
+++ b/scripts/_pmxt_raw_download.py
@@ -259,9 +259,9 @@ def _set_status(
     progress_bar.set_description_str(description, refresh=False)
     progress_bar.set_postfix_str(status, refresh=False)
     progress_bar.refresh()
-    setattr(progress_bar, "_pmxt_last_status_ts", now)
-    setattr(progress_bar, "_pmxt_last_status", status)
-    setattr(progress_bar, "_pmxt_last_description", description)
+    progress_bar._pmxt_last_status_ts = now
+    progress_bar._pmxt_last_status = status
+    progress_bar._pmxt_last_description = description
 
 
 def _write_progress_line(progress_bar: tqdm | None, line: str) -> None:

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -20,73 +20,86 @@
 Prediction market strategy examples.
 """
 
-from strategies.breakout import BarBreakoutConfig
-from strategies.breakout import BarBreakoutStrategy
-from strategies.breakout import QuoteTickBreakoutConfig
-from strategies.breakout import QuoteTickBreakoutStrategy
-from strategies.breakout import TradeTickBreakoutConfig
-from strategies.breakout import TradeTickBreakoutStrategy
-from strategies.deep_value import QuoteTickDeepValueHoldConfig
-from strategies.deep_value import QuoteTickDeepValueHoldStrategy
-from strategies.deep_value import TradeTickDeepValueHoldConfig
-from strategies.deep_value import TradeTickDeepValueHoldStrategy
-from strategies.ema_crossover import BarEMACrossoverConfig
-from strategies.ema_crossover import BarEMACrossoverStrategy
-from strategies.ema_crossover import QuoteTickEMACrossoverConfig
-from strategies.ema_crossover import QuoteTickEMACrossoverStrategy
-from strategies.ema_crossover import TradeTickEMACrossoverConfig
-from strategies.ema_crossover import TradeTickEMACrossoverStrategy
-from strategies.final_period_momentum import BarFinalPeriodMomentumConfig
-from strategies.final_period_momentum import BarFinalPeriodMomentumStrategy
-from strategies.final_period_momentum import QuoteTickFinalPeriodMomentumConfig
-from strategies.final_period_momentum import QuoteTickFinalPeriodMomentumStrategy
-from strategies.final_period_momentum import TradeTickFinalPeriodMomentumConfig
-from strategies.final_period_momentum import TradeTickFinalPeriodMomentumStrategy
-from strategies.late_favorite_limit_hold import QuoteTickLateFavoriteLimitHoldConfig
-from strategies.late_favorite_limit_hold import QuoteTickLateFavoriteLimitHoldStrategy
-from strategies.late_favorite_limit_hold import TradeTickLateFavoriteLimitHoldConfig
-from strategies.late_favorite_limit_hold import TradeTickLateFavoriteLimitHoldStrategy
-from strategies.mean_reversion import BarMeanReversionConfig
-from strategies.mean_reversion import BarMeanReversionStrategy
-from strategies.mean_reversion import QuoteTickMeanReversionConfig
-from strategies.mean_reversion import QuoteTickMeanReversionStrategy
-from strategies.mean_reversion import TradeTickMeanReversionConfig
-from strategies.mean_reversion import TradeTickMeanReversionStrategy
-from strategies.panic_fade import BarPanicFadeConfig
-from strategies.panic_fade import BarPanicFadeStrategy
-from strategies.panic_fade import QuoteTickPanicFadeConfig
-from strategies.panic_fade import QuoteTickPanicFadeStrategy
-from strategies.panic_fade import TradeTickPanicFadeConfig
-from strategies.panic_fade import TradeTickPanicFadeStrategy
-from strategies.rsi_reversion import BarRSIReversionConfig
-from strategies.rsi_reversion import BarRSIReversionStrategy
-from strategies.rsi_reversion import QuoteTickRSIReversionConfig
-from strategies.rsi_reversion import QuoteTickRSIReversionStrategy
-from strategies.rsi_reversion import TradeTickRSIReversionConfig
-from strategies.rsi_reversion import TradeTickRSIReversionStrategy
-from strategies.threshold_momentum import BarThresholdMomentumConfig
-from strategies.threshold_momentum import BarThresholdMomentumStrategy
-from strategies.threshold_momentum import QuoteTickThresholdMomentumConfig
-from strategies.threshold_momentum import QuoteTickThresholdMomentumStrategy
-from strategies.threshold_momentum import TradeTickThresholdMomentumConfig
-from strategies.threshold_momentum import TradeTickThresholdMomentumStrategy
-from strategies.vwap_reversion import QuoteTickVWAPReversionConfig
-from strategies.vwap_reversion import QuoteTickVWAPReversionStrategy
-from strategies.vwap_reversion import TradeTickVWAPReversionConfig
-from strategies.vwap_reversion import TradeTickVWAPReversionStrategy
-
+from strategies.breakout import (
+    BarBreakoutConfig,
+    BarBreakoutStrategy,
+    QuoteTickBreakoutConfig,
+    QuoteTickBreakoutStrategy,
+    TradeTickBreakoutConfig,
+    TradeTickBreakoutStrategy,
+)
+from strategies.deep_value import (
+    QuoteTickDeepValueHoldConfig,
+    QuoteTickDeepValueHoldStrategy,
+    TradeTickDeepValueHoldConfig,
+    TradeTickDeepValueHoldStrategy,
+)
+from strategies.ema_crossover import (
+    BarEMACrossoverConfig,
+    BarEMACrossoverStrategy,
+    QuoteTickEMACrossoverConfig,
+    QuoteTickEMACrossoverStrategy,
+    TradeTickEMACrossoverConfig,
+    TradeTickEMACrossoverStrategy,
+)
+from strategies.final_period_momentum import (
+    BarFinalPeriodMomentumConfig,
+    BarFinalPeriodMomentumStrategy,
+    QuoteTickFinalPeriodMomentumConfig,
+    QuoteTickFinalPeriodMomentumStrategy,
+    TradeTickFinalPeriodMomentumConfig,
+    TradeTickFinalPeriodMomentumStrategy,
+)
+from strategies.late_favorite_limit_hold import (
+    QuoteTickLateFavoriteLimitHoldConfig,
+    QuoteTickLateFavoriteLimitHoldStrategy,
+    TradeTickLateFavoriteLimitHoldConfig,
+    TradeTickLateFavoriteLimitHoldStrategy,
+)
+from strategies.mean_reversion import (
+    BarMeanReversionConfig,
+    BarMeanReversionStrategy,
+    QuoteTickMeanReversionConfig,
+    QuoteTickMeanReversionStrategy,
+    TradeTickMeanReversionConfig,
+    TradeTickMeanReversionStrategy,
+)
+from strategies.panic_fade import (
+    BarPanicFadeConfig,
+    BarPanicFadeStrategy,
+    QuoteTickPanicFadeConfig,
+    QuoteTickPanicFadeStrategy,
+    TradeTickPanicFadeConfig,
+    TradeTickPanicFadeStrategy,
+)
+from strategies.rsi_reversion import (
+    BarRSIReversionConfig,
+    BarRSIReversionStrategy,
+    QuoteTickRSIReversionConfig,
+    QuoteTickRSIReversionStrategy,
+    TradeTickRSIReversionConfig,
+    TradeTickRSIReversionStrategy,
+)
+from strategies.threshold_momentum import (
+    BarThresholdMomentumConfig,
+    BarThresholdMomentumStrategy,
+    QuoteTickThresholdMomentumConfig,
+    QuoteTickThresholdMomentumStrategy,
+    TradeTickThresholdMomentumConfig,
+    TradeTickThresholdMomentumStrategy,
+)
+from strategies.vwap_reversion import (
+    QuoteTickVWAPReversionConfig,
+    QuoteTickVWAPReversionStrategy,
+    TradeTickVWAPReversionConfig,
+    TradeTickVWAPReversionStrategy,
+)
 
 __all__ = [
     "BarBreakoutConfig",
     "BarBreakoutStrategy",
     "BarEMACrossoverConfig",
     "BarEMACrossoverStrategy",
-    "QuoteTickBreakoutConfig",
-    "QuoteTickBreakoutStrategy",
-    "QuoteTickDeepValueHoldConfig",
-    "QuoteTickDeepValueHoldStrategy",
-    "QuoteTickEMACrossoverConfig",
-    "QuoteTickEMACrossoverStrategy",
     "BarFinalPeriodMomentumConfig",
     "BarFinalPeriodMomentumStrategy",
     "BarMeanReversionConfig",
@@ -95,6 +108,14 @@ __all__ = [
     "BarPanicFadeStrategy",
     "BarRSIReversionConfig",
     "BarRSIReversionStrategy",
+    "BarThresholdMomentumConfig",
+    "BarThresholdMomentumStrategy",
+    "QuoteTickBreakoutConfig",
+    "QuoteTickBreakoutStrategy",
+    "QuoteTickDeepValueHoldConfig",
+    "QuoteTickDeepValueHoldStrategy",
+    "QuoteTickEMACrossoverConfig",
+    "QuoteTickEMACrossoverStrategy",
     "QuoteTickFinalPeriodMomentumConfig",
     "QuoteTickFinalPeriodMomentumStrategy",
     "QuoteTickLateFavoriteLimitHoldConfig",
@@ -125,8 +146,6 @@ __all__ = [
     "TradeTickPanicFadeStrategy",
     "TradeTickRSIReversionConfig",
     "TradeTickRSIReversionStrategy",
-    "BarThresholdMomentumConfig",
-    "BarThresholdMomentumStrategy",
     "TradeTickThresholdMomentumConfig",
     "TradeTickThresholdMomentumStrategy",
     "TradeTickVWAPReversionConfig",

--- a/strategies/breakout.py
+++ b/strategies/breakout.py
@@ -23,14 +23,12 @@ from decimal import Decimal
 from math import sqrt
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _BreakoutConfig(Protocol):

--- a/strategies/core.py
+++ b/strategies/core.py
@@ -18,15 +18,12 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
-from decimal import InvalidOperation
+from decimal import Decimal, InvalidOperation
 from typing import Protocol
 
-from nautilus_trader.model.enums import OrderSide
-from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.enums import OrderSide, TimeInForce
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import Strategy
-
 
 ENTRY_AFFORDABILITY_BUFFER = Decimal("0.97")
 
@@ -46,8 +43,8 @@ def _decimal_or_none(value: object) -> Decimal | None:
 
 
 def _estimate_entry_unit_cost(*, reference_price: Decimal, taker_fee: Decimal) -> Decimal:
-    clamped_price = min(max(reference_price, Decimal("0")), Decimal("1"))
-    return clamped_price + (taker_fee * clamped_price * (Decimal("1") - clamped_price))
+    clamped_price = min(max(reference_price, Decimal(0)), Decimal(1))
+    return clamped_price + (taker_fee * clamped_price * (Decimal(1) - clamped_price))
 
 
 def _cap_entry_size_to_free_balance(
@@ -58,12 +55,12 @@ def _cap_entry_size_to_free_balance(
     free_balance: Decimal | None,
 ) -> Decimal:
     if desired_size <= 0:
-        return Decimal("0")
+        return Decimal(0)
     if reference_price is None or reference_price <= 0 or free_balance is None:
         return desired_size
 
     unit_cost = _estimate_entry_unit_cost(
-        reference_price=reference_price, taker_fee=max(taker_fee, Decimal("0"))
+        reference_price=reference_price, taker_fee=max(taker_fee, Decimal(0))
     )
     if unit_cost <= 0:
         return desired_size
@@ -71,18 +68,18 @@ def _cap_entry_size_to_free_balance(
     # Leave a small cash buffer so marketable entries do not spend exactly to
     # the displayed top-of-book estimate on thin books.
     affordable_size = (free_balance * ENTRY_AFFORDABILITY_BUFFER) / unit_cost
-    return max(Decimal("0"), min(desired_size, affordable_size))
+    return max(Decimal(0), min(desired_size, affordable_size))
 
 
 def _cap_entry_size_to_visible_liquidity(
     *, desired_size: Decimal, visible_size: Decimal | None
 ) -> Decimal:
     if desired_size <= 0:
-        return Decimal("0")
+        return Decimal(0)
     if visible_size is None:
         return desired_size
     if visible_size <= 0:
-        return Decimal("0")
+        return Decimal(0)
     return min(desired_size, visible_size)
 
 
@@ -96,7 +93,7 @@ def _effective_entry_reference_price(
     # binary prediction market. Size against that worst-case cash usage rather
     # than the last print to avoid manufacturing affordable size from stale
     # trade-only signals.
-    return Decimal("1")
+    return Decimal(1)
 
 
 class LongOnlyPredictionMarketStrategy(Strategy):
@@ -151,7 +148,7 @@ class LongOnlyPredictionMarketStrategy(Strategy):
             reference_price=_effective_entry_reference_price(
                 reference_price=_decimal_or_none(reference_price), visible_size=visible_size_decimal
             ),
-            taker_fee=_decimal_or_none(self._instrument.taker_fee) or Decimal("0"),
+            taker_fee=_decimal_or_none(self._instrument.taker_fee) or Decimal(0),
             free_balance=self._free_quote_balance(),
         )
         if capped_size <= 0:

--- a/strategies/deep_value.py
+++ b/strategies/deep_value.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import QuoteTick, TradeTick
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class TradeTickDeepValueHoldConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]

--- a/strategies/ema_crossover.py
+++ b/strategies/ema_crossover.py
@@ -21,13 +21,11 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _EMACrossoverConfig(Protocol):

--- a/strategies/final_period_momentum.py
+++ b/strategies/final_period_momentum.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _FinalPeriodMomentumConfig(Protocol):

--- a/strategies/late_favorite_limit_hold.py
+++ b/strategies/late_favorite_limit_hold.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
-from nautilus_trader.model.enums import OrderSide
-from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.data import QuoteTick, TradeTick
+from nautilus_trader.model.enums import OrderSide, TimeInForce
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class TradeTickLateFavoriteLimitHoldConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -22,13 +22,11 @@ from collections import deque
 from decimal import Decimal
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _MeanReversionConfig(Protocol):

--- a/strategies/panic_fade.py
+++ b/strategies/panic_fade.py
@@ -22,14 +22,12 @@ from collections import deque
 from decimal import Decimal
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _PanicFadeConfig(Protocol):

--- a/strategies/rsi_reversion.py
+++ b/strategies/rsi_reversion.py
@@ -22,13 +22,11 @@ from collections import deque
 from decimal import Decimal
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _RSIReversionConfig(Protocol):

--- a/strategies/threshold_momentum.py
+++ b/strategies/threshold_momentum.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Protocol
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import Bar
-from nautilus_trader.model.data import BarType
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import Bar, BarType, QuoteTick, TradeTick
 from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class _ThresholdMomentumConfig(Protocol):

--- a/strategies/vwap_reversion.py
+++ b/strategies/vwap_reversion.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 from collections import deque
 from decimal import Decimal
 
-from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.data import QuoteTick
-from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.data import QuoteTick, TradeTick
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies.core import LongOnlyPredictionMarketStrategy
 
 
 class TradeTickVWAPReversionConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,5 +2,4 @@ from __future__ import annotations
 
 from prediction_market_extensions import install_commission_patch
 
-
 install_commission_patch()

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BACKTESTS_ROOT = REPO_ROOT / "backtests"
 

--- a/tests/test_backtest_script_helpers.py
+++ b/tests/test_backtest_script_helpers.py
@@ -5,9 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from backtests._script_helpers import ensure_repo_root
-from backtests._script_helpers import parse_bool_env
-from backtests._script_helpers import parse_csv_env
+from backtests._script_helpers import ensure_repo_root, parse_bool_env, parse_csv_env
 
 
 def test_ensure_repo_root_bootstraps_repo_path_and_commission_patch(

--- a/tests/test_backtest_utils.py
+++ b/tests/test_backtest_utils.py
@@ -3,16 +3,14 @@
 # Modified in this repository on 2026-03-11 and 2026-03-15.
 # See the repository NOTICE file for provenance and licensing scope.
 
-from datetime import datetime
 import warnings
+from datetime import datetime
 
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     compute_binary_settlement_pnl,
-)
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     extract_price_points,
+    to_naive_utc,
 )
-from prediction_market_extensions.adapters.prediction_market.backtest_utils import to_naive_utc
 
 
 def test_compute_binary_settlement_pnl_marks_open_position_to_resolution():

--- a/tests/test_breakout_strategy_behavior.py
+++ b/tests/test_breakout_strategy_behavior.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 from decimal import Decimal
 from types import SimpleNamespace
 
-from strategies import QuoteTickBreakoutConfig
-from strategies import QuoteTickBreakoutStrategy
 from nautilus_trader.model.enums import OrderSide
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
+from strategies import QuoteTickBreakoutConfig, QuoteTickBreakoutStrategy
 
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
 
@@ -47,7 +44,7 @@ def test_quote_breakout_requires_move_beyond_noise_before_entering() -> None:
     strategy = _BreakoutHarness(
         QuoteTickBreakoutConfig(
             instrument_id=INSTRUMENT_ID,
-            trade_size=Decimal("1"),
+            trade_size=Decimal(1),
             window=4,
             breakout_std=1.0,
             breakout_buffer=0.0005,
@@ -71,7 +68,7 @@ def test_quote_breakout_uses_hold_period_and_reentry_cooldown() -> None:
     strategy = _BreakoutHarness(
         QuoteTickBreakoutConfig(
             instrument_id=INSTRUMENT_ID,
-            trade_size=Decimal("1"),
+            trade_size=Decimal(1),
             window=4,
             breakout_std=1.0,
             breakout_buffer=0.0005,

--- a/tests/test_docs_nav.py
+++ b/tests/test_docs_nav.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_ROOT = REPO_ROOT / "docs"
 MKDOCS_PATH = REPO_ROOT / "mkdocs.yml"

--- a/tests/test_downsample_html_size.py
+++ b/tests/test_downsample_html_size.py
@@ -28,7 +28,6 @@ from prediction_market_extensions.analysis.legacy_backtesting.plotting import (
     _downsample,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_kalshi_backtests.py
+++ b/tests/test_kalshi_backtests.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 import importlib
 
 import pytest
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 from prediction_market_extensions.backtesting._strategy_configs import build_strategies_from_configs
-from strategies import TradeTickBreakoutConfig
-from strategies import TradeTickBreakoutStrategy
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
-
+from strategies import TradeTickBreakoutConfig, TradeTickBreakoutStrategy
 
 INSTRUMENT_ID = InstrumentId(Symbol("KALSHI-TEST"), Venue("KALSHI"))
 

--- a/tests/test_kalshi_ema_crossover.py
+++ b/tests/test_kalshi_ema_crossover.py
@@ -6,7 +6,6 @@ import pytest
 
 import backtests.kalshi_trade_tick_breakout as strat
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_kalshi_native_data_source.py
+++ b/tests/test_kalshi_native_data_source.py
@@ -5,11 +5,7 @@ import os
 
 from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     KALSHI_REST_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     RunnerKalshiDataLoader,
-)
-from prediction_market_extensions.backtesting.data_sources.kalshi_native import (
     configured_kalshi_native_data_source,
 )
 

--- a/tests/test_legacy_plot_fill_markers.py
+++ b/tests/test_legacy_plot_fill_markers.py
@@ -6,8 +6,7 @@
 from __future__ import annotations
 
 import warnings
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pandas as pd
@@ -15,23 +14,17 @@ import pytest
 
 from prediction_market_extensions.analysis import legacy_plot_adapter as adapter
 from prediction_market_extensions.analysis.legacy_backtesting import plotting
-from prediction_market_extensions.analysis.legacy_backtesting.models import BacktestResult
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_BRIER_ADVANTAGE
-from prediction_market_extensions.analysis.legacy_backtesting.models import PANEL_EQUITY
 from prediction_market_extensions.analysis.legacy_backtesting.models import (
+    PANEL_BRIER_ADVANTAGE,
+    PANEL_EQUITY,
     PANEL_TOTAL_BRIER_ADVANTAGE,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
     PANEL_TOTAL_CASH_EQUITY,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
     PANEL_TOTAL_DRAWDOWN,
-)
-from prediction_market_extensions.analysis.legacy_backtesting.models import (
     PANEL_TOTAL_ROLLING_SHARPE,
+    BacktestResult,
+    Platform,
+    PortfolioSnapshot,
 )
-from prediction_market_extensions.analysis.legacy_backtesting.models import Platform
-from prediction_market_extensions.analysis.legacy_backtesting.models import PortfolioSnapshot
 
 
 class _DummyLayout:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,8 +6,9 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-import main as main_module
 import pytest
+
+import main as main_module
 
 
 def _strip_ansi(text: str) -> str:

--- a/tests/test_market_data_support.py
+++ b/tests/test_market_data_support.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-import prediction_market_extensions.backtesting.data_sources as data_sources
-
-from prediction_market_extensions.backtesting._market_data_support import build_single_market_replay
+from prediction_market_extensions.backtesting import data_sources
 from prediction_market_extensions.backtesting._market_data_support import (
+    build_single_market_replay,
     resolve_market_data_support,
+    supported_market_data_keys,
 )
-from prediction_market_extensions.backtesting._market_data_support import supported_market_data_keys
-from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
-from prediction_market_extensions.backtesting._replay_specs import TradeReplay
-from prediction_market_extensions.backtesting.data_sources import Kalshi
-from prediction_market_extensions.backtesting.data_sources import Native
-from prediction_market_extensions.backtesting.data_sources import PMXT
-from prediction_market_extensions.backtesting.data_sources import Polymarket
-from prediction_market_extensions.backtesting.data_sources import QuoteTick
-from prediction_market_extensions.backtesting.data_sources import TradeTick
+from prediction_market_extensions.backtesting._replay_specs import QuoteReplay, TradeReplay
+from prediction_market_extensions.backtesting.data_sources import (
+    PMXT,
+    Kalshi,
+    Native,
+    Polymarket,
+    QuoteTick,
+    TradeTick,
+)
 
 
 def test_support_matrix_matches_publicly_supported_combinations() -> None:

--- a/tests/test_nautilus_override_bootstrap.py
+++ b/tests/test_nautilus_override_bootstrap.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import nautilus_trader
+
 from prediction_market_extensions.adapters.polymarket.execution import PolymarketExecutionClient
 from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
 from prediction_market_extensions.adapters.prediction_market import HistoricalReplayAdapter
 from prediction_market_extensions.analysis import config as analysis_config
-from prediction_market_extensions.analysis import legacy_plot_adapter
-from prediction_market_extensions.analysis import tearsheet
-
+from prediction_market_extensions.analysis import legacy_plot_adapter, tearsheet
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXTENSIONS_ROOT = REPO_ROOT / "prediction_market_extensions"
@@ -58,6 +57,7 @@ def test_commission_patch_installed() -> None:
     from decimal import Decimal
 
     from nautilus_trader.adapters.polymarket.common.parsing import calculate_commission
+
     from prediction_market_extensions.adapters.polymarket.parsing import (
         calculate_commission as pm_calculate_commission,
     )
@@ -68,9 +68,9 @@ def test_commission_patch_installed() -> None:
 
     # Verify the fee curve: at p=0.50, fee = qty * feeRate * 0.50 * 0.50
     fee = calculate_commission(
-        quantity=Decimal("100"),
+        quantity=Decimal(100),
         price=Decimal("0.50"),
-        fee_rate_bps=Decimal("200"),  # 2% = 200 bps
+        fee_rate_bps=Decimal(200),  # 2% = 200 bps
     )
     expected = 100 * 0.02 * 0.50 * 0.50  # = 0.50
     assert abs(fee - expected) < 0.001

--- a/tests/test_notebook_support.py
+++ b/tests/test_notebook_support.py
@@ -4,8 +4,7 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 from prediction_market_extensions.backtesting import _notebook_support as notebook_support
 from prediction_market_extensions.backtesting._timing_harness import ENABLE_TIMING_ENV

--- a/tests/test_notice_license_coverage.py
+++ b/tests/test_notice_license_coverage.py
@@ -4,7 +4,6 @@ import re
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 NOTICE_PATH = REPO_ROOT / "NOTICE"
 ROOT_NOTICE_START = "LGPL-covered root files"

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import pytest
 
 from prediction_market_extensions.backtesting import _optimizer as optimizer
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
     PredictionMarketBacktest,
 )

--- a/tests/test_pmxt_data_source.py
+++ b/tests/test_pmxt_data_source.py
@@ -11,17 +11,17 @@ import pyarrow.parquet as pq
 import pytest
 
 import prediction_market_extensions.backtesting.data_sources.pmxt as pmxt_module
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_DATA_SOURCE_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_LOCAL_RAWS_DIR_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_PREFETCH_WORKERS_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_REMOTE_BASE_URL_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_RAW_ROOT_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_RELAY_BASE_URL_ENV
-from prediction_market_extensions.backtesting.data_sources.pmxt import PMXT_SOURCE_PRIORITY_ENV
 from prediction_market_extensions.backtesting.data_sources.pmxt import (
+    PMXT_DATA_SOURCE_ENV,
+    PMXT_LOCAL_RAWS_DIR_ENV,
+    PMXT_PREFETCH_WORKERS_ENV,
+    PMXT_RAW_ROOT_ENV,
+    PMXT_RELAY_BASE_URL_ENV,
+    PMXT_REMOTE_BASE_URL_ENV,
+    PMXT_SOURCE_PRIORITY_ENV,
     RunnerPolymarketPMXTDataLoader,
+    configured_pmxt_data_source,
 )
-from prediction_market_extensions.backtesting.data_sources.pmxt import configured_pmxt_data_source
 
 
 def _make_loader(

--- a/tests/test_pmxt_data_source.py
+++ b/tests/test_pmxt_data_source.py
@@ -86,9 +86,8 @@ def test_configured_pmxt_data_source_requires_local_mirror(monkeypatch):
     monkeypatch.setenv(PMXT_DATA_SOURCE_ENV, "raw-local")
     monkeypatch.delenv(PMXT_LOCAL_RAWS_DIR_ENV, raising=False)
 
-    with pytest.raises(ValueError, match=PMXT_LOCAL_RAWS_DIR_ENV):
-        with configured_pmxt_data_source():
-            pass
+    with pytest.raises(ValueError, match=PMXT_LOCAL_RAWS_DIR_ENV), configured_pmxt_data_source():
+        pass
 
 
 def test_configured_pmxt_data_source_preserves_explicit_source_order(monkeypatch, tmp_path):
@@ -139,9 +138,11 @@ def test_configured_pmxt_data_source_preserves_existing_prefetch_override(
 
 
 def test_configured_pmxt_data_source_rejects_cache_explicit_source() -> None:
-    with pytest.raises(ValueError, match="The cache layer is implicit"):
-        with configured_pmxt_data_source(sources=["cache"]):
-            pass
+    with (
+        pytest.raises(ValueError, match="The cache layer is implicit"),
+        configured_pmxt_data_source(sources=["cache"]),
+    ):
+        pass
 
 
 @pytest.mark.parametrize(
@@ -160,9 +161,11 @@ def test_configured_pmxt_data_source_rejects_cache_explicit_source() -> None:
 def test_configured_pmxt_data_source_rejects_legacy_or_unprefixed_explicit_sources(
     source: str,
 ) -> None:
-    with pytest.raises(ValueError, match="Use one of: local:, archive:, relay:"):
-        with configured_pmxt_data_source(sources=[source]):
-            pass
+    with (
+        pytest.raises(ValueError, match="Use one of: local:, archive:, relay:"),
+        configured_pmxt_data_source(sources=[source]),
+    ):
+        pass
 
 
 def test_configured_pmxt_data_source_isolates_concurrent_loader_config(

--- a/tests/test_pmxt_raw_download.py
+++ b/tests/test_pmxt_raw_download.py
@@ -16,7 +16,7 @@ class _Response:
         self._offset = 0
         self.headers = headers or {}
 
-    def __enter__(self) -> "_Response":
+    def __enter__(self) -> _Response:
         return self
 
     def __exit__(self, exc_type, exc, tb) -> bool:

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 from dataclasses import replace
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-from aiohttp.test_utils import TestClient
-from aiohttp.test_utils import TestServer
+from aiohttp.test_utils import TestClient, TestServer
 
 from pmxt_relay.api import (
     INDEX_APP_KEY,
@@ -59,10 +56,10 @@ def test_rate_limiter_periodically_prunes_stale_clients():
     limiter = RequestRateLimiter(requests_per_minute=2)
 
     assert limiter.allow("203.0.113.1", now=0.0) is True
-    assert "203.0.113.1" in limiter._requests  # noqa: SLF001
+    assert "203.0.113.1" in limiter._requests
 
     assert limiter.allow("198.51.100.7", now=61.0) is True
-    assert "203.0.113.1" not in limiter._requests  # noqa: SLF001
+    assert "203.0.113.1" not in limiter._requests
 
 
 def test_client_id_uses_forwarded_for_from_trusted_proxy():
@@ -187,8 +184,8 @@ def test_events_route_tolerates_invalid_payload_json(tmp_path: Path):
         config.ensure_directories()
         app = create_app(config)
         index = app[INDEX_APP_KEY]
-        with index._conn:  # noqa: SLF001
-            index._conn.execute(  # noqa: SLF001
+        with index._conn:
+            index._conn.execute(
                 """
                 INSERT INTO relay_events (
                     created_at,

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -39,9 +39,11 @@ def _make_config(tmp_path: Path) -> RelayConfig:
 
 
 def test_cpu_percent_uses_load_average():
-    with patch("pmxt_relay.api.os.cpu_count", return_value=4):
-        with patch("pmxt_relay.api.os.getloadavg", return_value=(3.5, 3.0, 2.5)):
-            assert _cpu_percent_from_loadavg() == 87.5
+    with (
+        patch("pmxt_relay.api.os.cpu_count", return_value=4),
+        patch("pmxt_relay.api.os.getloadavg", return_value=(3.5, 3.0, 2.5)),
+    ):
+        assert _cpu_percent_from_loadavg() == 87.5
 
 
 def test_rate_limiter_enforces_sliding_window():

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
-from datetime import timezone
-from pathlib import Path
 import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -103,7 +102,7 @@ def test_upsert_discovered_hour_is_idempotent(tmp_path: Path):
 
         assert first_insert is True
         assert second_insert is False
-        row = index._conn.execute(  # noqa: SLF001
+        row = index._conn.execute(
             "SELECT archive_page, source_url FROM archive_hours WHERE filename = ?",
             ("polymarket_orderbook_2026-03-21T12.parquet",),
         ).fetchone()
@@ -145,7 +144,7 @@ def test_register_local_raw_marks_hour_ready(tmp_path: Path):
         )
 
         assert changed is True
-        row = index._conn.execute(  # noqa: SLF001
+        row = index._conn.execute(
             """
             SELECT local_path, content_length, mirror_status, mirrored_at
             FROM archive_hours
@@ -163,7 +162,7 @@ def test_relay_index_context_manager_closes_connection(tmp_path: Path):
     db_path = tmp_path / "relay.sqlite3"
     with RelayIndex(db_path) as index:
         index.initialize()
-        conn = index._conn  # noqa: SLF001
+        conn = index._conn
 
     with pytest.raises(sqlite3.ProgrammingError):
         conn.execute("SELECT 1")
@@ -281,7 +280,7 @@ def test_initialize_tolerates_duplicate_column_race_during_schema_upgrade(tmp_pa
     conn.close()
 
     with RelayIndex(db_path) as index:
-        real_conn = index._conn  # noqa: SLF001
+        real_conn = index._conn
 
         class _DuplicateColumnRaceConn:
             def __init__(self, wrapped: sqlite3.Connection) -> None:
@@ -304,7 +303,7 @@ def test_initialize_tolerates_duplicate_column_race_during_schema_upgrade(tmp_pa
                     raise sqlite3.OperationalError("duplicate column name: last_error_at")
                 return self._wrapped.execute(sql, params)
 
-        index._conn = _DuplicateColumnRaceConn(real_conn)  # type: ignore[assignment]  # noqa: SLF001
+        index._conn = _DuplicateColumnRaceConn(real_conn)  # type: ignore[assignment]
         index.initialize(apply_maintenance=False)
 
         columns = {

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -50,8 +50,8 @@ def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, mon
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
         source_url = f"https://r2.pmxt.dev/{filename}"
-        worker._index.upsert_discovered_hour(filename, source_url, 1)  # noqa: SLF001
-        row = worker._index.list_hours_needing_mirror()[0]  # noqa: SLF001
+        worker._index.upsert_discovered_hour(filename, source_url, 1)
+        row = worker._index.list_hours_needing_mirror()[0]
         requested_methods: list[str] = []
 
         def fake_urlopen(request: Request, timeout):  # type: ignore[no-untyped-def]
@@ -70,13 +70,13 @@ def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, mon
 
         monkeypatch.setattr("pmxt_relay.worker.urlopen", fake_urlopen)
 
-        worker._mirror_hour(row)  # noqa: SLF001
+        worker._mirror_hour(row)
 
         raw_path = config.raw_root / raw_relative_path(filename)
         assert raw_path.read_bytes() == b"raw-payload"
         assert requested_methods == ["HEAD", "GET"]
 
-        stats = worker._index.stats()  # noqa: SLF001
+        stats = worker._index.stats()
         assert stats["archive_hours"] == 1
         assert stats["mirrored_hours"] == 1
 
@@ -84,9 +84,9 @@ def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, mon
 def test_run_once_only_discovers_adopts_and_mirrors(tmp_path: Path, monkeypatch) -> None:
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
-        monkeypatch.setattr(worker, "_discover_archive_hours", lambda: 2)  # noqa: SLF001
-        monkeypatch.setattr(worker, "_adopt_local_raw_hours", lambda: 3)  # noqa: SLF001
-        monkeypatch.setattr(worker, "_mirror_pending_hours", lambda: 5)  # noqa: SLF001
+        monkeypatch.setattr(worker, "_discover_archive_hours", lambda: 2)
+        monkeypatch.setattr(worker, "_adopt_local_raw_hours", lambda: 3)
+        monkeypatch.setattr(worker, "_mirror_pending_hours", lambda: 5)
 
         assert worker.run_once() == 10
 
@@ -98,10 +98,10 @@ def test_adopt_local_raw_marks_hours_as_mirrored(tmp_path: Path) -> None:
     raw_path.write_bytes(b"raw-payload")
 
     with RelayWorker(config, reset_inflight=False) as worker:
-        adopted = worker._adopt_local_raw_hours()  # noqa: SLF001
+        adopted = worker._adopt_local_raw_hours()
 
         assert adopted == 1
-        stats = worker._index.stats()  # noqa: SLF001
+        stats = worker._index.stats()
         assert stats["mirrored_hours"] == 1
 
 
@@ -110,8 +110,8 @@ def test_run_once_scans_full_local_tree_only_on_first_cycle(tmp_path: Path, monk
     with RelayWorker(config, reset_inflight=False) as worker:
         calls = {"full": 0, "pending": 0}
 
-        monkeypatch.setattr(worker, "_discover_archive_hours", lambda: 0)  # noqa: SLF001
-        monkeypatch.setattr(worker, "_mirror_pending_hours", lambda: 0)  # noqa: SLF001
+        monkeypatch.setattr(worker, "_discover_archive_hours", lambda: 0)
+        monkeypatch.setattr(worker, "_mirror_pending_hours", lambda: 0)
 
         def _adopt_all() -> int:
             calls["full"] += 1
@@ -121,8 +121,8 @@ def test_run_once_scans_full_local_tree_only_on_first_cycle(tmp_path: Path, monk
             calls["pending"] += 1
             return 0
 
-        monkeypatch.setattr(worker, "_adopt_all_local_raw_hours", _adopt_all)  # noqa: SLF001
-        monkeypatch.setattr(worker, "_adopt_pending_local_raw_hours", _adopt_pending)  # noqa: SLF001
+        monkeypatch.setattr(worker, "_adopt_all_local_raw_hours", _adopt_all)
+        monkeypatch.setattr(worker, "_adopt_pending_local_raw_hours", _adopt_pending)
 
         assert worker.run_once() == 0
         assert worker.run_once() == 0
@@ -135,11 +135,11 @@ def test_repeated_404s_are_quarantined(tmp_path: Path, monkeypatch) -> None:
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
         source_url = f"https://r2.pmxt.dev/{filename}"
-        worker._index.upsert_discovered_hour(filename, source_url, 1)  # noqa: SLF001
-        worker._index.mark_mirror_retry(  # noqa: SLF001
+        worker._index.upsert_discovered_hour(filename, source_url, 1)
+        worker._index.mark_mirror_retry(
             filename, error="HTTP Error 404: Not Found", next_retry_at="1970-01-01T00:00:00+00:00"
         )
-        worker._index.mark_mirror_retry(  # noqa: SLF001
+        worker._index.mark_mirror_retry(
             filename, error="HTTP Error 404: Not Found", next_retry_at="1970-01-01T00:00:00+00:00"
         )
 
@@ -147,18 +147,18 @@ def test_repeated_404s_are_quarantined(tmp_path: Path, monkeypatch) -> None:
             request = Request(row["source_url"])
             raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
 
-        monkeypatch.setattr(worker, "_mirror_hour", _always_404)  # noqa: SLF001
+        monkeypatch.setattr(worker, "_mirror_hour", _always_404)
 
-        assert worker._mirror_pending_hours() == 0  # noqa: SLF001
+        assert worker._mirror_pending_hours() == 0
 
-        queue = worker._index.queue_summary()  # noqa: SLF001
-        stats = worker._index.stats()  # noqa: SLF001
-        events = worker._index.recent_events(limit=1)  # noqa: SLF001
+        queue = worker._index.queue_summary()
+        stats = worker._index.stats()
+        events = worker._index.recent_events(limit=1)
 
         assert queue["mirror_quarantined"] == 1
         assert queue["mirror_error"] == 1
         assert queue["mirror_retry_waiting"] == 1
         assert queue["next_retry_at"] is not None
         assert stats["mirror_quarantined"] == 1
-        assert worker._index.list_hours_needing_mirror() == []  # noqa: SLF001
+        assert worker._index.list_hours_needing_mirror() == []
         assert events[0]["event_type"] == "mirror_quarantined"

--- a/tests/test_polymarket_fees.py
+++ b/tests/test_polymarket_fees.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 import asyncio
 from decimal import Decimal
 
-from prediction_market_extensions.adapters.polymarket.parsing import calculate_commission
-from prediction_market_extensions.adapters.polymarket.parsing import infer_fee_exponent
 from prediction_market_extensions.adapters.polymarket.loaders import PolymarketDataLoader
+from prediction_market_extensions.adapters.polymarket.parsing import (
+    calculate_commission,
+    infer_fee_exponent,
+)
 
 
 def test_calculate_commission_matches_current_polymarket_formula() -> None:
     commission = calculate_commission(
-        quantity=Decimal("100"),
+        quantity=Decimal(100),
         price=Decimal("0.5"),
         fee_rate_bps=Decimal(
-            "30",
+            30,
         ),
     )
 
@@ -22,7 +24,7 @@ def test_calculate_commission_matches_current_polymarket_formula() -> None:
 
 def test_calculate_commission_rounds_to_five_decimals() -> None:
     commission = calculate_commission(
-        quantity=Decimal("1"),
+        quantity=Decimal(1),
         price=Decimal("0.5"),
         fee_rate_bps=Decimal(
             "2.2",
@@ -33,15 +35,15 @@ def test_calculate_commission_rounds_to_five_decimals() -> None:
 
 
 def test_infer_fee_exponent_is_now_a_compatibility_shim() -> None:
-    assert infer_fee_exponent(Decimal("0")) == 1
-    assert infer_fee_exponent(Decimal("35")) == 1
-    assert infer_fee_exponent(Decimal("2500")) == 1
+    assert infer_fee_exponent(Decimal(0)) == 1
+    assert infer_fee_exponent(Decimal(35)) == 1
+    assert infer_fee_exponent(Decimal(2500)) == 1
 
 
 def test_fee_rate_enrichment_keeps_maker_fee_zero(monkeypatch) -> None:
     async def fake_fetch_fee_rate_bps(cls, token_id: str, http_client) -> Decimal:
         del cls, token_id, http_client
-        return Decimal("35")
+        return Decimal(35)
 
     monkeypatch.setattr(
         PolymarketDataLoader, "_fetch_market_fee_rate_bps", classmethod(fake_fetch_fee_rate_bps)

--- a/tests/test_polymarket_native_data_source.py
+++ b/tests/test_polymarket_native_data_source.py
@@ -5,17 +5,9 @@ import os
 
 from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     POLYMARKET_CLOB_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     POLYMARKET_GAMMA_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     POLYMARKET_TRADE_API_BASE_URL_ENV,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     RunnerPolymarketDataLoader,
-)
-from prediction_market_extensions.backtesting.data_sources.polymarket_native import (
     configured_polymarket_native_data_source,
 )
 

--- a/tests/test_polymarket_pmxt_backtests.py
+++ b/tests/test_polymarket_pmxt_backtests.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 import importlib
 
 import pytest
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting._strategy_configs import build_strategies_from_configs
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
-from strategies import QuoteTickEMACrossoverConfig
-from strategies import QuoteTickEMACrossoverStrategy
-from strategies import QuoteTickVWAPReversionConfig
-from strategies import QuoteTickVWAPReversionStrategy
-
+from strategies import (
+    QuoteTickEMACrossoverConfig,
+    QuoteTickEMACrossoverStrategy,
+    QuoteTickVWAPReversionConfig,
+    QuoteTickVWAPReversionStrategy,
+)
 
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
 EXPECTED_PMXT_SOURCES = (

--- a/tests/test_polymarket_pmxt_cache.py
+++ b/tests/test_polymarket_pmxt_cache.py
@@ -368,7 +368,7 @@ def test_load_market_batches_falls_back_to_direct_relay_download(tmp_path, monke
             self._payload = payload
             self._offset = 0
 
-        def __enter__(self) -> "_Response":
+        def __enter__(self) -> _Response:
             return self
 
         def __exit__(self, exc_type, exc, tb) -> bool:
@@ -427,7 +427,7 @@ def test_load_relay_raw_market_batches_downloads_to_temp_file(tmp_path, monkeypa
             self._payload = payload
             self._offset = 0
 
-        def __enter__(self) -> "_Response":
+        def __enter__(self) -> _Response:
             return self
 
         def __exit__(self, exc_type, exc, tb) -> bool:
@@ -500,7 +500,7 @@ def test_load_remote_market_batches_downloads_to_temp_file_and_emits_progress(
             self._payload = payload
             self._offset = 0
 
-        def __enter__(self) -> "_Response":
+        def __enter__(self) -> _Response:
             return self
 
         def __exit__(self, exc_type, exc, tb) -> bool:

--- a/tests/test_polymarket_pmxt_loader.py
+++ b/tests/test_polymarket_pmxt_loader.py
@@ -6,7 +6,6 @@ import os
 import pandas as pd
 import pytest
 
-
 EXPECTED_MARKET_SLUG = "will-openai-launch-a-new-consumer-hardware-product-by-march-31-2026"
 
 
@@ -15,9 +14,9 @@ EXPECTED_MARKET_SLUG = "will-openai-launch-a-new-consumer-hardware-product-by-ma
     reason="Set RUN_PMXT_INTEGRATION=1 to exercise the live PMXT archive",
 )
 def test_pmxt_loader_returns_quotes_and_book_deltas():
+    from nautilus_trader.model.data import OrderBookDeltas, QuoteTick
+
     from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
-    from nautilus_trader.model.data import OrderBookDeltas
-    from nautilus_trader.model.data import QuoteTick
 
     async def _load():
         loader = await PolymarketPMXTDataLoader.from_market_slug(EXPECTED_MARKET_SLUG)

--- a/tests/test_polymarket_pmxt_multi_runner.py
+++ b/tests/test_polymarket_pmxt_multi_runner.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 from prediction_market_extensions.backtesting import (
     _independent_multi_replay_runner as independent_runner,
 )
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketSimConfig
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
+    MarketSimConfig,
     PredictionMarketBacktest,
 )
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig

--- a/tests/test_polymarket_pmxt_runner.py
+++ b/tests/test_polymarket_pmxt_runner.py
@@ -4,8 +4,10 @@ import asyncio
 from types import SimpleNamespace
 
 from prediction_market_extensions.backtesting import _prediction_market_runner as runner
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
     PredictionMarketBacktest,
 )

--- a/tests/test_polymarket_trade_tick_multi_runner.py
+++ b/tests/test_polymarket_trade_tick_multi_runner.py
@@ -11,9 +11,9 @@ from prediction_market_extensions.backtesting import (
     _independent_multi_replay_runner as independent_runner,
 )
 from prediction_market_extensions.backtesting._experiments import ReplayExperiment
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketSimConfig
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
+    MarketReportConfig,
+    MarketSimConfig,
     PredictionMarketBacktest,
 )
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig

--- a/tests/test_prediction_market_equivalence.py
+++ b/tests/test_prediction_market_equivalence.py
@@ -5,10 +5,10 @@ from types import SimpleNamespace
 
 import pandas as pd
 
-from prediction_market_extensions.backtesting import _prediction_market_runner as runner
 from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketSimConfig
+from prediction_market_extensions.backtesting import _prediction_market_runner as runner
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
+    MarketSimConfig,
     PredictionMarketBacktest,
 )
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig

--- a/tests/test_prediction_market_execution.py
+++ b/tests/test_prediction_market_execution.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import importlib
 from types import SimpleNamespace
 
-from prediction_market_extensions.backtesting._backtest_runtime import build_backtest_run_state
+from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
 from prediction_market_extensions.backtesting._backtest_runtime import (
+    build_backtest_run_state,
     print_backtest_result_warnings,
 )
-from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketSimConfig
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
+    MarketSimConfig,
     PredictionMarketBacktest,
 )
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
@@ -47,7 +49,7 @@ def test_prediction_market_backtest_build_engine_forwards_execution(monkeypatch)
         ),
     )
 
-    engine = backtest._build_engine()  # noqa: SLF001
+    engine = backtest._build_engine()
 
     assert len(engine.venues) == 1
     venue_kwargs = engine.venues[0]

--- a/tests/test_prediction_market_report_timestamps.py
+++ b/tests/test_prediction_market_report_timestamps.py
@@ -5,13 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
+from prediction_market_extensions.adapters.prediction_market import research
 from prediction_market_extensions.adapters.prediction_market.research import (
     save_aggregate_backtest_report,
-)
-from prediction_market_extensions.adapters.prediction_market.research import (
     save_joint_portfolio_backtest_report,
 )
-from prediction_market_extensions.adapters.prediction_market import research
 
 
 def test_save_aggregate_backtest_report_accepts_mixed_iso_timestamp_precision(tmp_path) -> None:

--- a/tests/test_prediction_market_runner.py
+++ b/tests/test_prediction_market_runner.py
@@ -4,18 +4,22 @@ import asyncio
 from types import SimpleNamespace
 
 from prediction_market_extensions.backtesting import _prediction_market_runner as runner
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
-from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
     PredictionMarketBacktest,
 )
-from prediction_market_extensions.backtesting.data_sources import Native
-from prediction_market_extensions.backtesting.data_sources import PMXT
-from prediction_market_extensions.backtesting.data_sources import PMXT_VENDOR
-from prediction_market_extensions.backtesting.data_sources import Polymarket
-from prediction_market_extensions.backtesting.data_sources import QuoteTick
-from prediction_market_extensions.backtesting.data_sources import TradeTick
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
+from prediction_market_extensions.backtesting.data_sources import (
+    PMXT,
+    PMXT_VENDOR,
+    Native,
+    Polymarket,
+    QuoteTick,
+    TradeTick,
+)
 
 
 def test_market_data_config_normalizes_values() -> None:

--- a/tests/test_quote_tick_runner_contract.py
+++ b/tests/test_quote_tick_runner_contract.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from prediction_market_extensions.backtesting._replay_specs import QuoteReplay
 from prediction_market_extensions.backtesting.optimizers import ParameterSearchWindow
 
-
 EXPECTED_PMXT_SOURCES = (
     "local:/Volumes/LaCie/pmxt_raws",
     "archive:r2.pmxt.dev",

--- a/tests/test_quote_tick_strategy_configs.py
+++ b/tests/test_quote_tick_strategy_configs.py
@@ -6,21 +6,20 @@
 from __future__ import annotations
 
 import pytest
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
-from strategies import QuoteTickBreakoutConfig
-from strategies import QuoteTickDeepValueHoldConfig
-from strategies import QuoteTickEMACrossoverConfig
-from strategies import QuoteTickFinalPeriodMomentumConfig
-from strategies import QuoteTickLateFavoriteLimitHoldConfig
-from strategies import QuoteTickMeanReversionConfig
-from strategies import QuoteTickPanicFadeConfig
-from strategies import QuoteTickRSIReversionConfig
-from strategies import QuoteTickThresholdMomentumConfig
-from strategies import QuoteTickVWAPReversionConfig
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
-
+from strategies import (
+    QuoteTickBreakoutConfig,
+    QuoteTickDeepValueHoldConfig,
+    QuoteTickEMACrossoverConfig,
+    QuoteTickFinalPeriodMomentumConfig,
+    QuoteTickLateFavoriteLimitHoldConfig,
+    QuoteTickMeanReversionConfig,
+    QuoteTickPanicFadeConfig,
+    QuoteTickRSIReversionConfig,
+    QuoteTickThresholdMomentumConfig,
+    QuoteTickVWAPReversionConfig,
+)
 
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
 

--- a/tests/test_replay_adapter_architecture.py
+++ b/tests/test_replay_adapter_architecture.py
@@ -5,26 +5,28 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AccountType, OmsType
+from nautilus_trader.model.identifiers import Venue
+
+from prediction_market_extensions.adapters.prediction_market import (
+    HistoricalReplayAdapter,
+    ReplayAdapterKey,
+    ReplayEngineProfile,
+    ReplayLoadRequest,
+)
 from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
-from prediction_market_extensions.backtesting._experiments import build_backtest_for_experiment
-from prediction_market_extensions.backtesting._experiments import build_replay_experiment
-from prediction_market_extensions.backtesting._market_data_support import MarketDataSupport
-from prediction_market_extensions.backtesting._market_data_support import build_single_market_replay
-from prediction_market_extensions.backtesting._market_data_support import (
-    register_market_data_support,
+from prediction_market_extensions.backtesting._experiments import (
+    build_backtest_for_experiment,
+    build_replay_experiment,
 )
 from prediction_market_extensions.backtesting._market_data_support import (
+    MarketDataSupport,
+    build_single_market_replay,
+    register_market_data_support,
     unregister_market_data_support,
 )
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
-from prediction_market_extensions.adapters.prediction_market import HistoricalReplayAdapter
-from prediction_market_extensions.adapters.prediction_market import ReplayAdapterKey
-from prediction_market_extensions.adapters.prediction_market import ReplayEngineProfile
-from prediction_market_extensions.adapters.prediction_market import ReplayLoadRequest
-from nautilus_trader.model.currencies import USD
-from nautilus_trader.model.enums import AccountType
-from nautilus_trader.model.enums import OmsType
-from nautilus_trader.model.identifiers import Venue
 
 
 @dataclass(frozen=True)
@@ -104,7 +106,7 @@ def test_new_adapter_registers_without_core_executor_changes(monkeypatch) -> Non
         backtest = build_backtest_for_experiment(experiment)
 
         assert backtest.replays == (FakeReplay(market_slug="demo-market"),)
-        engine = backtest._build_engine()  # noqa: SLF001
+        engine = backtest._build_engine()
         assert len(engine.venues) == 1
         assert engine.venues[0]["venue"] == Venue("FAKE")
         assert engine.venues[0]["account_type"] == AccountType.CASH

--- a/tests/test_strategy_configs.py
+++ b/tests/test_strategy_configs.py
@@ -3,18 +3,16 @@ from __future__ import annotations
 from decimal import Decimal
 from types import SimpleNamespace
 
-from prediction_market_extensions.backtesting._prediction_market_backtest import MarketSimConfig
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
+
 from prediction_market_extensions.backtesting._prediction_market_backtest import (
+    MarketSimConfig,
     PredictionMarketBacktest,
+    _LoadedMarketSim,
 )
-from prediction_market_extensions.backtesting._prediction_market_backtest import _LoadedMarketSim
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._strategy_configs import build_strategies_from_configs
-from strategies import QuoteTickBreakoutConfig
-from strategies import QuoteTickBreakoutStrategy
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
+from strategies import QuoteTickBreakoutConfig, QuoteTickBreakoutStrategy
 
 
 def test_strategy_configs_bind_primary_instrument_id() -> None:
@@ -25,7 +23,7 @@ def test_strategy_configs_bind_primary_instrument_id() -> None:
                 "strategy_path": "strategies:QuoteTickBreakoutStrategy",
                 "config_path": "strategies:QuoteTickBreakoutConfig",
                 "config": {
-                    "trade_size": Decimal("100"),
+                    "trade_size": Decimal(100),
                     "window": 20,
                     "breakout_std": 1.5,
                     "breakout_buffer": 0.001,
@@ -69,7 +67,7 @@ def test_prediction_market_backtest_binds_strategy_configs_across_sims() -> None
                 "strategy_path": "strategies:TradeTickLateFavoriteLimitHoldStrategy",
                 "config_path": "strategies:TradeTickLateFavoriteLimitHoldConfig",
                 "config": {
-                    "trade_size": Decimal("25"),
+                    "trade_size": Decimal(25),
                     "activation_start_time_ns": "__SIM_METADATA__:activation_start_time_ns",
                     "market_close_time_ns": "__SIM_METADATA__:market_close_time_ns",
                     "entry_price": 0.9,
@@ -117,7 +115,7 @@ def test_prediction_market_backtest_binds_strategy_configs_across_sims() -> None
         ),
     ]
 
-    importable_configs = backtest._build_importable_strategy_configs(loaded_sims)  # noqa: SLF001
+    importable_configs = backtest._build_importable_strategy_configs(loaded_sims)
 
     assert len(importable_configs) == 3
     assert importable_configs[0].config["market_close_time_ns"] == 111

--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from decimal import Decimal
-from decimal import ROUND_DOWN
+from decimal import ROUND_DOWN, Decimal
+
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
 from strategies import QuoteTickVWAPReversionConfig
 from strategies.core import LongOnlyPredictionMarketStrategy
-from nautilus_trader.model.identifiers import InstrumentId
-from nautilus_trader.model.identifiers import Symbol
-from nautilus_trader.model.identifiers import Venue
-
 
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
 
@@ -24,7 +21,7 @@ class _FakeQuantity:
 class _FakeInstrument:
     def __init__(self, *, min_quantity: Decimal | None) -> None:
         self.quote_currency = "USDC.e"
-        self.taker_fee = Decimal("0")
+        self.taker_fee = Decimal(0)
         self.lot_size = None
         self.min_quantity = None if min_quantity is None else _FakeQuantity(min_quantity)
 
@@ -54,10 +51,10 @@ class _EntryQuantityHarness(LongOnlyPredictionMarketStrategy):
 
 def test_entry_quantity_skips_clipped_size_below_min_quantity() -> None:
     strategy = _EntryQuantityHarness(
-        trade_size=Decimal("25"),
+        trade_size=Decimal(25),
         free_balance=Decimal("0.35"),
         min_quantity=Decimal(
-            "5",
+            5,
         ),
     )
 
@@ -68,7 +65,7 @@ def test_entry_quantity_skips_clipped_size_below_min_quantity() -> None:
 
 def test_entry_quantity_keeps_clipped_size_when_no_min_quantity_exists() -> None:
     strategy = _EntryQuantityHarness(
-        trade_size=Decimal("25"), free_balance=Decimal("0.35"), min_quantity=None
+        trade_size=Decimal(25), free_balance=Decimal("0.35"), min_quantity=None
     )
 
     quantity = strategy._entry_quantity(reference_price=0.074, visible_size=100.0)
@@ -79,10 +76,10 @@ def test_entry_quantity_keeps_clipped_size_when_no_min_quantity_exists() -> None
 
 def test_entry_quantity_leaves_cash_headroom_before_min_quantity_boundary() -> None:
     strategy = _EntryQuantityHarness(
-        trade_size=Decimal("5"),
-        free_balance=Decimal("1"),
+        trade_size=Decimal(5),
+        free_balance=Decimal(1),
         min_quantity=Decimal(
-            "5",
+            5,
         ),
     )
 

--- a/tests/test_subprocess_timing_bootstrap.py
+++ b/tests/test_subprocess_timing_bootstrap.py
@@ -4,8 +4,7 @@ import pickle
 from pathlib import Path
 from types import SimpleNamespace
 
-from prediction_market_extensions.backtesting import _isolated_replay_runner
-from prediction_market_extensions.backtesting import _optimizer
+from prediction_market_extensions.backtesting import _isolated_replay_runner, _optimizer
 
 
 class _FakeSendConn:

--- a/tests/test_timing_test.py
+++ b/tests/test_timing_test.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import importlib
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 
 import pytest
 
-from prediction_market_extensions.backtesting._timing_test import _progress_bar_description
-from prediction_market_extensions.backtesting._timing_test import _progress_bar_position
-from prediction_market_extensions.backtesting._timing_test import _progress_bar_total
-from prediction_market_extensions.backtesting._timing_test import _active_transfer_progress
-from prediction_market_extensions.backtesting._timing_test import _format_completed_hour_line
-from prediction_market_extensions.backtesting._timing_test import _transfer_progress_fraction
-from prediction_market_extensions.backtesting._timing_test import _transfer_label
+from prediction_market_extensions.backtesting._timing_test import (
+    _active_transfer_progress,
+    _format_completed_hour_line,
+    _progress_bar_description,
+    _progress_bar_position,
+    _progress_bar_total,
+    _transfer_label,
+    _transfer_progress_fraction,
+)
 
 
 def test_transfer_label_identifies_local_raw_paths() -> None:
@@ -151,11 +152,11 @@ def test_active_transfer_progress_dedupes_by_hour() -> None:
 
 
 def test_install_timing_patches_runner_loader_override() -> None:
+    from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
     from prediction_market_extensions.backtesting import _timing_test as timing_module
     from prediction_market_extensions.backtesting.data_sources.pmxt import (
         RunnerPolymarketPMXTDataLoader,
     )
-    from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
 
     timing_module = importlib.reload(timing_module)
 

--- a/tests/test_trade_tick_runner_contract.py
+++ b/tests/test_trade_tick_runner_contract.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
 
-
 EXPECTED_INITIAL_CASH = 100.0
 EXPECTED_EMIT_HTML = True
 EXPECTED_MULTI_RUNNER_EMIT_HTML = False


### PR DESCRIPTION
## Summary
- Modernize typing: move `Iterator`/`Sequence` to `collections.abc`, add `ClassVar` for mutable class attrs, swap `lru_cache(maxsize=None)` for `cache`.
- Simplify control flow: `contextlib.suppress` in `__del__`/rollback paths, drop redundant `list()`/`sorted()` wrappers, use `set.update` over loops, combine `global` statements.
- Expand `.gitignore` for `.uv-cache/`, `kalshi_catalog/`, `.pmxt-relay/`, `.benchmarks/`.

## Test plan
- [ ] \`uv run pytest tests/\`
- [ ] \`uv run ruff check .\`

Co-Authored-By: Codex <noreply@openai.com>