### PR TITLE
[codex] Add public runner validation harness

### DIFF
--- a/tests/_public_runner_validation_cases.py
+++ b/tests/_public_runner_validation_cases.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from nautilus_trader.adapters.polymarket.common.parsing import parse_polymarket_instrument
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import AggressorSide
+from nautilus_trader.model.identifiers import TradeId
+
+from prediction_market_extensions.adapters.kalshi.providers import market_dict_to_instrument
+from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
+from prediction_market_extensions.backtesting._experiments import run_experiment
+
+RESULT_MARKER = "PUBLIC_RUNNER_VALIDATION_RESULT="
+
+
+def _timestamp_ns(start: datetime, offset_seconds: int) -> int:
+    return int((start + timedelta(seconds=offset_seconds)).timestamp() * 1_000_000_000)
+
+
+def _make_trade_ticks(
+    *,
+    instrument: Any,
+    start: datetime,
+    prices: Sequence[float],
+    size: float,
+    trade_id_prefix: str,
+) -> tuple[TradeTick, ...]:
+    return tuple(
+        TradeTick(
+            instrument_id=instrument.id,
+            price=instrument.make_price(price),
+            size=instrument.make_qty(size),
+            aggressor_side=AggressorSide.BUYER,
+            trade_id=TradeId(f"{trade_id_prefix}{index:04d}"),
+            ts_event=_timestamp_ns(start, index),
+            ts_init=_timestamp_ns(start, index),
+        )
+        for index, price in enumerate(prices)
+    )
+
+
+def _minimal_result(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "fills": result["fills"],
+        "pnl": result["pnl"],
+        "terminated_early": result["terminated_early"],
+        "realized_outcome": result["realized_outcome"],
+        "fill_events": result["fill_events"],
+    }
+
+
+def _run_kalshi_breakout_case(*, prices: Sequence[float]) -> dict[str, Any]:
+    import backtests.kalshi_trade_tick_breakout as runner
+
+    market = {
+        "ticker": "KXLAYOFFSYINFO-26-494000",
+        "event_ticker": "SYNTHETIC",
+        "title": "Synthetic validation market",
+        "open_time": "2026-01-01T00:00:00+00:00",
+        "close_time": "2026-12-31T00:00:00+00:00",
+        "result": "yes",
+    }
+    instrument = market_dict_to_instrument(market)
+    trades = _make_trade_ticks(
+        instrument=instrument,
+        start=datetime(2026, 3, 15, tzinfo=timezone.utc),
+        prices=prices,
+        size=10,
+        trade_id_prefix="K",
+    )
+
+    class Loader:
+        def __init__(self) -> None:
+            self.instrument = instrument
+
+        async def load_trades(self, start, end):  # type: ignore[no-untyped-def]
+            return trades
+
+    class LoaderFactory:
+        @classmethod
+        async def from_market_ticker(cls, ticker: str):  # type: ignore[no-untyped-def]
+            if ticker != runner.REPLAYS[0].market_ticker:
+                raise AssertionError(f"unexpected ticker {ticker!r}")
+            return Loader()
+
+    backtest_module.KalshiDataLoader = LoaderFactory
+    experiment = replace(
+        runner.EXPERIMENT,
+        min_trades=0,
+        min_price_range=0.0,
+        nautilus_log_level="ERROR",
+        emit_html=False,
+        report=None,
+        chart_output_path=None,
+    )
+    results = run_experiment(experiment)
+    if len(results) != 1:
+        raise AssertionError(f"expected one result, received {len(results)}")
+    return _minimal_result(results[0])
+
+
+def _run_polymarket_trade_case() -> dict[str, Any]:
+    import backtests.polymarket_trade_tick_vwap_reversion as runner
+
+    market_info = {
+        "condition_id": "0x" + "1" * 64,
+        "question": "Synthetic validation market",
+        "minimum_tick_size": "0.01",
+        "minimum_order_size": "1",
+        "end_date_iso": "2026-12-31T00:00:00Z",
+        "maker_base_fee": "0",
+        "taker_base_fee": "0",
+        "result": "yes",
+    }
+    instrument = parse_polymarket_instrument(
+        market_info=market_info,
+        token_id="2" * 64,
+        outcome="Yes",
+        ts_init=0,
+    )
+    prices = [0.50] * 30 + [0.49, 0.50, 0.505, 0.49, 0.50]
+    trades = _make_trade_ticks(
+        instrument=instrument,
+        start=datetime(2026, 2, 21, 16, tzinfo=timezone.utc),
+        prices=prices,
+        size=10,
+        trade_id_prefix="P",
+    )
+
+    class Loader:
+        def __init__(self) -> None:
+            self.instrument = instrument
+
+        async def load_trades(self, start, end):  # type: ignore[no-untyped-def]
+            return trades
+
+    class LoaderFactory:
+        @classmethod
+        async def from_market_slug(cls, slug: str, *, token_index: int = 0):  # type: ignore[no-untyped-def]
+            if slug != runner.REPLAYS[0].market_slug:
+                raise AssertionError(f"unexpected slug {slug!r}")
+            if token_index != runner.REPLAYS[0].token_index:
+                raise AssertionError(f"unexpected token_index {token_index!r}")
+            return Loader()
+
+    backtest_module.PolymarketDataLoader = LoaderFactory
+    experiment = replace(
+        runner.EXPERIMENT,
+        min_trades=0,
+        min_price_range=0.0,
+        nautilus_log_level="ERROR",
+        emit_html=False,
+        report=None,
+        chart_output_path=None,
+    )
+    results = run_experiment(experiment)
+    if len(results) != 1:
+        raise AssertionError(f"expected one result, received {len(results)}")
+    return _minimal_result(results[0])
+
+
+def _run_case(case: str) -> dict[str, Any]:
+    if case == "kalshi-baseline":
+        return _run_kalshi_breakout_case(
+            prices=[0.50] * 61 + [0.55, 0.59, 0.60, 0.53, 0.51, 0.48, 0.46, 0.44]
+        )
+    if case == "kalshi-prefix-normal":
+        return _run_kalshi_breakout_case(prices=[0.50] * 61 + [0.55, 0.59, 0.60, 0.53, 0.51])
+    if case == "kalshi-prefix-stressed":
+        return _run_kalshi_breakout_case(prices=[0.50] * 61 + [0.55, 0.99, 0.01, 0.99, 0.01])
+    if case == "polymarket-trade":
+        return _run_polymarket_trade_case()
+    raise AssertionError(f"unknown validation case {case!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("case")
+    args = parser.parse_args()
+
+    result = _run_case(args.case)
+    print(f"{RESULT_MARKER}{json.dumps(result, sort_keys=True)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_public_runner_validation.py
+++ b/tests/test_public_runner_validation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests._public_runner_validation_cases import RESULT_MARKER
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_validation_case(case: str) -> dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, "-m", "tests._public_runner_validation_cases", case],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    for line in reversed(completed.stdout.splitlines()):
+        if line.startswith(RESULT_MARKER):
+            return json.loads(line.removeprefix(RESULT_MARKER))
+    raise AssertionError(
+        f"validation case {case!r} did not emit {RESULT_MARKER!r}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
+def _ledger_realized_pnl(fill_events: Sequence[dict[str, Any]]) -> float:
+    """Independent test oracle: do not call production PnL/report helpers here."""
+    cash = 0.0
+    commissions = 0.0
+    position = 0.0
+    for event in fill_events:
+        action = str(event["action"]).lower()
+        price = float(event["price"])
+        quantity = float(event["quantity"])
+        commission = float(event.get("commission", 0.0))
+        commissions += commission
+        if action == "buy":
+            cash -= price * quantity
+            position += quantity
+        elif action == "sell":
+            cash += price * quantity
+            position -= quantity
+        else:  # pragma: no cover - defensive guard for future fill schema drift.
+            raise AssertionError(f"unexpected fill action {action!r}")
+
+    assert abs(position) < 1e-9
+    return cash - commissions
+
+
+def test_public_kalshi_runner_reconciles_fills_fees_and_taker_slippage() -> None:
+    result = _run_validation_case("kalshi-baseline")
+
+    fill_events = result["fill_events"]
+    assert result["fills"] == len(fill_events) == 4
+    assert result["terminated_early"] is False
+    assert result["realized_outcome"] == 1.0
+    assert result["pnl"] == pytest.approx(_ledger_realized_pnl(fill_events))
+
+    # Kalshi trade ticks expose 4-decimal prices, but taker execution must be
+    # modeled with the real one-cent order tick.
+    assert [event["price"] for event in fill_events] == [0.51, 0.54, 0.60, 0.59]
+    assert [event["commission"] for event in fill_events] == [0.02, 0.02, 0.02, 0.02]
+
+
+def test_public_kalshi_runner_first_decision_is_invariant_to_future_ticks() -> None:
+    baseline = _run_validation_case("kalshi-prefix-normal")
+    stressed_future = _run_validation_case("kalshi-prefix-stressed")
+
+    assert baseline["fill_events"][0] == stressed_future["fill_events"][0]
+
+
+def test_public_polymarket_trade_runner_reconciles_size_clipping_and_slippage() -> None:
+    result = _run_validation_case("polymarket-trade")
+
+    fill_events = result["fill_events"]
+    assert result["fills"] == len(fill_events) == 4
+    assert result["terminated_early"] is False
+    assert result["pnl"] == pytest.approx(_ledger_realized_pnl(fill_events))
+    assert [event["price"] for event in fill_events] == [0.51, 0.49, 0.52, 0.49]
+    assert fill_events[0]["quantity"] == 97.0
+    assert fill_events[2]["quantity"] == pytest.approx(95.1182)


### PR DESCRIPTION
## Summary

Adds deterministic validation coverage for exposed public backtest entrypoints instead of relying only on mocked plumbing tests.

The new harness runs public runner experiment configs through real Nautilus backtest engine subprocesses with synthetic, known-truth market data. The parent pytest process parses a JSON result marker and reconciles the engine result against a small independent ledger oracle.

Covered paths:

- `backtests.kalshi_trade_tick_breakout` with `TradeTickBreakoutStrategy`
- `backtests.polymarket_trade_tick_vwap_reversion` with `TradeTickVWAPReversionStrategy`

Validation checks include:

- replay records reach real strategy callbacks through public runner configs
- real engine execution produces expected fills
- Kalshi taker execution uses the one-cent order tick
- Kalshi commissions are included in realized PnL
- Polymarket taker slippage and cash-constrained size clipping reconcile
- a point-in-time/metamorphic check where the first Kalshi decision is invariant to future tick changes

The subprocess isolation is intentional: multiple real Nautilus engine instances in one pytest process can trip native teardown/initialization behavior, while one process per validation case exercises the real engine without making the suite fragile.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` -> `354 passed, 1 skipped`

## Worktree Note

This PR includes only the two new validation test files. The local notebook edits in `backtests/generic_optimizer_research.ipynb` and `backtests/generic_tpe_research.ipynb` were pre-existing/unrelated and are intentionally not part of this branch.
