### PR TITLE
[codex] Support split PMXT raw archive sources

### DIFF
--- a/backtests/polymarket_quote_tick_ema_crossover.py
+++ b/backtests/polymarket_quote_tick_ema_crossover.py
@@ -58,7 +58,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/Volumes/LaCie/pmxt_raws",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:209-209-10-83.sslip.io",
     ),
 )

--- a/backtests/polymarket_quote_tick_ema_optimizer.py
+++ b/backtests/polymarket_quote_tick_ema_optimizer.py
@@ -43,7 +43,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/Volumes/LaCie/pmxt_raws",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:209-209-10-83.sslip.io",
     ),
 )

--- a/backtests/polymarket_quote_tick_independent_25_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_25_replay_runner.py
@@ -71,7 +71,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/Volumes/LaCie/pmxt_raws",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:209-209-10-83.sslip.io",
     ),
 )

--- a/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_quote_tick_independent_multi_replay_runner.py
@@ -70,7 +70,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/Volumes/LaCie/pmxt_raws",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:209-209-10-83.sslip.io",
     ),
 )

--- a/backtests/polymarket_quote_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_quote_tick_joint_portfolio_runner.py
@@ -68,7 +68,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/Volumes/LaCie/pmxt_raws",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:209-209-10-83.sslip.io",
     ),
 )

--- a/docs/backtests.md
+++ b/docs/backtests.md
@@ -111,7 +111,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/Volumes/LaCie/pmxt_raws",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:209-209-10-83.sslip.io",
     ),
 )

--- a/docs/pmxt-byod.md
+++ b/docs/pmxt-byod.md
@@ -29,7 +29,7 @@ DATA = MarketDataConfig(
     vendor=PMXT,
     sources=(
         "local:/data/pmxt/raw",
-        "archive:r2.pmxt.dev",
+        "archive:r2v2.pmxt.dev",
         "relay:mirror.example.com",
     ),
 )
@@ -71,7 +71,7 @@ The public PMXT runner layer reads one market/token/hour from these places:
 The current "bring your own data" story is therefore:
 
 - set `DATA.sources` in your runner to
-  `("local:/path/to/raw-hours", "archive:r2.pmxt.dev", "relay:relay.example.com")`
+  `("local:/path/to/raw-hours", "archive:r2v2.pmxt.dev", "relay:relay.example.com")`
 - or point `PMXT_LOCAL_ARCHIVE_DIR` / `PMXT_RAW_ROOT` at a directory of raw
   PMXT hour files you already mirrored locally
 - or run your own raw mirror and point `PMXT_RELAY_BASE_URL` at it
@@ -103,12 +103,17 @@ To mirror raw archive hours locally for this repo's runners, use:
 make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
 ```
 
-The downloader walks archive hours newest-first, then reports requested hours
-that are still missing locally and local parquet files with zero rows. It also
-prints per-hour completion lines plus the active transfer. Example output:
+The downloader walks every archive listing page newest-first, defaults to the
+PMXT v2 and v1 Polymarket listings, builds the full hourly range from the newest
+listed hour to the oldest listed hour, then reports the upstream listed-hour
+count, gaps in that covered span, requested hours still missing locally, and
+local parquet files with zero rows or less than 1 MiB of data. Existing local
+files are refreshed when they are empty or when an upstream source advertises a
+larger object. It also prints per-hour completion lines plus the active
+transfer. Example output:
 
 ```text
-PMXT raw source: explicit priority (archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+PMXT raw source: explicit priority (archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
 Downloading PMXT raw hours to /path/to/pmxt_raws (requested_hours=3, window_start=2026-02-27T11, window_end=2026-02-27T13)...
   2026-02-27T13  12.431s   445.9 MiB  archive
   2026-02-27T12   0.000s    existing  skip

--- a/docs/pmxt-fetch-sources.md
+++ b/docs/pmxt-fetch-sources.md
@@ -19,7 +19,7 @@ Two practical notes matter here:
   serving is the supported shared-server path
 - the public runner layer disables relay-hosted filtered parquet
 - PMXT upstream raw hours live at flat object URLs like
-  `https://r2.pmxt.dev/polymarket_orderbook_YYYY-MM-DDTHH.parquet`, while the
+  `https://r2v2.pmxt.dev/polymarket_orderbook_YYYY-MM-DDTHH.parquet`, while the
   local mirror serves those same files under dated `/v1/raw/YYYY/MM/DD/...`
   paths
 
@@ -39,7 +39,7 @@ uv run python main.py
 Running: polymarket_quote_tick_joint_portfolio_runner
 Running: polymarket_quote_tick_ema_crossover
 
-PMXT source: explicit priority (cache -> local /Volumes/LaCie/pmxt_raws -> archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+PMXT source: explicit priority (cache -> local /Volumes/LaCie/pmxt_raws -> archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
 Loading PMXT Polymarket market will-ludvig-aberg-win-the-2026-masters-tournament (token_index=0, window_start=2026-04-05T00:00:00+00:00, window_end=2026-04-07T23:59:59+00:00)...
   2026-04-05T00:00:00+00:00      ...          ... rows  cache 2026-04-05T00
   2026-04-05T01:00:00+00:00      ...          ... rows  cache 2026-04-05T01

--- a/docs/pmxt-relay.md
+++ b/docs/pmxt-relay.md
@@ -45,8 +45,9 @@ Deployment facts for the active box:
 
 - live checkout path: `/opt/prediction-market-backtesting`
 - env file: `/etc/pmxt-relay.env`
-- active PMXT archive listing:
-  `https://archive.pmxt.dev/Polymarket`
+- active PMXT archive sources:
+  `https://archive.pmxt.dev/Polymarket/v2|https://r2v2.pmxt.dev`,
+  then `https://archive.pmxt.dev/Polymarket/v1|https://r2.pmxt.dev`
 - systemd units:
   `pmxt-relay-api.service` and `pmxt-relay-worker.service`
 - public URL:

--- a/docs/research.md
+++ b/docs/research.md
@@ -24,7 +24,7 @@ Each trial runs in an isolated subprocess so a crashing strategy cannot poison t
 Run the notebook optimizer's market slugs and timestamps once through a regular
 runner before launching a long notebook sweep. The normal runner prints PMXT
 source and downloader progress while it fills the local filtered cache, making
-the `cache` / local raw / `archive:r2.pmxt.dev` /
+the `cache` / local raw / `archive:r2v2.pmxt.dev` /
 `relay:209-209-10-83.sslip.io` path visible. The notebook optimizer mostly
 surfaces trial-level output, so a cold archive or relay fill can look quiet for
 a long time.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -114,13 +114,20 @@ To mirror PMXT raw archive hours locally, run:
 make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
 ```
 
-The download is long-running, walks archive hours newest-first, and prints
-per-hour completion lines plus the currently active transfer. The final JSON
-summary includes `missing_local_hours` for requested hours still absent on disk
-and `empty_local_hours` for local parquet files with zero rows. Example output:
+The download is long-running, walks every archive listing page newest-first,
+defaults to the PMXT v2 and v1 Polymarket listings, builds the full hourly range
+from the newest listed hour to the oldest listed hour, and prints per-hour
+completion lines plus the currently active transfer.
+The final JSON summary includes `archive_listed_hours` for the number of hours
+actually exposed by the upstream listing, `archive_missing_hours` for gaps in
+the upstream listing's covered time span, `missing_local_hours` for requested
+hours still absent on disk, and `empty_local_hours` for local parquet files with
+zero rows or less than 1 MiB of data. Existing local files are refreshed when
+they are empty or when an upstream source advertises a larger object. Example
+output:
 
 ```text
-PMXT raw source: explicit priority (archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+PMXT raw source: explicit priority (archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
 Downloading PMXT raw hours to /path/to/pmxt_raws (requested_hours=3, window_start=2026-02-27T11, window_end=2026-02-27T13)...
   2026-02-27T13  12.431s   445.9 MiB  archive
   2026-02-27T12   0.000s    existing  skip
@@ -144,7 +151,7 @@ after the run.
 - PMXT filtered cache is enabled by default at
   `~/.cache/nautilus_trader/pmxt`
 - public PMXT runners pin `local:/Volumes/LaCie/pmxt_raws` first,
-  `archive:r2.pmxt.dev` second, and `relay:209-209-10-83.sslip.io` third
+  `archive:r2v2.pmxt.dev` second, and `relay:209-209-10-83.sslip.io` third
 - PMXT `DATA.sources` entries are explicit and prefix-driven: `local:`,
   `archive:`, `relay:`
 - normal Nautilus logs are still printed; the timing harness is additive

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,7 @@ independent basket runner.
 
 Quote-tick PMXT runners use the source path pinned in `DATA.sources` inside the
 file. Public PMXT runners now pin `local:/Volumes/LaCie/pmxt_raws` first,
-`archive:r2.pmxt.dev` second, and `relay:209-209-10-83.sslip.io` third. If that
+`archive:r2v2.pmxt.dev` second, and `relay:209-209-10-83.sslip.io` third. If that
 local mirror path is absent, the loader falls through to archive and relay.
 Those prefixes are the contract; do not use unprefixed hosts or ad hoc aliases.
 

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -53,9 +53,10 @@ worker cycle while the mirror still heals automatically when upstream recovers.
 
 Each cycle also re-validates a batch of already-mirrored files by HEAD-checking
 upstream for ETag or Content-Length changes. Files corrected upstream (e.g.
-initially broken uploads later replaced) are automatically re-queued for
-download. The batch size is configurable via `PMXT_RELAY_VERIFY_BATCH_SIZE`
-(default 50). Parquet row counts are tracked to detect empty/broken files.
+initially broken uploads later replaced with larger files) are automatically
+re-queued for download. The batch size is configurable via
+`PMXT_RELAY_VERIFY_BATCH_SIZE` (default 50). Parquet row counts and byte sizes
+are tracked to detect empty/broken files.
 
 ## Self-Healing Coverage
 
@@ -68,9 +69,10 @@ bucket auto-heals when upstream catches up:
   page 1 of the archive listing.
 - Quarantined upstream 404s (counted as missing): retried hourly per
   `_MIRROR_QUARANTINE_RETRY_SECS`; flip to ready when upstream serves 200.
-- Mirrored-but-empty parquets (`row_count == 0`, counted as empty): caught
-  by the HEAD re-verifier when upstream replaces the bytes (different ETag
-  or Content-Length), then re-mirrored and `row_count` recomputed.
+- Mirrored-but-empty parquets (`row_count == 0` or `Content-Length < 1 MiB`,
+  counted as empty): caught by the HEAD re-verifier when upstream replaces the
+  bytes (different ETag or Content-Length), then re-mirrored and `row_count`
+  recomputed.
 - Updated bytes for filenames already on disk: same HEAD re-verifier path;
   filename does not need to change.
 
@@ -120,8 +122,12 @@ and raw origin URL explicitly for the environment you run.
 Important env knobs from `pmxt_relay/systemd/pmxt-relay.env.example`:
 
 - `PMXT_RELAY_DATA_DIR` for relay-owned state under `/srv/pmxt-relay`
+- `PMXT_RELAY_ARCHIVE_SOURCES` for ordered archive source pairs in
+  `LISTING_URL|RAW_BASE_URL` form. PMXT Polymarket currently uses v2 first and
+  v1 second because upstream split the archive across both listings.
 - `PMXT_RELAY_ARCHIVE_LISTING_URL` for the upstream archive listing to poll
-  (PMXT Polymarket currently uses `https://archive.pmxt.dev/Polymarket`)
+  when `PMXT_RELAY_ARCHIVE_SOURCES` is unset
+  (PMXT Polymarket v2 uses `https://archive.pmxt.dev/Polymarket/v2`)
 - `PMXT_RELAY_RAW_BASE_URL` for the upstream raw object base URL
 - `PMXT_RELAY_TRUSTED_PROXY_IPS` if the API sits behind Caddy, nginx, or
   another reverse proxy and should trust forwarded client IPs from that proxy
@@ -154,11 +160,11 @@ Active mirror-focused endpoints:
 state. The active relay path is limited to mirroring, health, and raw file
 serving.
 
-The public badges separate relay health from `r2.pmxt.dev` availability:
+The public badges separate relay health from `r2v2.pmxt.dev` availability:
 
 - `/v1/badge/status(.svg)` reports whether the relay itself is up, recent, and
   has active API/worker services.
-- `/v1/badge/upstream(.svg)` reports whether recent `r2.pmxt.dev` polling is
+- `/v1/badge/upstream(.svg)` reports whether recent `r2v2.pmxt.dev` polling is
   online or offline.
 - `/v1/badge/missing-hours.svg` shows hours not currently represented on disk
   by a non-empty mirror — includes quarantined upstream 404s, pending downloads,
@@ -166,6 +172,7 @@ The public badges separate relay health from `r2.pmxt.dev` availability:
   empty hours; together with mirrored + empty, sums to the wall-clock hours
   since the first recorded hour.
 - `/v1/badge/empty-hours.svg` shows how many mirrored parquet files have zero
-  rows (broken/empty uploads). Empty hours are excluded from the "mirrored"
-  count surfaced by `/v1/stats` and `/v1/badge/mirrored.svg`, but they are
-  still counted as `ready` and therefore are NOT counted as missing.
+  rows or less than 1 MiB of data (broken/empty uploads). Empty hours are
+  excluded from the "mirrored" count surfaced by `/v1/stats` and
+  `/v1/badge/mirrored.svg`, but they are still counted as `ready` and therefore
+  are NOT counted as missing.

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -11,6 +11,7 @@ import time
 from collections import defaultdict, deque
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 from xml.sax.saxutils import escape
 
 from aiohttp import web
@@ -459,10 +460,11 @@ def _upstream_badge_payload(
     del queue
     current = datetime.now(timezone.utc) if now is None else now.astimezone(timezone.utc)
     last_event_at = _parse_db_timestamp(stats.get("last_event_at"))  # type: ignore[arg-type]
+    upstream_label = urlparse(config.raw_base_url).netloc or config.raw_base_url
 
     if last_event_at is None:
         return _badge_payload(
-            label="r2.pmxt.dev",
+            label=upstream_label,
             message="checking",
             color="yellow",
         )
@@ -471,13 +473,13 @@ def _upstream_badge_payload(
     stale_threshold = max(config.poll_interval_secs * 4, 3600)
     if age_seconds > stale_threshold:
         return _badge_payload(
-            label="r2.pmxt.dev",
+            label=upstream_label,
             message="offline",
             color="red",
         )
 
     return _badge_payload(
-        label="r2.pmxt.dev",
+        label=upstream_label,
         message="online",
         color="brightgreen",
     )

--- a/pmxt_relay/config.py
+++ b/pmxt_relay/config.py
@@ -25,6 +25,30 @@ def _env_csv(name: str, default: tuple[str, ...] = ()) -> tuple[str, ...]:
 
 
 @dataclass(frozen=True)
+class ArchiveSource:
+    listing_url: str
+    raw_base_url: str
+
+
+def _env_archive_sources(name: str) -> tuple[ArchiveSource, ...]:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return ()
+    sources: list[ArchiveSource] = []
+    for part in value.split(","):
+        stripped = part.strip()
+        if not stripped:
+            continue
+        if "|" not in stripped:
+            raise ValueError(f"{name} entries must use LISTING_URL|RAW_BASE_URL syntax.")
+        listing_url, raw_base_url = (item.strip().rstrip("/") for item in stripped.split("|", 1))
+        if not listing_url or not raw_base_url:
+            raise ValueError(f"{name} entries must include both listing and raw base URLs.")
+        sources.append(ArchiveSource(listing_url=listing_url, raw_base_url=raw_base_url))
+    return tuple(sources)
+
+
+@dataclass(frozen=True)
 class RelayConfig:
     data_dir: Path
     bind_host: str
@@ -39,14 +63,19 @@ class RelayConfig:
     api_rate_limit_per_minute: int
     verify_batch_size: int = 50
     trusted_proxy_ips: tuple[str, ...] = ("127.0.0.1", "::1")
+    archive_sources: tuple[ArchiveSource, ...] = ()
 
     @classmethod
     def from_env(cls) -> RelayConfig:
         default_data_dir = Path.cwd() / ".pmxt-relay"
         data_dir = Path(os.getenv("PMXT_RELAY_DATA_DIR", str(default_data_dir))).expanduser()
         archive_max_pages = _env_int("PMXT_RELAY_ARCHIVE_MAX_PAGES", 0)
+        archive_sources = _env_archive_sources("PMXT_RELAY_ARCHIVE_SOURCES")
         archive_listing_url = (os.getenv("PMXT_RELAY_ARCHIVE_LISTING_URL") or "").strip()
         raw_base_url = (os.getenv("PMXT_RELAY_RAW_BASE_URL") or "").strip()
+        if archive_sources:
+            archive_listing_url = archive_sources[0].listing_url
+            raw_base_url = archive_sources[0].raw_base_url
         if not archive_listing_url:
             raise ValueError("PMXT_RELAY_ARCHIVE_LISTING_URL is required.")
         if not raw_base_url:
@@ -67,6 +96,16 @@ class RelayConfig:
             ),
             verify_batch_size=max(1, _env_int("PMXT_RELAY_VERIFY_BATCH_SIZE", 50)),
             trusted_proxy_ips=_env_csv("PMXT_RELAY_TRUSTED_PROXY_IPS", ("127.0.0.1", "::1")),
+            archive_sources=archive_sources,
+        )
+
+    @property
+    def resolved_archive_sources(self) -> tuple[ArchiveSource, ...]:
+        return self.archive_sources or (
+            ArchiveSource(
+                listing_url=self.archive_listing_url.rstrip("/"),
+                raw_base_url=self.raw_base_url.rstrip("/"),
+            ),
         )
 
     @property

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -19,6 +19,7 @@ _LOCKED_ERROR_SNIPPETS = (
 )
 _DUPLICATE_COLUMN_ERROR_SNIPPET = "duplicate column name"
 _LEGACY_ACTIVE_STATUS = "processing"
+_MIN_NONEMPTY_RAW_BYTES = 1024 * 1024
 
 
 def _utc_now_datetime() -> datetime:
@@ -327,15 +328,19 @@ class RelayIndex:
                     """,
                     (filename, hour, source_url, archive_page, _utc_now()),
                 )
-                self._conn.execute(
+                update_cursor = self._conn.execute(
                     """
                     UPDATE archive_hours
                     SET archive_page = ?, source_url = ?
                     WHERE filename = ?
+                      AND (
+                        archive_page != ?
+                        OR source_url != ?
+                      )
                     """,
-                    (archive_page, source_url, filename),
+                    (archive_page, source_url, filename, archive_page, source_url),
                 )
-            return cursor.rowcount > 0
+            return (cursor.rowcount + update_cursor.rowcount) > 0
 
         return self._run_with_lock_retry(operation)
 
@@ -495,7 +500,6 @@ class RelayIndex:
                     """
                     UPDATE archive_hours
                     SET
-                        source_url = ?,
                         local_path = ?,
                         content_length = COALESCE(content_length, ?),
                         mirror_status = 'ready',
@@ -510,18 +514,15 @@ class RelayIndex:
                         OR local_path != ?
                         OR mirror_status != 'ready'
                         OR (content_length IS NULL AND ? IS NOT NULL)
-                        OR source_url != ?
                       )
                     """,
                     (
-                        source_url,
                         local_path,
                         content_length,
                         mirrored_at,
                         filename,
                         local_path,
                         content_length,
-                        source_url,
                     ),
                 )
             return (insert_cursor.rowcount + update_cursor.rowcount) > 0
@@ -591,7 +592,9 @@ class RelayIndex:
                 FROM archive_hours
                 WHERE mirror_status = 'ready'
                   AND (row_count IS NULL OR row_count > 0)
+                  AND (content_length IS NULL OR content_length >= ?)
                 """,
+                (_MIN_NONEMPTY_RAW_BYTES,),
                 default=0,
             )
         )
@@ -605,9 +608,12 @@ class RelayIndex:
                 SELECT COUNT(*)
                 FROM archive_hours
                 WHERE mirror_status = 'ready'
-                  AND row_count IS NOT NULL
-                  AND row_count = 0
+                  AND (
+                    (row_count IS NOT NULL AND row_count = 0)
+                    OR (content_length IS NOT NULL AND content_length < ?)
+                  )
                 """,
+                (_MIN_NONEMPTY_RAW_BYTES,),
                 default=0,
             )
         )
@@ -630,6 +636,7 @@ class RelayIndex:
                 SUM(
                     CASE
                         WHEN mirror_status = 'ready' AND (row_count IS NULL OR row_count > 0)
+                          AND (content_length IS NULL OR content_length >= ?)
                         THEN 1
                         ELSE 0
                     END
@@ -637,7 +644,8 @@ class RelayIndex:
                 SUM(CASE WHEN mirror_status IN ('error', 'quarantined') THEN 1 ELSE 0 END) AS mirror_errors,
                 SUM(CASE WHEN mirror_status = 'quarantined' THEN 1 ELSE 0 END) AS mirror_quarantined
             FROM archive_hours
-            """
+            """,
+            (_MIN_NONEMPTY_RAW_BYTES,),
         )
         stats_row = dict(row) if row is not None else {}
         archive_hours = self._compute_elapsed_archive_hours(now=now)

--- a/pmxt_relay/systemd/pmxt-relay.env.example
+++ b/pmxt_relay/systemd/pmxt-relay.env.example
@@ -1,8 +1,9 @@
 PMXT_RELAY_DATA_DIR=/srv/pmxt-relay
 PMXT_RELAY_BIND_HOST=0.0.0.0
 PMXT_RELAY_BIND_PORT=8080
-PMXT_RELAY_ARCHIVE_LISTING_URL=https://archive.example.com/pmxt
-PMXT_RELAY_RAW_BASE_URL=https://raw-origin.example.com/pmxt
+PMXT_RELAY_ARCHIVE_SOURCES=https://archive.pmxt.dev/Polymarket/v2|https://r2v2.pmxt.dev,https://archive.pmxt.dev/Polymarket/v1|https://r2.pmxt.dev
+PMXT_RELAY_ARCHIVE_LISTING_URL=https://archive.pmxt.dev/Polymarket/v2
+PMXT_RELAY_RAW_BASE_URL=https://r2v2.pmxt.dev
 PMXT_RELAY_POLL_INTERVAL_SECS=900
 PMXT_RELAY_EVENT_RETENTION=50000
 PMXT_RELAY_API_RATE_LIMIT_PER_MINUTE=2400

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -111,21 +111,30 @@ class RelayWorker:
 
     def _discover_archive_hours(self) -> int:
         discovered = 0
+        # Process lower-priority sources first so higher-priority sources later
+        # refresh source_url for filenames exposed by multiple archive versions.
+        for archive_source in reversed(self._config.resolved_archive_sources):
+            discovered += self._discover_archive_source(
+                archive_listing_url=archive_source.listing_url,
+                raw_base_url=archive_source.raw_base_url,
+            )
+        return discovered
+
+    def _discover_archive_source(self, *, archive_listing_url: str, raw_base_url: str) -> int:
+        discovered = 0
         page = 1
         stale_pages = 0
         while True:
             if self._config.archive_max_pages is not None and page > self._config.archive_max_pages:
                 break
-            html = fetch_archive_page(
-                self._config.archive_listing_url, page, self._config.http_timeout_secs
-            )
+            html = fetch_archive_page(archive_listing_url, page, self._config.http_timeout_secs)
             filenames = extract_archive_filenames(html)
             if not filenames:
                 break
 
             page_new = 0
             for filename in filenames:
-                source_url = f"{self._config.raw_base_url}/{filename}"
+                source_url = f"{raw_base_url}/{filename}"
                 if self._index.upsert_discovered_hour(filename, source_url, page):
                     page_new += 1
 
@@ -139,7 +148,13 @@ class RelayWorker:
                     level="INFO",
                     event_type="discover_page",
                     message=f"Discovered {page_new} new PMXT archive hours on page {page}",
-                    payload={"page": page, "new_hours": page_new, "total_entries": len(filenames)},
+                    payload={
+                        "listing_url": archive_listing_url,
+                        "raw_base_url": raw_base_url,
+                        "page": page,
+                        "new_hours": page_new,
+                        "total_entries": len(filenames),
+                    },
                 )
                 stale_pages = 0
             page += 1

--- a/prediction_market_extensions/adapters/polymarket/pmxt.py
+++ b/prediction_market_extensions/adapters/polymarket/pmxt.py
@@ -81,7 +81,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
     `QuoteTick` records.
     """
 
-    _PMXT_BASE_URL = "https://r2.pmxt.dev"
+    _PMXT_BASE_URL = "https://r2v2.pmxt.dev"
     _PMXT_REMOTE_COLUMNS: ClassVar[list[str]] = ["market_id", "update_type", "data"]
     _PMXT_COLUMNS: ClassVar[list[str]] = ["update_type", "data"]
     _PMXT_CACHE_DIR_ENV = "PMXT_CACHE_DIR"

--- a/scripts/_pmxt_raw_download.py
+++ b/scripts/_pmxt_raw_download.py
@@ -16,26 +16,41 @@ from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
 from pmxt_relay.storage import parse_archive_hour, raw_relative_path
 
 _USER_AGENT = "prediction-market-backtesting/1.0"
-_DEFAULT_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/Polymarket"
-_DEFAULT_ARCHIVE_BASE_URL = "https://r2.pmxt.dev"
+_DEFAULT_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/Polymarket/v2"
+_DEFAULT_ARCHIVE_BASE_URL = "https://r2v2.pmxt.dev"
+_DEFAULT_V1_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/Polymarket/v1"
+_DEFAULT_V1_ARCHIVE_BASE_URL = "https://r2.pmxt.dev"
 _DEFAULT_RELAY_BASE_URL = "https://209-209-10-83.sslip.io"
 _DOWNLOAD_CHUNK_SIZE = 8 * 1024 * 1024
 _STATUS_REFRESH_SECS = 0.2
+_MIN_NONEMPTY_RAW_BYTES = 1024 * 1024
 _RAW_FILENAME_PREFIX = "polymarket_orderbook_"
 _RAW_FILENAME_SUFFIX = ".parquet"
+
+
+@dataclass(frozen=True)
+class ArchiveSource:
+    listing_url: str
+    base_url: str
 
 
 @dataclass(frozen=True)
 class RawDownloadSummary:
     destination: str
     requested_hours: int
+    archive_listed_hours: int
     downloaded_hours: int
     skipped_existing_hours: int
+    refreshed_existing_hours: int
+    archive_missing_hours: list[str]
     failed_hours: list[str]
     missing_local_hours: list[str]
     empty_local_hours: list[str]
+    zero_row_local_hours: list[str]
+    small_local_hours: list[str]
     source_hits: dict[str, int]
     source_order: list[str]
+    archive_sources: list[str]
     start_hour: str | None
     end_hour: str | None
 
@@ -61,13 +76,13 @@ def _parse_hour_bound(value: str | None) -> datetime | None:
     return parsed.replace(minute=0, second=0, microsecond=0)
 
 
-def discover_archive_hours(
+def discover_archive_filenames(
     *,
     archive_listing_url: str = _DEFAULT_ARCHIVE_LISTING_URL,
     timeout_secs: int = 60,
     stale_pages: int = 1,
     max_pages: int | None = None,
-) -> list[datetime]:
+) -> list[str]:
     if stale_pages < 1:
         raise ValueError("stale_pages must be >= 1")
 
@@ -92,8 +107,24 @@ def discover_archive_hours(
             stale_count = 0
         page += 1
 
+    return sorted(discovered, key=discovered.__getitem__, reverse=True)
+
+
+def discover_archive_hours(
+    *,
+    archive_listing_url: str = _DEFAULT_ARCHIVE_LISTING_URL,
+    timeout_secs: int = 60,
+    stale_pages: int = 1,
+    max_pages: int | None = None,
+) -> list[datetime]:
     return [
-        discovered[name] for name in sorted(discovered, key=discovered.__getitem__, reverse=True)
+        parse_archive_hour(filename)
+        for filename in discover_archive_filenames(
+            archive_listing_url=archive_listing_url,
+            timeout_secs=timeout_secs,
+            stale_pages=stale_pages,
+            max_pages=max_pages,
+        )
     ]
 
 
@@ -115,6 +146,19 @@ def _sort_filenames_newest_first(filenames: list[str]) -> list[str]:
     return sorted(filenames, key=parse_archive_hour, reverse=True)
 
 
+def _filename_for_hour(hour: datetime) -> str:
+    return f"polymarket_orderbook_{hour.strftime('%Y-%m-%dT%H')}.parquet"
+
+
+def _hour_range_filenames(*, start_hour: datetime, end_hour: datetime) -> list[str]:
+    filenames: list[str] = []
+    current = start_hour
+    while current <= end_hour:
+        filenames.append(_filename_for_hour(current))
+        current += timedelta(hours=1)
+    return filenames
+
+
 def _archive_url(base_url: str, filename: str) -> str:
     return f"{base_url.rstrip('/')}/{filename}"
 
@@ -122,6 +166,88 @@ def _archive_url(base_url: str, filename: str) -> str:
 def _relay_url(base_url: str, filename: str) -> str:
     relative = raw_relative_path(filename).as_posix()
     return f"{base_url.rstrip('/')}/v1/raw/{relative}"
+
+
+def _source_url(
+    *, source: str, filename: str, archive_base_url: str, relay_base_url: str
+) -> tuple[str, str]:
+    if source == "archive":
+        return _archive_url(archive_base_url, filename), f"archive:{archive_base_url.rstrip('/')}"
+    return _relay_url(relay_base_url, filename), f"relay:{relay_base_url.rstrip('/')}"
+
+
+def _archive_sources_from_args(
+    *,
+    archive_sources: list[tuple[str, str]] | None,
+    archive_listing_url: str,
+    archive_base_url: str,
+) -> list[ArchiveSource]:
+    if archive_sources is None:
+        return [ArchiveSource(archive_listing_url.rstrip("/"), archive_base_url.rstrip("/"))]
+    normalized: list[ArchiveSource] = []
+    seen: set[tuple[str, str]] = set()
+    for listing_url, base_url in archive_sources:
+        source = ArchiveSource(listing_url.rstrip("/"), base_url.rstrip("/"))
+        key = (source.listing_url, source.base_url)
+        if key in seen:
+            continue
+        normalized.append(source)
+        seen.add(key)
+    if not normalized:
+        raise ValueError("At least one PMXT archive source must be configured.")
+    return normalized
+
+
+def _archive_candidate_urls(
+    *,
+    filename: str,
+    archive_sources: list[ArchiveSource],
+    discovered_archive_base_urls: dict[str, str],
+) -> list[tuple[str, str]]:
+    discovered_base_url = discovered_archive_base_urls.get(filename)
+    if discovered_base_url is not None:
+        return [
+            (
+                _archive_url(discovered_base_url, filename),
+                f"archive:{discovered_base_url.rstrip('/')}",
+            )
+        ]
+    return [
+        (_archive_url(source.base_url, filename), f"archive:{source.base_url.rstrip('/')}")
+        for source in archive_sources
+    ]
+
+
+def _candidate_urls(
+    *,
+    source: str,
+    filename: str,
+    archive_sources: list[ArchiveSource],
+    discovered_archive_base_urls: dict[str, str],
+    relay_base_url: str,
+) -> list[tuple[str, str]]:
+    if source == "archive":
+        return _archive_candidate_urls(
+            filename=filename,
+            archive_sources=archive_sources,
+            discovered_archive_base_urls=discovered_archive_base_urls,
+        )
+    return [(_relay_url(relay_base_url, filename), f"relay:{relay_base_url.rstrip('/')}")]
+
+
+def _remote_content_length(*, url: str, timeout_secs: int) -> int | None:
+    request = Request(url, method="HEAD", headers={"User-Agent": _USER_AGENT})
+    try:
+        with urlopen(request, timeout=timeout_secs) as response:
+            value = response.headers.get("Content-Length")
+    except Exception:
+        return None
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def _hour_label_for_filename(filename: str) -> str:
@@ -166,13 +292,22 @@ def _hour_result_text(*, hour_label: str, elapsed_secs: float, detail: str, sour
     return f"  {hour_label:>13s}  {elapsed_secs:6.3f}s  {detail:>10s}  {source}"
 
 
+def _format_download_error(exc: Exception) -> str:
+    if isinstance(exc, HTTPError):
+        message = f"HTTP {exc.code}"
+    else:
+        message = str(exc) or exc.__class__.__name__
+    return message.replace("\n", " ")[:180]
+
+
 def _source_priority_summary(
-    *, source_sequence: list[str], archive_base_url: str, relay_base_url: str
+    *, source_sequence: list[str], archive_sources: list[ArchiveSource], relay_base_url: str
 ) -> str:
     parts: list[str] = []
     for source in source_sequence:
         if source == "archive":
-            parts.append(f"archive {archive_base_url.rstrip('/')}")
+            archive_labels = ", ".join(source.base_url.rstrip("/") for source in archive_sources)
+            parts.append(f"archive {archive_labels}")
         else:
             parts.append(f"relay {relay_base_url.rstrip('/')}")
     return "PMXT raw source: explicit priority (" + " -> ".join(parts) + ")"
@@ -192,20 +327,62 @@ def _read_parquet_row_count(path: Path) -> int | None:
         return None
 
 
+def _local_raw_is_empty(path: Path) -> bool:
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        return True
+    if file_size < _MIN_NONEMPTY_RAW_BYTES:
+        return True
+    return _read_parquet_row_count(path) == 0
+
+
+def _existing_refresh_reason(
+    *,
+    path: Path,
+    source_urls: list[str],
+    timeout_secs: int,
+) -> str | None:
+    try:
+        local_size = path.stat().st_size
+    except OSError:
+        return "unreadable"
+
+    if _local_raw_is_empty(path):
+        return "empty"
+
+    for url in source_urls:
+        remote_size = _remote_content_length(url=url, timeout_secs=timeout_secs)
+        if remote_size is not None and remote_size > local_size:
+            return f"remote-larger:{_format_mib(remote_size)}"
+    return None
+
+
 def _validate_local_raw_hours(
     *, destination: Path, filenames: list[str]
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], list[str], list[str]]:
     missing: list[str] = []
     empty: list[str] = []
+    zero_row: list[str] = []
+    small: list[str] = []
     for filename in filenames:
+        hour_label = parse_archive_hour(filename).isoformat()
         destination_path = destination / raw_relative_path(filename)
         if not destination_path.exists():
-            missing.append(parse_archive_hour(filename).isoformat())
+            missing.append(hour_label)
             continue
+        try:
+            file_size = destination_path.stat().st_size
+        except OSError:
+            file_size = 0
         row_count = _read_parquet_row_count(destination_path)
         if row_count == 0:
-            empty.append(parse_archive_hour(filename).isoformat())
-    return missing, empty
+            zero_row.append(hour_label)
+        if file_size < _MIN_NONEMPTY_RAW_BYTES:
+            small.append(hour_label)
+        if row_count == 0 or file_size < _MIN_NONEMPTY_RAW_BYTES:
+            empty.append(hour_label)
+    return missing, empty, zero_row, small
 
 
 def _pid_is_active(pid: int) -> bool:
@@ -369,6 +546,7 @@ def download_raw_hours(
     destination: Path,
     archive_listing_url: str = _DEFAULT_ARCHIVE_LISTING_URL,
     archive_base_url: str = _DEFAULT_ARCHIVE_BASE_URL,
+    archive_sources: list[tuple[str, str]] | None = None,
     relay_base_url: str = _DEFAULT_RELAY_BASE_URL,
     source_order: list[str] | None = None,
     start_time: str | None = None,
@@ -381,6 +559,11 @@ def download_raw_hours(
 ) -> RawDownloadSummary:
     normalized_destination = destination.expanduser().resolve()
     normalized_destination.mkdir(parents=True, exist_ok=True)
+    resolved_archive_sources = _archive_sources_from_args(
+        archive_sources=archive_sources,
+        archive_listing_url=archive_listing_url,
+        archive_base_url=archive_base_url,
+    )
 
     selected_sources = source_order or ["archive", "relay"]
     source_sequence: list[str] = []
@@ -395,31 +578,66 @@ def download_raw_hours(
 
     start_hour = _parse_hour_bound(start_time)
     end_hour = _parse_hour_bound(end_time)
+    archive_missing_hours: list[str] = []
+    archive_listed_hours = 0
+    discovered_archive_base_urls: dict[str, str] = {}
     if start_hour is not None and end_hour is not None:
-        filenames = []
-        current = start_hour
-        while current <= end_hour:
-            filenames.append(f"polymarket_orderbook_{current.strftime('%Y-%m-%dT%H')}.parquet")
-            current += timedelta(hours=1)
+        filenames = _hour_range_filenames(start_hour=start_hour, end_hour=end_hour)
     else:
-        discovered_hours = discover_archive_hours(
-            archive_listing_url=archive_listing_url,
-            timeout_secs=timeout_secs,
-            stale_pages=discovery_stale_pages,
-            max_pages=discovery_max_pages,
+        discovered_filenames: list[str] = []
+        discovered_seen: set[str] = set()
+        for archive_source in reversed(resolved_archive_sources):
+            source_filenames = discover_archive_filenames(
+                archive_listing_url=archive_source.listing_url,
+                timeout_secs=timeout_secs,
+                stale_pages=discovery_stale_pages,
+                max_pages=discovery_max_pages,
+            )
+            for filename in source_filenames:
+                discovered_archive_base_urls[filename] = archive_source.base_url
+                if filename in discovered_seen:
+                    continue
+                discovered_filenames.append(filename)
+                discovered_seen.add(filename)
+        discovered_filenames = _sort_filenames_newest_first(discovered_filenames)
+        discovered_filenames = _filter_filenames_to_window(
+            discovered_filenames, start_hour=start_hour, end_hour=end_hour
         )
-        filenames = [
-            f"polymarket_orderbook_{hour.strftime('%Y-%m-%dT%H')}.parquet"
-            for hour in discovered_hours
-        ]
-        filenames = _filter_filenames_to_window(filenames, start_hour=start_hour, end_hour=end_hour)
+        archive_listed_hours = len(discovered_filenames)
+        if discovered_filenames:
+            discovered_hours = [parse_archive_hour(filename) for filename in discovered_filenames]
+            expected_start_hour = start_hour if start_hour is not None else min(discovered_hours)
+            expected_end_hour = end_hour if end_hour is not None else max(discovered_hours)
+            filenames = _hour_range_filenames(
+                start_hour=expected_start_hour, end_hour=expected_end_hour
+            )
+            discovered_set = set(discovered_filenames)
+            archive_missing_hours = [
+                parse_archive_hour(filename).isoformat()
+                for filename in _sort_filenames_newest_first(filenames)
+                if filename not in discovered_set
+            ]
+        else:
+            filenames = []
     filenames = _sort_filenames_newest_first(filenames)
+    if not filenames:
+        if start_hour is not None and end_hour is not None and start_hour > end_hour:
+            raise ValueError(
+                f"PMXT raw download window is empty: start_time {start_time!r} is after "
+                f"end_time {end_time!r}."
+            )
+        raise RuntimeError(
+            "No PMXT raw archive hours were discovered or selected. "
+            "Checked listings "
+            f"{[source.listing_url for source in resolved_archive_sources]!r}. "
+            "Pass --start-time/--end-time for an explicit window or check the archive listing URL."
+        )
 
     if show_progress:
         print(
             _source_priority_summary(
                 source_sequence=source_sequence,
-                archive_base_url=archive_base_url,
+                archive_sources=resolved_archive_sources,
                 relay_base_url=relay_base_url,
             )
         )
@@ -450,6 +668,7 @@ def download_raw_hours(
     failed_hours: list[str] = []
     downloaded_hours = 0
     skipped_existing_hours = 0
+    refreshed_existing_hours = 0
     completed_hours = 0
 
     try:
@@ -458,60 +677,94 @@ def download_raw_hours(
             _cleanup_stale_tmp_downloads(destination_path)
             hour_label = _hour_label_for_filename(filename)
             if destination_path.exists() and not overwrite:
-                skipped_existing_hours += 1
+                source_urls = [
+                    url
+                    for candidate_source in source_sequence
+                    for url, _source_label in _candidate_urls(
+                        source=candidate_source,
+                        filename=filename,
+                        archive_sources=resolved_archive_sources,
+                        discovered_archive_base_urls=discovered_archive_base_urls,
+                        relay_base_url=relay_base_url,
+                    )
+                ]
+                refresh_reason = _existing_refresh_reason(
+                    path=destination_path,
+                    source_urls=source_urls,
+                    timeout_secs=timeout_secs,
+                )
+                if refresh_reason is None:
+                    skipped_existing_hours += 1
+                    _write_progress_line(
+                        progress_bar,
+                        _hour_result_text(
+                            hour_label=hour_label,
+                            elapsed_secs=0.0,
+                            detail="existing",
+                            source="skip",
+                        ),
+                    )
+                    if progress_bar is not None:
+                        progress_bar.update(1)
+                    completed_hours += 1
+                    _set_status(
+                        progress_bar,
+                        total_hours=len(filenames),
+                        completed_hours=completed_hours,
+                        active_hours=0,
+                        status="",
+                        force=True,
+                    )
+                    continue
+                refreshed_existing_hours += 1
                 _write_progress_line(
                     progress_bar,
                     _hour_result_text(
-                        hour_label=hour_label, elapsed_secs=0.0, detail="existing", source="skip"
+                        hour_label=hour_label,
+                        elapsed_secs=0.0,
+                        detail="refresh",
+                        source=refresh_reason,
                     ),
                 )
-                if progress_bar is not None:
-                    progress_bar.update(1)
-                completed_hours += 1
-                _set_status(
-                    progress_bar,
-                    total_hours=len(filenames),
-                    completed_hours=completed_hours,
-                    active_hours=0,
-                    status="",
-                    force=True,
-                )
-                continue
 
             last_error: Exception | None = None
             hour_started_at = time.perf_counter()
             completed_source: str | None = None
             downloaded_size_bytes: int | None = None
             for source in source_sequence:
-                if source == "archive":
-                    url = _archive_url(archive_base_url, filename)
-                    source_label = f"archive:{archive_base_url.rstrip('/')}"
-                else:
-                    url = _relay_url(relay_base_url, filename)
-                    source_label = f"relay:{relay_base_url.rstrip('/')}"
-                try:
-                    downloaded_size_bytes = _download_one(
-                        url=url,
-                        destination=destination_path,
-                        timeout_secs=timeout_secs,
-                        progress_bar=progress_bar,
-                        total_hours=len(filenames),
-                        completed_hours=completed_hours,
-                        source=source,
-                        hour_label=hour_label,
-                    )
-                    source_hits[source_label] += 1
-                    downloaded_hours += 1
-                    completed_source = source
-                    last_error = None
-                    break
-                except HTTPError as exc:
-                    last_error = exc
-                    if exc.code != 404:
+                source_candidates = _candidate_urls(
+                    source=source,
+                    filename=filename,
+                    archive_sources=resolved_archive_sources,
+                    discovered_archive_base_urls=discovered_archive_base_urls,
+                    relay_base_url=relay_base_url,
+                )
+                for url, source_label in source_candidates:
+                    try:
+                        downloaded_size_bytes = _download_one(
+                            url=url,
+                            destination=destination_path,
+                            timeout_secs=timeout_secs,
+                            progress_bar=progress_bar,
+                            total_hours=len(filenames),
+                            completed_hours=completed_hours,
+                            source=source,
+                            hour_label=hour_label,
+                        )
+                        source_hits[source_label] += 1
+                        downloaded_hours += 1
+                        completed_source = source
+                        last_error = None
+                        break
+                    except HTTPError as exc:
+                        last_error = exc
+                        if exc.code != 404:
+                            continue
+                    except Exception as exc:
+                        last_error = exc
                         continue
-                except Exception as exc:
-                    last_error = exc
-                    continue
+                if last_error is None:
+                    break
 
             elapsed_secs = time.perf_counter() - hour_started_at
             if last_error is not None:
@@ -522,7 +775,10 @@ def download_raw_hours(
                         hour_label=hour_label,
                         elapsed_secs=elapsed_secs,
                         detail="failed",
-                        source=" -> ".join(source_sequence),
+                        source=(
+                            f"{' -> '.join(source_sequence)}; "
+                            f"last_error={_format_download_error(last_error)}"
+                        ),
                     ),
                 )
             elif downloaded_size_bytes is not None and completed_source is not None:
@@ -550,20 +806,29 @@ def download_raw_hours(
         if progress_bar is not None:
             progress_bar.close()
 
-    missing_local_hours, empty_local_hours = _validate_local_raw_hours(
-        destination=normalized_destination, filenames=filenames
-    )
+    (
+        missing_local_hours,
+        empty_local_hours,
+        zero_row_local_hours,
+        small_local_hours,
+    ) = _validate_local_raw_hours(destination=normalized_destination, filenames=filenames)
 
     return RawDownloadSummary(
         destination=str(normalized_destination),
         requested_hours=len(filenames),
+        archive_listed_hours=archive_listed_hours,
         downloaded_hours=downloaded_hours,
         skipped_existing_hours=skipped_existing_hours,
+        refreshed_existing_hours=refreshed_existing_hours,
+        archive_missing_hours=archive_missing_hours,
         failed_hours=failed_hours,
         missing_local_hours=missing_local_hours,
         empty_local_hours=empty_local_hours,
+        zero_row_local_hours=zero_row_local_hours,
+        small_local_hours=small_local_hours,
         source_hits=dict(source_hits),
         source_order=source_sequence,
+        archive_sources=[source.base_url for source in resolved_archive_sources],
         start_hour=start_hour.isoformat() if start_hour is not None else None,
         end_hour=end_hour.isoformat() if end_hour is not None else None,
     )

--- a/scripts/pmxt_download_raws.py
+++ b/scripts/pmxt_download_raws.py
@@ -14,18 +14,41 @@ ensure_repo_root(__file__)
 from scripts._pmxt_raw_download import download_raw_hours  # noqa: E402
 
 
+def _parse_archive_source(value: str) -> tuple[str, str]:
+    if "|" not in value:
+        raise argparse.ArgumentTypeError(
+            "Archive sources must use LISTING_URL|RAW_BASE_URL syntax."
+        )
+    listing_url, base_url = (part.strip() for part in value.split("|", maxsplit=1))
+    if not listing_url or not base_url:
+        raise argparse.ArgumentTypeError(
+            "Archive sources must include both LISTING_URL and RAW_BASE_URL."
+        )
+    return listing_url, base_url
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Download PMXT raw archive hours into a local mirror. With no time "
+            "Download PMXT v2 raw archive hours into a local mirror. With no time "
             "window, the script discovers all archive hours and downloads them "
             "newest-first to the destination using archive first and relay as "
             "fallback, then reports missing and zero-row local hours."
         )
     )
     parser.add_argument("--destination", type=Path, required=True)
-    parser.add_argument("--archive-listing-url", default="https://archive.pmxt.dev/Polymarket")
-    parser.add_argument("--archive-base-url", default="https://r2.pmxt.dev")
+    parser.add_argument("--archive-listing-url", default=None)
+    parser.add_argument("--archive-base-url", default=None)
+    parser.add_argument(
+        "--archive-source",
+        action="append",
+        type=_parse_archive_source,
+        default=[],
+        help=(
+            "Archive source pair in LISTING_URL|RAW_BASE_URL form. May be repeated. "
+            "Defaults to PMXT Polymarket v2 first, then v1."
+        ),
+    )
     parser.add_argument("--relay-base-url", default="https://209-209-10-83.sslip.io")
     parser.add_argument(
         "--source",
@@ -43,10 +66,25 @@ def main() -> int:
     parser.add_argument("--discovery-max-pages", type=int, default=None)
     args = parser.parse_args()
 
+    archive_sources = args.archive_source or None
+    archive_listing_url = args.archive_listing_url
+    archive_base_url = args.archive_base_url
+    if archive_sources is None and (archive_listing_url is None and archive_base_url is None):
+        archive_sources = [
+            ("https://archive.pmxt.dev/Polymarket/v2", "https://r2v2.pmxt.dev"),
+            ("https://archive.pmxt.dev/Polymarket/v1", "https://r2.pmxt.dev"),
+        ]
+        archive_listing_url = "https://archive.pmxt.dev/Polymarket/v2"
+        archive_base_url = "https://r2v2.pmxt.dev"
+    else:
+        archive_listing_url = archive_listing_url or "https://archive.pmxt.dev/Polymarket/v2"
+        archive_base_url = archive_base_url or "https://r2v2.pmxt.dev"
+
     summary = download_raw_hours(
         destination=args.destination,
-        archive_listing_url=args.archive_listing_url,
-        archive_base_url=args.archive_base_url,
+        archive_listing_url=archive_listing_url,
+        archive_base_url=archive_base_url,
+        archive_sources=archive_sources,
         relay_base_url=args.relay_base_url,
         source_order=args.source or None,
         start_time=args.start_time,
@@ -58,7 +96,13 @@ def main() -> int:
         discovery_max_pages=args.discovery_max_pages,
     )
     print(json.dumps(summary.as_dict(), indent=2, sort_keys=True))
-    return 1 if summary.failed_hours else 0
+    incomplete = (
+        summary.archive_missing_hours
+        or summary.failed_hours
+        or summary.missing_local_hours
+        or summary.empty_local_hours
+    )
+    return 1 if incomplete else 0
 
 
 if __name__ == "__main__":

--- a/tests/_public_runner_validation_cases.py
+++ b/tests/_public_runner_validation_cases.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from nautilus_trader.adapters.polymarket.common.parsing import parse_polymarket_instrument
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import AggressorSide
+from nautilus_trader.model.identifiers import TradeId
+
+from prediction_market_extensions.adapters.kalshi.providers import market_dict_to_instrument
+from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
+from prediction_market_extensions.backtesting._experiments import run_experiment
+
+RESULT_MARKER = "PUBLIC_RUNNER_VALIDATION_RESULT="
+
+
+def _timestamp_ns(start: datetime, offset_seconds: int) -> int:
+    return int((start + timedelta(seconds=offset_seconds)).timestamp() * 1_000_000_000)
+
+
+def _make_trade_ticks(
+    *,
+    instrument: Any,
+    start: datetime,
+    prices: Sequence[float],
+    size: float,
+    trade_id_prefix: str,
+) -> tuple[TradeTick, ...]:
+    return tuple(
+        TradeTick(
+            instrument_id=instrument.id,
+            price=instrument.make_price(price),
+            size=instrument.make_qty(size),
+            aggressor_side=AggressorSide.BUYER,
+            trade_id=TradeId(f"{trade_id_prefix}{index:04d}"),
+            ts_event=_timestamp_ns(start, index),
+            ts_init=_timestamp_ns(start, index),
+        )
+        for index, price in enumerate(prices)
+    )
+
+
+def _minimal_result(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "fills": result["fills"],
+        "pnl": result["pnl"],
+        "terminated_early": result["terminated_early"],
+        "realized_outcome": result["realized_outcome"],
+        "fill_events": result["fill_events"],
+    }
+
+
+def _run_kalshi_breakout_case(*, prices: Sequence[float]) -> dict[str, Any]:
+    import backtests.kalshi_trade_tick_breakout as runner
+
+    market = {
+        "ticker": "KXLAYOFFSYINFO-26-494000",
+        "event_ticker": "SYNTHETIC",
+        "title": "Synthetic validation market",
+        "open_time": "2026-01-01T00:00:00+00:00",
+        "close_time": "2026-12-31T00:00:00+00:00",
+        "result": "yes",
+    }
+    instrument = market_dict_to_instrument(market)
+    trades = _make_trade_ticks(
+        instrument=instrument,
+        start=datetime(2026, 3, 15, tzinfo=timezone.utc),
+        prices=prices,
+        size=10,
+        trade_id_prefix="K",
+    )
+
+    class Loader:
+        def __init__(self) -> None:
+            self.instrument = instrument
+
+        async def load_trades(self, start, end):  # type: ignore[no-untyped-def]
+            return trades
+
+    class LoaderFactory:
+        @classmethod
+        async def from_market_ticker(cls, ticker: str):  # type: ignore[no-untyped-def]
+            if ticker != runner.REPLAYS[0].market_ticker:
+                raise AssertionError(f"unexpected ticker {ticker!r}")
+            return Loader()
+
+    backtest_module.KalshiDataLoader = LoaderFactory
+    experiment = replace(
+        runner.EXPERIMENT,
+        min_trades=0,
+        min_price_range=0.0,
+        nautilus_log_level="ERROR",
+        emit_html=False,
+        report=None,
+        chart_output_path=None,
+    )
+    results = run_experiment(experiment)
+    if len(results) != 1:
+        raise AssertionError(f"expected one result, received {len(results)}")
+    return _minimal_result(results[0])
+
+
+def _run_polymarket_trade_case() -> dict[str, Any]:
+    import backtests.polymarket_trade_tick_vwap_reversion as runner
+
+    market_info = {
+        "condition_id": "0x" + "1" * 64,
+        "question": "Synthetic validation market",
+        "minimum_tick_size": "0.01",
+        "minimum_order_size": "1",
+        "end_date_iso": "2026-12-31T00:00:00Z",
+        "maker_base_fee": "0",
+        "taker_base_fee": "0",
+        "result": "yes",
+    }
+    instrument = parse_polymarket_instrument(
+        market_info=market_info,
+        token_id="2" * 64,
+        outcome="Yes",
+        ts_init=0,
+    )
+    prices = [0.50] * 30 + [0.49, 0.50, 0.505, 0.49, 0.50]
+    trades = _make_trade_ticks(
+        instrument=instrument,
+        start=datetime(2026, 2, 21, 16, tzinfo=timezone.utc),
+        prices=prices,
+        size=10,
+        trade_id_prefix="P",
+    )
+
+    class Loader:
+        def __init__(self) -> None:
+            self.instrument = instrument
+
+        async def load_trades(self, start, end):  # type: ignore[no-untyped-def]
+            return trades
+
+    class LoaderFactory:
+        @classmethod
+        async def from_market_slug(cls, slug: str, *, token_index: int = 0):  # type: ignore[no-untyped-def]
+            if slug != runner.REPLAYS[0].market_slug:
+                raise AssertionError(f"unexpected slug {slug!r}")
+            if token_index != runner.REPLAYS[0].token_index:
+                raise AssertionError(f"unexpected token_index {token_index!r}")
+            return Loader()
+
+    backtest_module.PolymarketDataLoader = LoaderFactory
+    experiment = replace(
+        runner.EXPERIMENT,
+        min_trades=0,
+        min_price_range=0.0,
+        nautilus_log_level="ERROR",
+        emit_html=False,
+        report=None,
+        chart_output_path=None,
+    )
+    results = run_experiment(experiment)
+    if len(results) != 1:
+        raise AssertionError(f"expected one result, received {len(results)}")
+    return _minimal_result(results[0])
+
+
+def _run_case(case: str) -> dict[str, Any]:
+    if case == "kalshi-baseline":
+        return _run_kalshi_breakout_case(
+            prices=[0.50] * 61 + [0.55, 0.59, 0.60, 0.53, 0.51, 0.48, 0.46, 0.44]
+        )
+    if case == "kalshi-prefix-normal":
+        return _run_kalshi_breakout_case(prices=[0.50] * 61 + [0.55, 0.59, 0.60, 0.53, 0.51])
+    if case == "kalshi-prefix-stressed":
+        return _run_kalshi_breakout_case(prices=[0.50] * 61 + [0.55, 0.99, 0.01, 0.99, 0.01])
+    if case == "polymarket-trade":
+        return _run_polymarket_trade_case()
+    raise AssertionError(f"unknown validation case {case!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("case")
+    args = parser.parse_args()
+
+    result = _run_case(args.case)
+    print(f"{RESULT_MARKER}{json.dumps(result, sort_keys=True)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pmxt_data_source.py
+++ b/tests/test_pmxt_data_source.py
@@ -148,12 +148,12 @@ def test_configured_pmxt_data_source_rejects_cache_explicit_source() -> None:
 @pytest.mark.parametrize(
     "source",
     [
-        "r2.pmxt.dev",
+        "r2v2.pmxt.dev",
         "/tmp/pmxt-raw",
         "local_raws:/tmp/pmxt-raw",
         "processed:/tmp/pmxt-processed",
         "raw:/tmp/pmxt-raw",
-        "raw-remote:https://r2.pmxt.dev",
+        "raw-remote:https://r2v2.pmxt.dev",
         "mirror:/tmp/pmxt-raw",
         "relay-raw:https://relay.vendor.test",
     ],
@@ -401,7 +401,7 @@ def test_runner_loader_uses_user_agent_for_remote_downloads(monkeypatch, tmp_pat
 
     destination = tmp_path / "download.parquet"
     total_bytes = loader._download_to_file_with_progress(
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-02-22T11.parquet", destination
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-02-22T11.parquet", destination
     )
 
     assert total_bytes == len(payload)
@@ -450,12 +450,12 @@ def test_runner_loader_uses_timeout_for_remote_payload_and_head(monkeypatch) -> 
 
     assert (
         loader._download_payload_with_progress(
-            "https://r2.pmxt.dev/polymarket_orderbook_2026-02-22T12.parquet"
+            "https://r2v2.pmxt.dev/polymarket_orderbook_2026-02-22T12.parquet"
         )
         == payload
     )
     assert loader._progress_total_bytes(
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-02-22T12.parquet"
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-02-22T12.parquet"
     ) == len(payload)
 
     assert len(requests) == 2

--- a/tests/test_pmxt_raw_download.py
+++ b/tests/test_pmxt_raw_download.py
@@ -117,7 +117,7 @@ def test_discover_archive_hours_reads_listing_pages(monkeypatch) -> None:
     )
 
     hours = raw_download.discover_archive_hours(
-        archive_listing_url="https://archive.pmxt.dev/Polymarket", timeout_secs=60
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2", timeout_secs=60
     )
 
     assert [hour.isoformat() for hour in hours] == [
@@ -135,10 +135,10 @@ def test_download_raw_hours_fetches_archive_then_relay_fallback(
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_hours",
+        "discover_archive_filenames",
         lambda **_: [
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T09.parquet"),
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T10.parquet"),
+            "polymarket_orderbook_2026-03-21T09.parquet",
+            "polymarket_orderbook_2026-03-21T10.parquet",
         ],
     )
 
@@ -161,13 +161,13 @@ def test_download_raw_hours_fetches_archive_then_relay_fallback(
     assert summary.skipped_existing_hours == 0
     assert summary.failed_hours == []
     assert summary.source_hits == {
-        "archive:https://r2.pmxt.dev": 1,
+        "archive:https://r2v2.pmxt.dev": 1,
         "relay:https://209-209-10-83.sslip.io": 1,
     }
     assert requested_urls == [
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
         "https://209-209-10-83.sslip.io/v1/raw/2026/03/21/polymarket_orderbook_2026-03-21T10.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
     ]
     assert (
         tmp_path / "raws" / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T09.parquet"
@@ -185,10 +185,10 @@ def test_download_raw_hours_skips_existing_files(monkeypatch, tmp_path: Path) ->
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_hours",
+        "discover_archive_filenames",
         lambda **_: [
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T09.parquet"),
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T10.parquet"),
+            "polymarket_orderbook_2026-03-21T09.parquet",
+            "polymarket_orderbook_2026-03-21T10.parquet",
         ],
     )
     monkeypatch.setattr(
@@ -196,6 +196,7 @@ def test_download_raw_hours_skips_existing_files(monkeypatch, tmp_path: Path) ->
         "urlopen",
         lambda request, timeout=60: _Response(payload),  # type: ignore[arg-type]
     )
+    monkeypatch.setattr(raw_download, "_existing_refresh_reason", lambda **_: None)
 
     summary = raw_download.download_raw_hours(destination=destination, show_progress=False)
 
@@ -222,8 +223,8 @@ def test_download_raw_hours_removes_stale_temp_files_before_skipping(
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_hours",
-        lambda **_: [raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T09.parquet")],
+        "discover_archive_filenames",
+        lambda **_: ["polymarket_orderbook_2026-03-21T09.parquet"],
     )
 
     def fake_pid_is_active(pid: int) -> bool:
@@ -235,6 +236,7 @@ def test_download_raw_hours_removes_stale_temp_files_before_skipping(
         raise AssertionError(f"unexpected download request for {request.full_url}")
 
     monkeypatch.setattr(raw_download, "_pid_is_active", fake_pid_is_active)
+    monkeypatch.setattr(raw_download, "_existing_refresh_reason", lambda **_: None)
     monkeypatch.setattr(raw_download, "urlopen", unexpected_urlopen)
 
     summary = raw_download.download_raw_hours(destination=destination, show_progress=False)
@@ -254,10 +256,10 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_hours",
+        "discover_archive_filenames",
         lambda **_: [
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T09.parquet"),
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T10.parquet"),
+            "polymarket_orderbook_2026-03-21T09.parquet",
+            "polymarket_orderbook_2026-03-21T10.parquet",
         ],
     )
 
@@ -287,7 +289,7 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
     captured = capsys.readouterr()
 
     assert (
-        "PMXT raw source: explicit priority (archive https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)"
+        "PMXT raw source: explicit priority (archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)"
     ) in captured.out
     assert "window_start=2026-03-21T09" in captured.out
     assert "window_end=2026-03-21T10" in captured.out
@@ -308,10 +310,10 @@ def test_download_raw_hours_reports_missing_and_empty_local_hours(
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_hours",
+        "discover_archive_filenames",
         lambda **_: [
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T09.parquet"),
-            raw_download.parse_archive_hour("polymarket_orderbook_2026-03-21T10.parquet"),
+            "polymarket_orderbook_2026-03-21T09.parquet",
+            "polymarket_orderbook_2026-03-21T10.parquet",
         ],
     )
 
@@ -330,3 +332,152 @@ def test_download_raw_hours_reports_missing_and_empty_local_hours(
     assert summary.failed_hours == ["2026-03-21T09:00:00+00:00"]
     assert summary.missing_local_hours == ["2026-03-21T09:00:00+00:00"]
     assert summary.empty_local_hours == ["2026-03-21T10:00:00+00:00"]
+
+
+def test_download_raw_hours_progress_output_includes_failure_error(
+    monkeypatch, tmp_path: Path
+) -> None:
+    bars: list[_FakeTqdm] = []
+
+    monkeypatch.setattr(
+        raw_download,
+        "discover_archive_filenames",
+        lambda **_: ["polymarket_orderbook_2026-03-21T09.parquet"],
+    )
+    monkeypatch.setattr(
+        raw_download,
+        "tqdm",
+        lambda *args, **kwargs: bars.append(_FakeTqdm(*args, **kwargs)) or bars[-1],
+    )  # type: ignore[func-returns-value]
+
+    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
+        del timeout
+        raise HTTPError(request.full_url, 503, "unavailable", hdrs=None, fp=None)
+
+    monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
+
+    summary = raw_download.download_raw_hours(
+        destination=tmp_path / "raws", source_order=["archive"], show_progress=True
+    )
+
+    assert summary.failed_hours == ["2026-03-21T09:00:00+00:00"]
+    assert len(bars) == 1
+    assert any("failed" in line and "last_error=HTTP 503" in line for line in bars[0].writes)
+
+
+def test_download_raw_hours_requests_full_hour_range_and_reports_archive_gaps(
+    monkeypatch, tmp_path: Path
+) -> None:
+    payload = _raw_parquet_payload()
+    requested_urls: list[str] = []
+
+    monkeypatch.setattr(
+        raw_download,
+        "discover_archive_filenames",
+        lambda **_: [
+            "polymarket_orderbook_2026-03-21T09.parquet",
+            "polymarket_orderbook_2026-03-21T11.parquet",
+        ],
+    )
+
+    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
+        del timeout
+        requested_urls.append(request.full_url)
+        return _Response(payload, headers={"Content-Length": str(len(payload))})
+
+    monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
+
+    summary = raw_download.download_raw_hours(
+        destination=tmp_path / "raws", source_order=["archive"], show_progress=False
+    )
+
+    assert summary.requested_hours == 3
+    assert summary.archive_listed_hours == 2
+    assert summary.archive_missing_hours == ["2026-03-21T10:00:00+00:00"]
+    assert requested_urls == [
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet",
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
+    ]
+
+
+def test_download_raw_hours_combines_v1_and_v2_archive_sources(monkeypatch, tmp_path: Path) -> None:
+    payload = _raw_parquet_payload()
+    pages = {
+        "https://archive.pmxt.dev/Polymarket/v2": [
+            "polymarket_orderbook_2026-03-21T11.parquet",
+            "polymarket_orderbook_2026-03-21T10.parquet",
+        ],
+        "https://archive.pmxt.dev/Polymarket/v1": [
+            "polymarket_orderbook_2026-03-21T09.parquet",
+        ],
+    }
+    requested_urls: list[str] = []
+
+    monkeypatch.setattr(
+        raw_download,
+        "discover_archive_filenames",
+        lambda archive_listing_url, **_: pages[archive_listing_url],  # type: ignore[no-untyped-def]
+    )
+
+    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
+        del timeout
+        requested_urls.append(request.full_url)
+        return _Response(payload, headers={"Content-Length": str(len(payload))})
+
+    monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
+
+    summary = raw_download.download_raw_hours(
+        destination=tmp_path / "raws",
+        archive_sources=[
+            ("https://archive.pmxt.dev/Polymarket/v2", "https://r2v2.pmxt.dev"),
+            ("https://archive.pmxt.dev/Polymarket/v1", "https://r2.pmxt.dev"),
+        ],
+        source_order=["archive"],
+        show_progress=False,
+    )
+
+    assert summary.archive_listed_hours == 3
+    assert summary.requested_hours == 3
+    assert summary.archive_sources == ["https://r2v2.pmxt.dev", "https://r2.pmxt.dev"]
+    assert requested_urls == [
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet",
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
+        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
+    ]
+
+
+def test_download_raw_hours_refreshes_existing_when_upstream_is_larger(
+    monkeypatch, tmp_path: Path
+) -> None:
+    payload = _raw_parquet_payload()
+    destination = tmp_path / "raws"
+    existing_path = (
+        destination / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T09.parquet"
+    )
+    existing_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_path.write_bytes(b"old")
+
+    monkeypatch.setattr(
+        raw_download,
+        "discover_archive_filenames",
+        lambda **_: ["polymarket_orderbook_2026-03-21T09.parquet"],
+    )
+    monkeypatch.setattr(raw_download, "_local_raw_is_empty", lambda path: False)
+
+    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
+        del timeout
+        if request.get_method() == "HEAD":
+            return _Response(b"", headers={"Content-Length": "1024"})
+        return _Response(payload, headers={"Content-Length": str(len(payload))})
+
+    monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
+
+    summary = raw_download.download_raw_hours(
+        destination=destination, source_order=["archive"], show_progress=False
+    )
+
+    assert summary.downloaded_hours == 1
+    assert summary.refreshed_existing_hours == 1
+    assert summary.skipped_existing_hours == 0
+    assert existing_path.read_bytes() == payload

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -27,8 +27,8 @@ def _make_config(tmp_path: Path) -> RelayConfig:
         data_dir=tmp_path,
         bind_host="127.0.0.1",
         bind_port=8080,
-        archive_listing_url="https://archive.pmxt.dev/Polymarket",
-        raw_base_url="https://r2.pmxt.dev",
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
         poll_interval_secs=900,
         http_timeout_secs=30,
         archive_stale_pages=3,
@@ -353,7 +353,7 @@ def test_upstream_badge_stays_online_for_fresh_unresolved_mirror_gaps(tmp_path: 
         now=now,
     )
 
-    assert payload["label"] == "r2.pmxt.dev"
+    assert payload["label"] == "r2v2.pmxt.dev"
     assert payload["message"] == "online"
     assert payload["color"] == "brightgreen"
 
@@ -374,7 +374,7 @@ def test_upstream_badge_stays_online_for_backlog_with_old_latest_mirror(tmp_path
         now=now,
     )
 
-    assert payload["label"] == "r2.pmxt.dev"
+    assert payload["label"] == "r2v2.pmxt.dev"
     assert payload["message"] == "online"
     assert payload["color"] == "brightgreen"
 
@@ -395,7 +395,7 @@ def test_upstream_badge_uses_offline_for_stale_polling(tmp_path: Path):
         now=now,
     )
 
-    assert payload["label"] == "r2.pmxt.dev"
+    assert payload["label"] == "r2v2.pmxt.dev"
     assert payload["message"] == "offline"
     assert payload["color"] == "red"
 
@@ -552,7 +552,7 @@ def test_empty_hours_badge_shows_count(tmp_path: Path):
                 filename,
                 local_path=str(tmp_path / filename),
                 etag=None,
-                content_length=1,
+                content_length=2 * 1024 * 1024,
                 last_modified=None,
             )
         index.update_row_count(empty, 0)
@@ -593,6 +593,6 @@ def test_upstream_badge_old_mirror_errors_still_report_online(tmp_path: Path):
         now=now,
     )
 
-    assert payload["label"] == "r2.pmxt.dev"
+    assert payload["label"] == "r2v2.pmxt.dev"
     assert payload["message"] == "online"
     assert payload["color"] == "brightgreen"

--- a/tests/test_pmxt_relay_archive.py
+++ b/tests/test_pmxt_relay_archive.py
@@ -4,7 +4,7 @@ from pmxt_relay.archive import extract_archive_filenames
 def test_extract_archive_filenames_deduplicates_and_preserves_order():
     html = """
     <a href="/dumps/polymarket_orderbook_2026-03-21T12.parquet">latest</a>
-    <a href="https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet">new link</a>
+    <a href="https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet">new link</a>
     <a href="/dumps/polymarket_orderbook_2026-03-21T11.parquet">previous</a>
     <a href="/dumps/polymarket_orderbook_2026-03-21T12.parquet">duplicate</a>
     """

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -16,12 +16,12 @@ def test_relay_index_events_and_queue_summary_are_mirror_only(tmp_path: Path):
 
         index.upsert_discovered_hour(
             "polymarket_orderbook_2026-03-21T12.parquet",
-            "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
+            "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
             1,
         )
         index.upsert_discovered_hour(
             "polymarket_orderbook_2026-03-21T13.parquet",
-            "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet",
+            "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T13.parquet",
             1,
         )
         index.mark_mirroring("polymarket_orderbook_2026-03-21T12.parquet")
@@ -85,13 +85,13 @@ def test_relay_index_events_and_queue_summary_are_mirror_only(tmp_path: Path):
         assert stats["last_error_at"] is not None
 
 
-def test_upsert_discovered_hour_is_idempotent(tmp_path: Path):
+def test_upsert_discovered_hour_refreshes_source_url_once(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
 
         first_insert = index.upsert_discovered_hour(
             "polymarket_orderbook_2026-03-21T12.parquet",
-            "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
+            "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
             1,
         )
         second_insert = index.upsert_discovered_hour(
@@ -99,9 +99,15 @@ def test_upsert_discovered_hour_is_idempotent(tmp_path: Path):
             "https://mirror.example.com/polymarket_orderbook_2026-03-21T12.parquet",
             2,
         )
+        unchanged = index.upsert_discovered_hour(
+            "polymarket_orderbook_2026-03-21T12.parquet",
+            "https://mirror.example.com/polymarket_orderbook_2026-03-21T12.parquet",
+            2,
+        )
 
         assert first_insert is True
-        assert second_insert is False
+        assert second_insert is True
+        assert unchanged is False
         row = index._conn.execute(
             "SELECT archive_page, source_url FROM archive_hours WHERE filename = ?",
             ("polymarket_orderbook_2026-03-21T12.parquet",),
@@ -118,7 +124,7 @@ def test_initialize_resets_stale_mirror_rows(tmp_path: Path):
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
         index.upsert_discovered_hour(
-            filename, "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet", 1
+            filename, "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet", 1
         )
         index.mark_mirroring(filename)
 
@@ -140,7 +146,7 @@ def test_register_local_raw_marks_hour_ready(tmp_path: Path):
             filename,
             local_path="/srv/pmxt-relay/raw/2026/03/21/" + filename,
             content_length=123,
-            source_url="https://r2.pmxt.dev/" + filename,
+            source_url="https://r2v2.pmxt.dev/" + filename,
         )
 
         assert changed is True
@@ -156,6 +162,42 @@ def test_register_local_raw_marks_hour_ready(tmp_path: Path):
         assert row["mirror_status"] == "ready"
         assert row["content_length"] == 123
         assert row["mirrored_at"] is not None
+
+
+def test_register_local_raw_does_not_overwrite_discovered_source_url(tmp_path: Path):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        source_url = f"https://r2.pmxt.dev/{filename}"
+        changed_source_url = f"https://r2v2.pmxt.dev/{filename}"
+        index.upsert_discovered_hour(filename, source_url, 1)
+
+        changed = index.register_local_raw(
+            filename,
+            local_path="/srv/pmxt-relay/raw/2026/03/21/" + filename,
+            content_length=123,
+            source_url=changed_source_url,
+        )
+        unchanged = index.register_local_raw(
+            filename,
+            local_path="/srv/pmxt-relay/raw/2026/03/21/" + filename,
+            content_length=123,
+            source_url=changed_source_url,
+        )
+
+        row = index._conn.execute(
+            """
+            SELECT source_url, local_path, mirror_status
+            FROM archive_hours
+            WHERE filename = ?
+            """,
+            (filename,),
+        ).fetchone()
+        assert changed is True
+        assert unchanged is False
+        assert row is not None
+        assert row["source_url"] == source_url
+        assert row["mirror_status"] == "ready"
 
 
 def test_relay_index_context_manager_closes_connection(tmp_path: Path):
@@ -176,12 +218,12 @@ def test_queue_summary_reports_latest_mirrored_filename(tmp_path: Path):
             "polymarket_orderbook_2026-03-21T13.parquet",
         ]
         for filename in filenames:
-            index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
             index.mark_mirrored(
                 filename,
                 local_path=f"/srv/pmxt-relay/raw/{filename}",
                 etag=None,
-                content_length=1,
+                content_length=2 * 1024 * 1024,
                 last_modified=None,
             )
 
@@ -196,7 +238,7 @@ def test_error_rows_back_off_until_next_retry(tmp_path: Path):
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
         retry_at = "2026-03-21T13:00:00+00:00"
-        index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         index.mark_mirror_retry(
             filename, error="transient upstream failure", next_retry_at=retry_at
         )
@@ -222,7 +264,7 @@ def test_quarantined_rows_count_as_errors_until_their_retry_window(tmp_path: Pat
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
         retry_at = "2026-03-21T14:00:00+00:00"
-        index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         index.mark_mirror_quarantined(
             filename, error="HTTP Error 404: Not Found", next_retry_at=retry_at
         )
@@ -322,12 +364,12 @@ def test_list_hours_needing_verification_returns_oldest_first(tmp_path: Path):
             "polymarket_orderbook_2026-03-21T14.parquet",
         ]
         for filename in filenames:
-            index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
             index.mark_mirrored(
                 filename,
                 local_path=f"/srv/pmxt-relay/raw/{filename}",
                 etag=None,
-                content_length=1,
+                content_length=2 * 1024 * 1024,
                 last_modified=None,
             )
         with index._conn:
@@ -351,7 +393,7 @@ def test_mark_verified_sets_timestamp(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         index.mark_mirrored(
             filename,
             local_path=f"/srv/pmxt-relay/raw/{filename}",
@@ -374,7 +416,7 @@ def test_mark_needs_remirror_resets_to_pending(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         index.mark_mirrored(
             filename,
             local_path=f"/srv/pmxt-relay/raw/{filename}",
@@ -408,13 +450,13 @@ def test_count_missing_hours_includes_unpublished_gap(tmp_path: Path):
         quarantined = "polymarket_orderbook_2026-03-21T14.parquet"
         pending = "polymarket_orderbook_2026-03-21T15.parquet"
         for filename in [ready, empty, quarantined, pending]:
-            index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         for filename in [ready, empty]:
             index.mark_mirrored(
                 filename,
                 local_path=f"/srv/pmxt-relay/raw/{filename}",
                 etag=None,
-                content_length=1,
+                content_length=2 * 1024 * 1024,
                 last_modified=None,
             )
         index.update_row_count(empty, 0)
@@ -431,7 +473,7 @@ def test_count_missing_hours_wall_clock_gap_dominant(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         ready = "polymarket_orderbook_2026-03-21T00.parquet"
-        index.upsert_discovered_hour(ready, f"https://r2.pmxt.dev/{ready}", 1)
+        index.upsert_discovered_hour(ready, f"https://r2v2.pmxt.dev/{ready}", 1)
         index.mark_mirrored(
             ready,
             local_path=f"/srv/pmxt-relay/raw/{ready}",
@@ -451,7 +493,7 @@ def test_stats_archive_hours_are_elapsed_wall_clock_hours(tmp_path: Path):
         earliest = "polymarket_orderbook_2026-03-21T12.parquet"
         later = "polymarket_orderbook_2026-03-21T13.parquet"
         for filename in [earliest, later]:
-            index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         index._conn.execute(
             "UPDATE archive_hours SET hour = ? WHERE filename = ?",
             ("2026-03-21T12:45:00Z", earliest),
@@ -470,12 +512,12 @@ def test_stats_mirrored_hours_exclude_known_empty_rows(tmp_path: Path):
         unknown = "polymarket_orderbook_2026-03-21T13.parquet"
         nonempty = "polymarket_orderbook_2026-03-21T14.parquet"
         for filename in [empty, unknown, nonempty]:
-            index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
             index.mark_mirrored(
                 filename,
                 local_path=f"/srv/pmxt-relay/raw/{filename}",
                 etag=None,
-                content_length=1,
+                content_length=2 * 1024 * 1024,
                 last_modified=None,
             )
         index.update_row_count(empty, 0)
@@ -495,12 +537,12 @@ def test_count_empty_hours(tmp_path: Path):
             "polymarket_orderbook_2026-03-21T14.parquet",
         ]
         for filename in filenames:
-            index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
             index.mark_mirrored(
                 filename,
                 local_path=f"/srv/pmxt-relay/raw/{filename}",
                 etag=None,
-                content_length=1,
+                content_length=2 * 1024 * 1024,
                 last_modified=None,
             )
         index.update_row_count(filenames[0], 0)
@@ -509,11 +551,31 @@ def test_count_empty_hours(tmp_path: Path):
         assert index.count_empty_hours() == 1
 
 
+def test_count_empty_hours_includes_sub_one_mib_raws(tmp_path: Path):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
+        index.mark_mirrored(
+            filename,
+            local_path=f"/srv/pmxt-relay/raw/{filename}",
+            etag=None,
+            content_length=512 * 1024,
+            last_modified=None,
+        )
+        index.update_row_count(filename, 100)
+
+        stats = index.stats(now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc))
+
+        assert index.count_empty_hours() == 1
+        assert stats["mirrored_hours"] == 0
+
+
 def test_update_row_count(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        index.upsert_discovered_hour(filename, f"https://r2.pmxt.dev/{filename}", 1)
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
 
         index.update_row_count(filename, 42)
 

--- a/tests/test_pmxt_relay_raw_mirror_verifier.py
+++ b/tests/test_pmxt_relay_raw_mirror_verifier.py
@@ -36,8 +36,8 @@ def test_verify_local_raw_mirror_reports_missing_and_corrupt_files(tmp_path: Pat
     summary = verifier.verify_local_raw_mirror(
         vendor="pmxt",
         raw_root=raw_root,
-        archive_listing_url="https://archive.pmxt.dev/Polymarket",
-        raw_base_url="https://r2.pmxt.dev",
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
         check_upstream=False,
         check_parquet=True,
     )
@@ -67,8 +67,8 @@ def test_verify_local_raw_mirror_separates_in_progress_downloads(tmp_path: Path,
     summary = verifier.verify_local_raw_mirror(
         vendor="pmxt",
         raw_root=raw_root,
-        archive_listing_url="https://archive.pmxt.dev/Polymarket",
-        raw_base_url="https://r2.pmxt.dev",
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
         check_upstream=False,
         check_parquet=True,
     )

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import Request
 
-from pmxt_relay.config import RelayConfig
+from pmxt_relay.config import ArchiveSource, RelayConfig
 from pmxt_relay.storage import raw_relative_path
 from pmxt_relay.worker import RelayWorker
 
@@ -15,8 +15,8 @@ def _make_config(tmp_path: Path) -> RelayConfig:
         data_dir=tmp_path,
         bind_host="127.0.0.1",
         bind_port=8080,
-        archive_listing_url="https://archive.pmxt.dev/Polymarket",
-        raw_base_url="https://r2.pmxt.dev",
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
         poll_interval_secs=900,
         http_timeout_secs=30,
         archive_stale_pages=3,
@@ -47,11 +47,69 @@ class _FakeResponse:
         return chunk
 
 
+def test_discover_archive_hours_uses_multiple_archive_sources(tmp_path: Path, monkeypatch) -> None:
+    config = RelayConfig(
+        data_dir=tmp_path,
+        bind_host="127.0.0.1",
+        bind_port=8080,
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
+        poll_interval_secs=900,
+        http_timeout_secs=30,
+        archive_stale_pages=1,
+        archive_max_pages=None,
+        event_retention=1000,
+        api_rate_limit_per_minute=2400,
+        verify_batch_size=50,
+        archive_sources=(
+            ArchiveSource(
+                listing_url="https://archive.pmxt.dev/Polymarket/v2",
+                raw_base_url="https://r2v2.pmxt.dev",
+            ),
+            ArchiveSource(
+                listing_url="https://archive.pmxt.dev/Polymarket/v1",
+                raw_base_url="https://r2.pmxt.dev",
+            ),
+        ),
+    )
+    pages = {
+        ("https://archive.pmxt.dev/Polymarket/v2", 1): (
+            '<a href="https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet">12</a>'
+        ),
+        ("https://archive.pmxt.dev/Polymarket/v2", 2): "",
+        ("https://archive.pmxt.dev/Polymarket/v1", 1): (
+            '<a href="https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet">11</a>'
+            '<a href="https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet">12</a>'
+        ),
+        ("https://archive.pmxt.dev/Polymarket/v1", 2): "",
+    }
+
+    monkeypatch.setattr(
+        "pmxt_relay.worker.fetch_archive_page",
+        lambda archive_listing_url, page, timeout_secs: pages[(archive_listing_url, page)],  # type: ignore[no-untyped-def]
+    )
+
+    with RelayWorker(config, reset_inflight=False) as worker:
+        discovered = worker._discover_archive_hours()
+        rows = {
+            row["filename"]: row
+            for row in worker._index._fetchall("SELECT * FROM archive_hours ORDER BY filename")
+        }
+
+    assert discovered == 3
+    assert rows["polymarket_orderbook_2026-03-21T11.parquet"]["source_url"] == (
+        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet"
+    )
+    assert rows["polymarket_orderbook_2026-03-21T12.parquet"]["source_url"] == (
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet"
+    )
+
+
 def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, monkeypatch) -> None:
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        source_url = f"https://r2.pmxt.dev/{filename}"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
         worker._index.upsert_discovered_hour(filename, source_url, 1)
         row = worker._index.list_hours_needing_mirror()[0]
         requested_methods: list[str] = []
@@ -97,7 +155,7 @@ def test_adopt_local_raw_marks_hours_as_mirrored(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
     raw_path = config.raw_root / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T12.parquet"
     raw_path.parent.mkdir(parents=True, exist_ok=True)
-    raw_path.write_bytes(b"raw-payload")
+    raw_path.write_bytes(b"x" * (2 * 1024 * 1024))
 
     with RelayWorker(config, reset_inflight=False) as worker:
         adopted = worker._adopt_local_raw_hours()
@@ -105,6 +163,29 @@ def test_adopt_local_raw_marks_hours_as_mirrored(tmp_path: Path) -> None:
         assert adopted == 1
         stats = worker._index.stats()
         assert stats["mirrored_hours"] == 1
+
+
+def test_adopt_local_raw_preserves_archive_source_url(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    filename = "polymarket_orderbook_2026-03-21T12.parquet"
+    raw_path = config.raw_root / "2026" / "03" / "21" / filename
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_path.write_bytes(b"x" * (2 * 1024 * 1024))
+
+    with RelayWorker(config, reset_inflight=False) as worker:
+        source_url = f"https://r2.pmxt.dev/{filename}"
+        worker._index.upsert_discovered_hour(filename, source_url, 1)
+
+        adopted = worker._adopt_local_raw_hours()
+
+        row = worker._index._conn.execute(
+            "SELECT source_url, mirror_status FROM archive_hours WHERE filename = ?",
+            (filename,),
+        ).fetchone()
+        assert adopted == 1
+        assert row is not None
+        assert row["source_url"] == source_url
+        assert row["mirror_status"] == "ready"
 
 
 def test_run_once_scans_full_local_tree_only_on_first_cycle(tmp_path: Path, monkeypatch) -> None:
@@ -136,7 +217,7 @@ def test_repeated_404s_are_quarantined(tmp_path: Path, monkeypatch) -> None:
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        source_url = f"https://r2.pmxt.dev/{filename}"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
         worker._index.upsert_discovered_hour(filename, source_url, 1)
         worker._index.mark_mirror_retry(
             filename, error="HTTP Error 404: Not Found", next_retry_at="1970-01-01T00:00:00+00:00"
@@ -170,7 +251,7 @@ def test_verify_ready_hours_requeues_changed_upstream(tmp_path: Path, monkeypatc
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        source_url = f"https://r2.pmxt.dev/{filename}"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
         worker._index.upsert_discovered_hour(filename, source_url, 1)
         worker._index.mark_mirrored(
             filename,
@@ -202,7 +283,7 @@ def test_verify_ready_hours_skips_unchanged(tmp_path: Path, monkeypatch) -> None
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        source_url = f"https://r2.pmxt.dev/{filename}"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
         worker._index.upsert_discovered_hour(filename, source_url, 1)
         worker._index.mark_mirrored(
             filename,
@@ -234,7 +315,7 @@ def test_verify_ready_hours_tolerates_head_failure(tmp_path: Path, monkeypatch) 
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
-        source_url = f"https://r2.pmxt.dev/{filename}"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
         worker._index.upsert_discovered_hour(filename, source_url, 1)
         worker._index.mark_mirrored(
             filename,

--- a/tests/test_polymarket_pmxt_backtests.py
+++ b/tests/test_polymarket_pmxt_backtests.py
@@ -17,7 +17,7 @@ from strategies import (
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
 EXPECTED_PMXT_SOURCES = (
     "local:/Volumes/LaCie/pmxt_raws",
-    "archive:r2.pmxt.dev",
+    "archive:r2v2.pmxt.dev",
     "relay:209-209-10-83.sslip.io",
 )
 EXPECTED_DETAIL_PLOT_PANELS = (

--- a/tests/test_public_runner_validation.py
+++ b/tests/test_public_runner_validation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests._public_runner_validation_cases import RESULT_MARKER
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_validation_case(case: str) -> dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, "-m", "tests._public_runner_validation_cases", case],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    for line in reversed(completed.stdout.splitlines()):
+        if line.startswith(RESULT_MARKER):
+            return json.loads(line.removeprefix(RESULT_MARKER))
+    raise AssertionError(
+        f"validation case {case!r} did not emit {RESULT_MARKER!r}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
+def _ledger_realized_pnl(fill_events: Sequence[dict[str, Any]]) -> float:
+    """Independent test oracle: do not call production PnL/report helpers here."""
+    cash = 0.0
+    commissions = 0.0
+    position = 0.0
+    for event in fill_events:
+        action = str(event["action"]).lower()
+        price = float(event["price"])
+        quantity = float(event["quantity"])
+        commission = float(event.get("commission", 0.0))
+        commissions += commission
+        if action == "buy":
+            cash -= price * quantity
+            position += quantity
+        elif action == "sell":
+            cash += price * quantity
+            position -= quantity
+        else:  # pragma: no cover - defensive guard for future fill schema drift.
+            raise AssertionError(f"unexpected fill action {action!r}")
+
+    assert abs(position) < 1e-9
+    return cash - commissions
+
+
+def test_public_kalshi_runner_reconciles_fills_fees_and_taker_slippage() -> None:
+    result = _run_validation_case("kalshi-baseline")
+
+    fill_events = result["fill_events"]
+    assert result["fills"] == len(fill_events) == 4
+    assert result["terminated_early"] is False
+    assert result["realized_outcome"] == 1.0
+    assert result["pnl"] == pytest.approx(_ledger_realized_pnl(fill_events))
+
+    # Kalshi trade ticks expose 4-decimal prices, but taker execution must be
+    # modeled with the real one-cent order tick.
+    assert [event["price"] for event in fill_events] == [0.51, 0.54, 0.60, 0.59]
+    assert [event["commission"] for event in fill_events] == [0.02, 0.02, 0.02, 0.02]
+
+
+def test_public_kalshi_runner_first_decision_is_invariant_to_future_ticks() -> None:
+    baseline = _run_validation_case("kalshi-prefix-normal")
+    stressed_future = _run_validation_case("kalshi-prefix-stressed")
+
+    assert baseline["fill_events"][0] == stressed_future["fill_events"][0]
+
+
+def test_public_polymarket_trade_runner_reconciles_size_clipping_and_slippage() -> None:
+    result = _run_validation_case("polymarket-trade")
+
+    fill_events = result["fill_events"]
+    assert result["fills"] == len(fill_events) == 4
+    assert result["terminated_early"] is False
+    assert result["pnl"] == pytest.approx(_ledger_realized_pnl(fill_events))
+    assert [event["price"] for event in fill_events] == [0.51, 0.49, 0.52, 0.49]
+    assert fill_events[0]["quantity"] == 97.0
+    assert fill_events[2]["quantity"] == pytest.approx(95.1182)

--- a/tests/test_quote_tick_runner_contract.py
+++ b/tests/test_quote_tick_runner_contract.py
@@ -8,7 +8,7 @@ from prediction_market_extensions.backtesting.optimizers import ParameterSearchW
 
 EXPECTED_PMXT_SOURCES = (
     "local:/Volumes/LaCie/pmxt_raws",
-    "archive:r2.pmxt.dev",
+    "archive:r2v2.pmxt.dev",
     "relay:209-209-10-83.sslip.io",
 )
 EXPECTED_PMXT_LATENCY = {

--- a/tests/test_timing_test.py
+++ b/tests/test_timing_test.py
@@ -49,7 +49,7 @@ def test_transfer_label_identifies_relay_raw_urls() -> None:
 
 
 def test_transfer_label_identifies_r2_raw_urls() -> None:
-    label = _transfer_label("https://r2.pmxt.dev/polymarket_orderbook_2026-02-22T11.parquet")
+    label = _transfer_label("https://r2v2.pmxt.dev/polymarket_orderbook_2026-02-22T11.parquet")
 
     assert label == "r2 raw 2026-02-22T11"
 
@@ -129,7 +129,7 @@ def test_active_transfer_progress_dedupes_by_hour() -> None:
     active_hours, active_progress = _active_transfer_progress(
         {
             "one": {
-                "url": "https://r2.pmxt.dev/polymarket_orderbook_2026-02-22T15.parquet",
+                "url": "https://r2v2.pmxt.dev/polymarket_orderbook_2026-02-22T15.parquet",
                 "hour_key": "2026-02-22T15:00:00+00:00",
                 "mode": "download",
                 "downloaded_bytes": 50,


### PR DESCRIPTION
## Summary

- Updates PMXT raw downloading to combine the v2 and v1 archive listings, build a continuous hourly range, and report upstream listing gaps.
- Refreshes existing local raws when they are zero-row, under 1 MiB, or when an upstream source advertises a larger object.
- Adds relay support for multiple archive source pairs via `PMXT_RELAY_ARCHIVE_SOURCES`, with v2 first and v1 second, and counts sub-1 MiB raws as empty.
- Updates PMXT runner archive defaults and docs from the old single `r2.pmxt.dev` archive source to the split v2/v1 behavior.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q`
- `uv run mkdocs build --strict`
- Smoke: `uv run python scripts/pmxt_download_raws.py --destination /tmp/pmxt-raw-smoke --source archive --start-time 2026-04-16T05 --end-time 2026-04-16T05 --timeout-secs 20` confirmed v2-to-v1 fallback and empty-file reporting; command exits nonzero because the fetched upstream file is empty/small by the new checks.

Unrelated dirty notebook changes in `backtests/generic_optimizer_research.ipynb` and `backtests/generic_tpe_research.ipynb` were left unstaged and are not part of this PR.
