### PR TITLE
[codex] fix relay remirror reuse loop

### DIFF
--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -60,15 +60,13 @@ are tracked to detect empty/broken files.
 
 ## Self-Healing Coverage
 
-The three stat buckets are disjoint and sum to wall-clock hours since the
-first recorded hour: `mirrored + empty + missing == archive_hours`. Each
-bucket auto-heals when upstream catches up:
+Coverage metrics separate upstream availability from local mirror state:
 
-- Hours upstream has not yet published (the wall-clock gap, counted as
-  missing): picked up by discovery on the next cycle when they appear on
-  page 1 of the archive listing.
-- Quarantined upstream 404s (counted as missing): retried hourly per
-  `_MIRROR_QUARANTINE_RETRY_SECS`; flip to ready when upstream serves 200.
+- Missing hours are wall-clock hours since the first recorded hour that do not
+  appear in upstream archive listings at all. They are picked up by discovery on
+  the next cycle after upstream publishes them.
+- Pending, active, error, and quarantined mirror rows are not counted as missing
+  upstream hours. They are local mirror backlog and are reported by `/v1/queue`.
 - Mirrored-but-empty parquets (`row_count == 0` or `Content-Length < 1 MiB`,
   counted as empty): caught by the HEAD re-verifier when upstream replaces the
   bytes (different ETag or Content-Length), then re-mirrored and `row_count`
@@ -166,13 +164,9 @@ The public badges separate relay health from `r2v2.pmxt.dev` availability:
   has active API/worker services.
 - `/v1/badge/upstream(.svg)` reports whether recent `r2v2.pmxt.dev` polling is
   online or offline.
-- `/v1/badge/missing-hours.svg` shows hours not currently represented on disk
-  by a non-empty mirror — includes quarantined upstream 404s, pending downloads,
-  in-flight mirrors, AND hours upstream has not yet published. Disjoint from
-  empty hours; together with mirrored + empty, sums to the wall-clock hours
-  since the first recorded hour.
+- `/v1/badge/missing-hours.svg` shows wall-clock hours since the first recorded
+  hour that do not appear in upstream archive listings.
 - `/v1/badge/empty-hours.svg` shows how many mirrored parquet files have zero
   rows or less than 1 MiB of data (broken/empty uploads). Empty hours are
   excluded from the "mirrored" count surfaced by `/v1/stats` and
-  `/v1/badge/mirrored.svg`, but they are still counted as `ready` and therefore
-  are NOT counted as missing.
+  `/v1/badge/mirrored.svg`, but they are still counted as `ready`.

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -20,6 +20,7 @@ _LOCKED_ERROR_SNIPPETS = (
 _DUPLICATE_COLUMN_ERROR_SNIPPET = "duplicate column name"
 _LEGACY_ACTIVE_STATUS = "processing"
 _MIN_NONEMPTY_RAW_BYTES = 1024 * 1024
+REMIRROR_CONTENT_CHANGED_REASON = "upstream content changed"
 
 
 def _utc_now_datetime() -> datetime:
@@ -515,6 +516,11 @@ class RelayIndex:
                         OR mirror_status != 'ready'
                         OR (content_length IS NULL AND ? IS NOT NULL)
                       )
+                      AND (
+                        mirror_status != 'pending'
+                        OR last_error IS NULL
+                        OR last_error != ?
+                      )
                     """,
                     (
                         local_path,
@@ -523,6 +529,7 @@ class RelayIndex:
                         filename,
                         local_path,
                         content_length,
+                        REMIRROR_CONTENT_CHANGED_REASON,
                     ),
                 )
             return (insert_cursor.rowcount + update_cursor.rowcount) > 0
@@ -561,13 +568,13 @@ class RelayIndex:
                 SET mirror_status = 'pending',
                     last_verified_at = NULL,
                     error_count = 0,
-                    last_error = 'upstream content changed',
+                    last_error = ?,
                     last_error_at = ?,
                     next_retry_at = NULL,
                     row_count = NULL
                 WHERE filename = ?
                 """,
-                (_utc_now(), filename),
+                (REMIRROR_CONTENT_CHANGED_REASON, _utc_now(), filename),
             )
         )
 
@@ -585,21 +592,22 @@ class RelayIndex:
 
     def count_missing_hours(self, *, now: datetime | None = None) -> int:
         archive_hours = self._compute_elapsed_archive_hours(now=now)
-        mirrored_hours = int(
+        if archive_hours == 0:
+            return 0
+        now_reference = _utc_now_datetime() if now is None else now.astimezone(UTC)
+        now_floor = now_reference.replace(minute=0, second=0, microsecond=0)
+        discovered_hours = int(
             self._fetchscalar(
                 """
-                SELECT COUNT(*)
+                SELECT COUNT(DISTINCT hour)
                 FROM archive_hours
-                WHERE mirror_status = 'ready'
-                  AND (row_count IS NULL OR row_count > 0)
-                  AND (content_length IS NULL OR content_length >= ?)
+                WHERE hour <= ?
                 """,
-                (_MIN_NONEMPTY_RAW_BYTES,),
+                (now_floor.isoformat(),),
                 default=0,
             )
         )
-        empty_hours = self.count_empty_hours()
-        return max(0, archive_hours - mirrored_hours - empty_hours)
+        return max(0, archive_hours - discovered_hours)
 
     def count_empty_hours(self) -> int:
         return int(

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -12,7 +12,7 @@ from urllib.request import Request, urlopen
 
 from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
 from pmxt_relay.config import RelayConfig
-from pmxt_relay.index_db import RelayIndex
+from pmxt_relay.index_db import REMIRROR_CONTENT_CHANGED_REASON, RelayIndex
 from pmxt_relay.storage import raw_relative_path
 
 LOG = logging.getLogger(__name__)
@@ -370,7 +370,8 @@ class RelayWorker:
         raw_path = self._config.raw_root / raw_relative_path(filename)
         raw_path.parent.mkdir(parents=True, exist_ok=True)
         self._index.mark_mirroring(filename)
-        if raw_path.exists() and raw_path.stat().st_size > 0:
+        should_reuse_existing = row["last_error"] != REMIRROR_CONTENT_CHANGED_REASON
+        if should_reuse_existing and raw_path.exists() and raw_path.stat().st_size > 0:
             self._index.mark_mirrored(
                 filename,
                 local_path=str(raw_path),

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -509,10 +509,10 @@ def test_missing_hours_badge_shows_count(tmp_path: Path):
         app = create_app(config)
         index = app[INDEX_APP_KEY]
         current_hour = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
-        previous_hour = current_hour - timedelta(hours=1)
-        pending = f"polymarket_orderbook_{previous_hour:%Y-%m-%dT%H}.parquet"
+        two_hours_ago = current_hour - timedelta(hours=2)
+        earlier = f"polymarket_orderbook_{two_hours_ago:%Y-%m-%dT%H}.parquet"
         ready = f"polymarket_orderbook_{current_hour:%Y-%m-%dT%H}.parquet"
-        index.upsert_discovered_hour(pending, f"https://raw.example.com/{pending}", 1)
+        index.upsert_discovered_hour(earlier, f"https://raw.example.com/{earlier}", 1)
         index.upsert_discovered_hour(ready, f"https://raw.example.com/{ready}", 1)
         index.mark_mirrored(
             ready,
@@ -533,7 +533,7 @@ def test_missing_hours_badge_shows_count(tmp_path: Path):
 
         assert response.status == 200
         assert "Missing hours" in payload
-        assert "1/2" in payload
+        assert "1/3" in payload
 
     asyncio.run(scenario())
 

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -442,14 +442,49 @@ def test_mark_needs_remirror_resets_to_pending(tmp_path: Path):
         assert row["last_error"] == "upstream content changed"
 
 
-def test_count_missing_hours_includes_unpublished_gap(tmp_path: Path):
+def test_register_local_raw_does_not_adopt_content_changed_remirror(tmp_path: Path):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        local_path = f"/srv/pmxt-relay/raw/{filename}"
+        index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
+        index.mark_mirrored(
+            filename,
+            local_path=local_path,
+            etag="abc",
+            content_length=1,
+            last_modified=None,
+        )
+        index.mark_needs_remirror(filename)
+
+        changed = index.register_local_raw(
+            filename,
+            local_path=local_path,
+            content_length=1,
+            source_url=f"https://r2v2.pmxt.dev/{filename}",
+        )
+
+        row = index._conn.execute(
+            """
+            SELECT mirror_status, last_error
+            FROM archive_hours
+            WHERE filename = ?
+            """,
+            (filename,),
+        ).fetchone()
+        assert changed is False
+        assert row is not None
+        assert row["mirror_status"] == "pending"
+        assert row["last_error"] == "upstream content changed"
+
+
+def test_count_missing_hours_counts_unlisted_upstream_gaps(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         ready = "polymarket_orderbook_2026-03-21T12.parquet"
         empty = "polymarket_orderbook_2026-03-21T13.parquet"
-        quarantined = "polymarket_orderbook_2026-03-21T14.parquet"
-        pending = "polymarket_orderbook_2026-03-21T15.parquet"
-        for filename in [ready, empty, quarantined, pending]:
+        quarantined = "polymarket_orderbook_2026-03-21T15.parquet"
+        for filename in [ready, empty, quarantined]:
             index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
         for filename in [ready, empty]:
             index.mark_mirrored(
@@ -466,7 +501,7 @@ def test_count_missing_hours_includes_unpublished_gap(tmp_path: Path):
 
         now = datetime(2026, 3, 21, 15, 10, tzinfo=timezone.utc)
 
-        assert index.count_missing_hours(now=now) == 2
+        assert index.count_missing_hours(now=now) == 1
 
 
 def test_count_missing_hours_wall_clock_gap_dominant(tmp_path: Path):

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -141,6 +141,60 @@ def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, mon
         assert stats["mirrored_hours"] == 1
 
 
+def test_content_changed_remirror_replaces_existing_raw(tmp_path: Path, monkeypatch) -> None:
+    config = _make_config(tmp_path)
+    with RelayWorker(config, reset_inflight=False) as worker:
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
+        raw_path = config.raw_root / raw_relative_path(filename)
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_path.write_bytes(b"old-raw-payload")
+        worker._index.upsert_discovered_hour(filename, source_url, 1)
+        worker._index.mark_mirrored(
+            filename,
+            local_path=str(raw_path),
+            etag='"old"',
+            content_length=len(b"old-raw-payload"),
+            last_modified=None,
+        )
+        worker._index.mark_needs_remirror(filename)
+        row = worker._index.list_hours_needing_mirror()[0]
+        requested_methods: list[str] = []
+
+        def fake_urlopen(request: Request, timeout):  # type: ignore[no-untyped-def]
+            requested_methods.append(request.get_method())
+            if request.get_method() == "HEAD":
+                return _FakeResponse(
+                    b"",
+                    headers={
+                        "ETag": '"new"',
+                        "Last-Modified": "Sun, 21 Mar 2026 13:59:59 GMT",
+                        "Content-Length": str(len(b"new-raw-payload")),
+                    },
+                )
+            return _FakeResponse(b"new-raw-payload")
+
+        monkeypatch.setattr("pmxt_relay.worker.urlopen", fake_urlopen)
+
+        worker._mirror_hour(row)
+
+        assert raw_path.read_bytes() == b"new-raw-payload"
+        assert requested_methods == ["HEAD", "GET"]
+        updated = worker._index._conn.execute(
+            """
+            SELECT mirror_status, etag, content_length, last_error
+            FROM archive_hours
+            WHERE filename = ?
+            """,
+            (filename,),
+        ).fetchone()
+        assert updated is not None
+        assert updated["mirror_status"] == "ready"
+        assert updated["etag"] == '"new"'
+        assert updated["content_length"] == len(b"new-raw-payload")
+        assert updated["last_error"] is None
+
+
 def test_run_once_only_discovers_adopts_and_mirrors(tmp_path: Path, monkeypatch) -> None:
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:


### PR DESCRIPTION
## Summary

- Force content-change remirror rows to download fresh upstream bytes instead of reusing the stale local raw file.
- Prevent local raw adoption from flipping explicit content-change remirror rows back to ready before the download path runs.
- Make the missing-hours badge count only hours absent from upstream archive listings, while empty-hours continues to count ready zero-row/tiny parquet files.
- Document the missing/empty/backlog metric split in the relay README.

## Root Cause

The relay re-validator correctly detected v1/v2 upstream metadata changes and marked affected hours pending, but the next worker cycle adopted or reused the existing local file before it could download the preferred upstream object. That created a requeue/reuse loop and made mirrored-hour counts sink or oscillate.

The missing-hours badge also mixed true upstream listing gaps with local mirror backlog, which made it look like upstream was missing far more hours than it actually was during remirror work.

## Validation

- Deployed to the VPS and restarted `pmxt-relay-api.service` / `pmxt-relay-worker.service`.
- Verified live health and stats on `127.0.0.1:8080`.
- Confirmed live missing-hours reports true upstream gaps (`3/1334`) and empty-hours reports ready zero-row/tiny files (`7/...`).
- Observed the live remirror queue draining with services active.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` (`364 passed, 1 skipped`).
