### PR TITLE
[codex] fix relay error hours badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 [![Hours Mirrored](https://209-209-10-83.sslip.io/v1/badge/mirrored.svg)](https://209-209-10-83.sslip.io/v1/stats)
 [![Missing Hours](https://209-209-10-83.sslip.io/v1/badge/missing-hours.svg)](https://209-209-10-83.sslip.io/v1/stats)
 [![Empty Hours](https://209-209-10-83.sslip.io/v1/badge/empty-hours.svg)](https://209-209-10-83.sslip.io/v1/stats)
+[![Error Hours](https://209-209-10-83.sslip.io/v1/badge/error-hours.svg)](https://209-209-10-83.sslip.io/v1/queue)
 [![Latest File](https://209-209-10-83.sslip.io/v1/badge/latest-file.svg)](https://209-209-10-83.sslip.io/v1/stats)
 
 **Thanks to [PMXT](https://github.com/pmxt-dev/pmxt) for providing this data for free!**

--- a/docs/pmxt-relay.md
+++ b/docs/pmxt-relay.md
@@ -39,7 +39,8 @@ Operational note:
 
 - the public relay status badge reports relay health only
 - the public PMXT upstream badge reports source polling as online or offline;
-  missing archive hours and zero-row mirrored files have separate badges
+  missing archive hours, zero-row mirrored files, and listed-but-uncovered
+  mirror rows have separate badges
 
 Deployment facts for the active box:
 

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -65,12 +65,16 @@ Coverage metrics separate upstream availability from local mirror state:
 - Missing hours are wall-clock hours since the first recorded hour that do not
   appear in upstream archive listings at all. They are picked up by discovery on
   the next cycle after upstream publishes them.
-- Pending, active, error, and quarantined mirror rows are not counted as missing
-  upstream hours. They are local mirror backlog and are reported by `/v1/queue`.
 - Mirrored-but-empty parquets (`row_count == 0` or `Content-Length < 1 MiB`,
   counted as empty): caught by the HEAD re-verifier when upstream replaces the
   bytes (different ETag or Content-Length), then re-mirrored and `row_count`
-  recomputed.
+  recomputed. If upstream later returns 404 for a known-empty file, the verifier
+  moves it to the error bucket instead.
+- Error hours are listed archive rows that are not currently represented by a
+  non-empty mirror or known-empty file. This includes pending, active, error, and
+  quarantined mirror rows; detailed states are reported by `/v1/queue`.
+- The coverage gap is expected to reconcile as:
+  `archive_hours - mirrored_hours == missing + empty + error`.
 - Updated bytes for filenames already on disk: same HEAD re-verifier path;
   filename does not need to change.
 
@@ -170,3 +174,5 @@ The public badges separate relay health from `r2v2.pmxt.dev` availability:
   rows or less than 1 MiB of data (broken/empty uploads). Empty hours are
   excluded from the "mirrored" count surfaced by `/v1/stats` and
   `/v1/badge/mirrored.svg`, but they are still counted as `ready`.
+- `/v1/badge/error-hours.svg` shows listed archive rows that are not currently
+  represented by a non-empty mirror or known-empty file.

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -556,6 +556,24 @@ def _empty_hours_badge_payload(*, index: RelayIndex) -> dict[str, object]:
     )
 
 
+def _error_hours_badge_payload(*, index: RelayIndex) -> dict[str, object]:
+    errors = index.count_error_hours()
+    total = int(index.stats().get("archive_hours") or 0)
+    if total == 0:
+        color = "lightgrey"
+    elif errors == 0:
+        color = "brightgreen"
+    elif errors <= 5:
+        color = "yellow"
+    else:
+        color = "red"
+    return _badge_payload(
+        label="Error hours",
+        message=f"{errors}/{total}",
+        color=color,
+    )
+
+
 class RequestRateLimiter:
     def __init__(self, requests_per_minute: int) -> None:
         self._requests_per_minute = requests_per_minute
@@ -934,6 +952,12 @@ async def badge_empty_hours_svg(request: web.Request) -> web.Response:
     return _badge_svg_response(payload)
 
 
+async def badge_error_hours_svg(request: web.Request) -> web.Response:
+    index = request.app[INDEX_APP_KEY]
+    payload = await asyncio.to_thread(_error_hours_badge_payload, index=index)
+    return _badge_svg_response(payload)
+
+
 async def serve_raw(request: web.Request) -> web.StreamResponse:
     config = request.app[CONFIG_APP_KEY]
     filename = request.match_info["filename"]
@@ -980,5 +1004,6 @@ def create_app(config: RelayConfig) -> web.Application:
     app.router.add_get("/v1/badge/mirroring.svg", badge_mirroring_svg)
     app.router.add_get("/v1/badge/missing-hours.svg", badge_missing_hours_svg)
     app.router.add_get("/v1/badge/empty-hours.svg", badge_empty_hours_svg)
+    app.router.add_get("/v1/badge/error-hours.svg", badge_error_hours_svg)
     app.router.add_get("/v1/raw/{filename:.*}", serve_raw)
     return app

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -626,6 +626,44 @@ class RelayIndex:
             )
         )
 
+    def count_error_hours(self, *, now: datetime | None = None) -> int:
+        now_reference = _utc_now_datetime() if now is None else now.astimezone(UTC)
+        now_floor = now_reference.replace(minute=0, second=0, microsecond=0)
+        row = self._fetchone(
+            """
+            SELECT
+                COUNT(DISTINCT hour) AS discovered_hours,
+                SUM(
+                    CASE
+                        WHEN mirror_status = 'ready' AND (row_count IS NULL OR row_count > 0)
+                          AND (content_length IS NULL OR content_length >= ?)
+                        THEN 1
+                        ELSE 0
+                    END
+                ) AS mirrored_hours,
+                SUM(
+                    CASE
+                        WHEN mirror_status = 'ready'
+                          AND (
+                            (row_count IS NOT NULL AND row_count = 0)
+                            OR (content_length IS NOT NULL AND content_length < ?)
+                          )
+                        THEN 1
+                        ELSE 0
+                    END
+                ) AS empty_hours
+            FROM archive_hours
+            WHERE hour <= ?
+            """,
+            (_MIN_NONEMPTY_RAW_BYTES, _MIN_NONEMPTY_RAW_BYTES, now_floor.isoformat()),
+        )
+        if row is None:
+            return 0
+        discovered_hours = int(row["discovered_hours"] or 0)
+        mirrored_hours = int(row["mirrored_hours"] or 0)
+        empty_hours = int(row["empty_hours"] or 0)
+        return max(0, discovered_hours - mirrored_hours - empty_hours)
+
     def _compute_elapsed_archive_hours(self, *, now: datetime | None = None) -> int:
         min_hour_value = self._fetchscalar("SELECT MIN(hour) FROM archive_hours", default=None)
         min_hour = _parse_db_timestamp(min_hour_value if isinstance(min_hour_value, str) else None)

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -20,6 +20,7 @@ _MIRROR_404_QUARANTINE_AFTER = 3
 _MIRROR_RETRY_BACKOFF_CAP_SECS = 6 * 3600
 _MIRROR_QUARANTINE_RETRY_SECS = 3600
 _VERIFY_HTTP_TIMEOUT_CAP_SECS = 2
+_MIN_NONEMPTY_RAW_BYTES = 1024 * 1024
 
 
 class RelayWorker:
@@ -191,6 +192,8 @@ class RelayWorker:
             byte_size = raw_path.stat().st_size
         except FileNotFoundError:
             return 0
+        if byte_size < _MIN_NONEMPTY_RAW_BYTES:
+            return 0
         changed = self._index.register_local_raw(
             filename,
             local_path=str(raw_path),
@@ -275,6 +278,33 @@ class RelayWorker:
             try:
                 changed = self._check_upstream_changed(row)
             except Exception as exc:
+                if self._should_reclassify_ready_empty_as_error(row, exc):
+                    next_error_count = int(row["error_count"] or 0) + 1
+                    next_retry_at = self._next_retry_at(error_count=next_error_count)
+                    self._index.mark_mirror_retry(
+                        row["filename"], error=str(exc), next_retry_at=next_retry_at.isoformat()
+                    )
+                    self._record_event(
+                        level="WARNING",
+                        event_type="verify_empty_unavailable",
+                        filename=row["filename"],
+                        message=(
+                            f"Upstream empty raw hour unavailable for {row['filename']}; "
+                            "moving to error"
+                        ),
+                        payload={
+                            "error": str(exc),
+                            "error_count": next_error_count,
+                            "next_retry_at": next_retry_at.isoformat(),
+                        },
+                    )
+                    LOG.warning(
+                        "Moving empty raw hour %s to error after verification failure: %s",
+                        row["filename"],
+                        exc,
+                    )
+                    requeued += 1
+                    continue
                 LOG.warning("Verification HEAD failed for %s: %s", row["filename"], exc)
                 self._index.mark_verified(row["filename"])
                 continue
@@ -303,6 +333,16 @@ class RelayWorker:
                 payload={"batch_size": len(batch), "requeued": requeued},
             )
         return requeued
+
+    @staticmethod
+    def _should_reclassify_ready_empty_as_error(row, exc: Exception) -> bool:  # type: ignore[no-untyped-def]
+        if not isinstance(exc, HTTPError) or exc.code != 404:
+            return False
+        row_count = row["row_count"]
+        content_length = row["content_length"]
+        return (row_count is not None and row_count == 0) or (
+            content_length is not None and content_length < _MIN_NONEMPTY_RAW_BYTES
+        )
 
     def _check_upstream_changed(self, row) -> bool:  # type: ignore[no-untyped-def]
         source_url = row["source_url"]

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -574,6 +574,40 @@ def test_empty_hours_badge_shows_count(tmp_path: Path):
     asyncio.run(scenario())
 
 
+def test_error_hours_badge_shows_listed_uncovered_count(tmp_path: Path):
+    async def scenario() -> None:
+        config = _make_config(tmp_path)
+        config.ensure_directories()
+        app = create_app(config)
+        index = app[INDEX_APP_KEY]
+        current_hour = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+        previous_hour = current_hour - timedelta(hours=1)
+        pending = f"polymarket_orderbook_{previous_hour:%Y-%m-%dT%H}.parquet"
+        errored = f"polymarket_orderbook_{current_hour:%Y-%m-%dT%H}.parquet"
+        index.upsert_discovered_hour(pending, f"https://raw.example.com/{pending}", 1)
+        index.upsert_discovered_hour(errored, f"https://raw.example.com/{errored}", 1)
+        index.mark_mirror_retry(
+            errored,
+            error="HTTP 500",
+            next_retry_at=(current_hour + timedelta(hours=1)).isoformat(),
+        )
+
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            response = await client.get("/v1/badge/error-hours.svg")
+            payload = await response.text()
+        finally:
+            await client.close()
+
+        assert response.status == 200
+        assert "Error hours" in payload
+        assert "2/2" in payload
+
+    asyncio.run(scenario())
+
+
 def test_upstream_badge_old_mirror_errors_still_report_online(tmp_path: Path):
     config = _make_config(tmp_path)
     now = datetime(2026, 4, 3, 20, 0, tzinfo=timezone.utc)

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -522,6 +522,44 @@ def test_count_missing_hours_wall_clock_gap_dominant(tmp_path: Path):
         assert index.count_missing_hours(now=now) == 5
 
 
+def test_coverage_gap_buckets_reconcile(tmp_path: Path):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        ready = "polymarket_orderbook_2026-03-21T12.parquet"
+        empty = "polymarket_orderbook_2026-03-21T13.parquet"
+        pending = "polymarket_orderbook_2026-03-21T14.parquet"
+        active = "polymarket_orderbook_2026-03-21T15.parquet"
+        errored = "polymarket_orderbook_2026-03-21T16.parquet"
+        for filename in [ready, empty, pending, active, errored]:
+            index.upsert_discovered_hour(filename, f"https://r2v2.pmxt.dev/{filename}", 1)
+        for filename in [ready, empty]:
+            index.mark_mirrored(
+                filename,
+                local_path=f"/srv/pmxt-relay/raw/{filename}",
+                etag=None,
+                content_length=2 * 1024 * 1024,
+                last_modified=None,
+            )
+        index.update_row_count(empty, 0)
+        index.mark_mirroring(active)
+        index.mark_mirror_retry(
+            errored, error="HTTP 500", next_retry_at="2026-03-21T17:00:00+00:00"
+        )
+
+        now = datetime(2026, 3, 21, 17, 10, tzinfo=timezone.utc)
+        stats = index.stats(now=now)
+        mirrored = int(stats["mirrored_hours"])
+        archive_hours = int(stats["archive_hours"])
+        missing = index.count_missing_hours(now=now)
+        empty_hours = index.count_empty_hours()
+        error_hours = index.count_error_hours(now=now)
+
+        assert archive_hours - mirrored == missing + empty_hours + error_hours
+        assert missing == 1
+        assert empty_hours == 1
+        assert error_hours == 3
+
+
 def test_stats_archive_hours_are_elapsed_wall_clock_hours(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -219,6 +219,19 @@ def test_adopt_local_raw_marks_hours_as_mirrored(tmp_path: Path) -> None:
         assert stats["mirrored_hours"] == 1
 
 
+def test_adopt_local_raw_skips_tiny_raw_files(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    raw_path = config.raw_root / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T12.parquet"
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_path.write_bytes(b"x" * 214)
+
+    with RelayWorker(config, reset_inflight=False) as worker:
+        adopted = worker._adopt_local_raw_hours()
+
+        assert adopted == 0
+        assert worker._index.stats()["mirrored_hours"] == 0
+
+
 def test_adopt_local_raw_preserves_archive_source_url(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
     filename = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -394,6 +407,41 @@ def test_verify_ready_hours_tolerates_head_failure(tmp_path: Path, monkeypatch) 
         ).fetchone()
         assert row is not None
         assert row["mirror_status"] == "ready"
+
+
+def test_verify_ready_empty_hour_404_moves_to_error(tmp_path: Path, monkeypatch) -> None:
+    config = _make_config(tmp_path)
+    with RelayWorker(config, reset_inflight=False) as worker:
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        source_url = f"https://r2v2.pmxt.dev/{filename}"
+        worker._index.upsert_discovered_hour(filename, source_url, 1)
+        worker._index.mark_mirrored(
+            filename,
+            local_path=str(tmp_path / filename),
+            etag="abc",
+            content_length=214,
+            last_modified=None,
+        )
+        worker._index.update_row_count(filename, 0)
+
+        def fake_urlopen(request: Request, timeout):  # type: ignore[no-untyped-def]
+            assert timeout == 2
+            assert request.get_method() == "HEAD"
+            raise HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)
+
+        monkeypatch.setattr("pmxt_relay.worker.urlopen", fake_urlopen)
+
+        assert worker._verify_ready_hours() == 1
+
+        row = worker._index._conn.execute(
+            "SELECT mirror_status, last_error FROM archive_hours WHERE filename = ?",
+            (filename,),
+        ).fetchone()
+        assert row is not None
+        assert row["mirror_status"] == "error"
+        assert row["last_error"] == "HTTP Error 404: Not Found"
+        assert worker._index.count_empty_hours() == 0
+        assert worker._index.count_error_hours() == 1
 
 
 def test_run_once_includes_verification_step(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Add a public error-hours badge for listed archive hours that are not covered by non-empty mirrored data or known-empty files.
- Make coverage accounting reconcile as `archive_hours - mirrored_hours == missing + empty + error`.
- Move known-empty mirrored rows to the error bucket when upstream later returns 404, and avoid re-adopting tiny local raw files as mirrored after restart.
- Update relay docs and focused tests for badge behavior, accounting, and worker verification.

## Root Cause

The relay had separate missing and empty badges, but listed archive rows that were pending, errored, active, or quarantined were only visible through `/v1/queue`. That made the badge math look like mirrored hours had disappeared. A second issue let tiny local raw files be adopted as ready again on worker startup, which could keep hours in the empty bucket even after upstream stopped serving them.

## Validation

- `uv run pytest tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py tests/test_pmxt_relay_index_db.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q`
- Deployed to the live relay and observed stable API/worker services.
- Checked live badge/accounting values: `1334 - 1283 = 3 + 2 + 46`.
- Spot-checked `r2.pmxt.dev` and `r2v2.pmxt.dev`: the three missing hours were absent from both listings, the two retained empty hours were downloadable 214-byte files, and sampled error hours returned 404 upstream.
