### PR TITLE
[codex] Fix PMXT relay source priority metrics

### DIFF
--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -62,16 +62,13 @@ are tracked to detect empty/broken files.
 
 Coverage metrics separate upstream availability from local mirror state:
 
-- Missing hours are wall-clock hours since the first recorded hour that do not
-  appear in upstream archive listings at all. They are picked up by discovery on
-  the next cycle after upstream publishes them.
-- Mirrored-but-empty parquets (`row_count == 0` or `Content-Length < 1 MiB`,
-  counted as empty): caught by the HEAD re-verifier when upstream replaces the
-  bytes (different ETag or Content-Length), then re-mirrored and `row_count`
-  recomputed. If upstream later returns 404 for a known-empty file, the verifier
-  moves it to the error bucket instead.
+- Missing hours are listed raw objects whose upstream URL currently returns
+  404. Gaps in archive listings are not counted as relay failures.
+- Zero-row or tiny parquets are treated as mirrored hours because they can be
+  valid no-trade periods. If upstream later returns 404 for a mirrored file, the
+  verifier moves it to the missing bucket.
 - Error hours are listed archive rows that are not currently represented by a
-  non-empty mirror or known-empty file. This includes pending, active, error, and
+  mirror or known-missing 404. This includes pending, active, error, and
   quarantined mirror rows; detailed states are reported by `/v1/queue`.
 - The coverage gap is expected to reconcile as:
   `archive_hours - mirrored_hours == missing + empty + error`.
@@ -168,11 +165,10 @@ The public badges separate relay health from `r2v2.pmxt.dev` availability:
   has active API/worker services.
 - `/v1/badge/upstream(.svg)` reports whether recent `r2v2.pmxt.dev` polling is
   online or offline.
-- `/v1/badge/missing-hours.svg` shows wall-clock hours since the first recorded
-  hour that do not appear in upstream archive listings.
-- `/v1/badge/empty-hours.svg` shows how many mirrored parquet files have zero
-  rows or less than 1 MiB of data (broken/empty uploads). Empty hours are
-  excluded from the "mirrored" count surfaced by `/v1/stats` and
-  `/v1/badge/mirrored.svg`, but they are still counted as `ready`.
+- `/v1/badge/missing-hours.svg` shows listed raw objects whose upstream URL
+  currently returns 404.
+- `/v1/badge/empty-hours.svg` is retained for compatibility, but zero-row or
+  tiny parquets are treated as mirrored hours because they can be valid no-trade
+  periods.
 - `/v1/badge/error-hours.svg` shows listed archive rows that are not currently
-  represented by a non-empty mirror or known-empty file.
+  represented by a mirror or known-missing 404.

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -60,6 +60,7 @@ class RelayIndex:
             "filename",
             "hour",
             "source_url",
+            "source_priority",
             "archive_page",
             "discovered_at",
             "local_path",
@@ -137,6 +138,7 @@ class RelayIndex:
                 filename TEXT PRIMARY KEY,
                 hour TEXT NOT NULL,
                 source_url TEXT NOT NULL,
+                source_priority INTEGER NOT NULL DEFAULT 1000000,
                 archive_page INTEGER NOT NULL,
                 discovered_at TEXT NOT NULL,
                 local_path TEXT,
@@ -182,6 +184,11 @@ class RelayIndex:
             )
         if "row_count" not in archive_columns:
             self._ensure_archive_column("ALTER TABLE archive_hours ADD COLUMN row_count INTEGER")
+        if "source_priority" not in archive_columns:
+            self._ensure_archive_column(
+                "ALTER TABLE archive_hours "
+                "ADD COLUMN source_priority INTEGER NOT NULL DEFAULT 1000000"
+            )
         self._conn.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_archive_hours_retry_status_hour
@@ -312,8 +319,11 @@ class RelayIndex:
 
         return self._run_with_lock_retry(operation)
 
-    def upsert_discovered_hour(self, filename: str, source_url: str, archive_page: int) -> bool:
+    def upsert_discovered_hour(
+        self, filename: str, source_url: str, archive_page: int, *, source_priority: int = 0
+    ) -> bool:
         hour = parse_archive_hour(filename).isoformat()
+        normalized_source_priority = max(0, source_priority)
 
         def operation() -> bool:
             with self._conn:
@@ -323,23 +333,97 @@ class RelayIndex:
                         filename,
                         hour,
                         source_url,
+                        source_priority,
                         archive_page,
                         discovered_at
-                    ) VALUES (?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?)
                     """,
-                    (filename, hour, source_url, archive_page, _utc_now()),
+                    (
+                        filename,
+                        hour,
+                        source_url,
+                        normalized_source_priority,
+                        archive_page,
+                        _utc_now(),
+                    ),
                 )
                 update_cursor = self._conn.execute(
                     """
                     UPDATE archive_hours
-                    SET archive_page = ?, source_url = ?
+                    SET archive_page = ?,
+                        source_url = ?,
+                        source_priority = ?,
+                        mirror_status = CASE
+                            WHEN source_url != ?
+                              AND mirror_status IN ('ready', 'error', 'quarantined')
+                            THEN 'pending'
+                            ELSE mirror_status
+                        END,
+                        last_error = CASE
+                            WHEN source_url != ?
+                              AND mirror_status IN ('ready', 'error', 'quarantined')
+                            THEN ?
+                            ELSE last_error
+                        END,
+                        last_error_at = CASE
+                            WHEN source_url != ?
+                              AND mirror_status IN ('ready', 'error', 'quarantined')
+                            THEN ?
+                            ELSE last_error_at
+                        END,
+                        next_retry_at = CASE
+                            WHEN source_url != ?
+                              AND mirror_status IN ('ready', 'error', 'quarantined')
+                            THEN NULL
+                            ELSE next_retry_at
+                        END,
+                        error_count = CASE
+                            WHEN source_url != ?
+                              AND mirror_status IN ('ready', 'error', 'quarantined')
+                            THEN 0
+                            ELSE error_count
+                        END,
+                        last_verified_at = CASE
+                            WHEN source_url != ? THEN NULL
+                            ELSE last_verified_at
+                        END,
+                        row_count = CASE
+                            WHEN source_url != ?
+                              AND mirror_status = 'ready'
+                            THEN NULL
+                            ELSE row_count
+                        END
                     WHERE filename = ?
                       AND (
-                        archive_page != ?
-                        OR source_url != ?
+                        source_priority > ?
+                        OR (
+                            source_priority = ?
+                            AND (
+                                archive_page != ?
+                                OR source_url != ?
+                            )
+                        )
                       )
                     """,
-                    (archive_page, source_url, filename, archive_page, source_url),
+                    (
+                        archive_page,
+                        source_url,
+                        normalized_source_priority,
+                        source_url,
+                        source_url,
+                        REMIRROR_CONTENT_CHANGED_REASON,
+                        source_url,
+                        _utc_now(),
+                        source_url,
+                        source_url,
+                        source_url,
+                        source_url,
+                        filename,
+                        normalized_source_priority,
+                        normalized_source_priority,
+                        archive_page,
+                        source_url,
+                    ),
                 )
             return (cursor.rowcount + update_cursor.rowcount) > 0
 
@@ -353,7 +437,7 @@ class RelayIndex:
             FROM archive_hours
             WHERE mirror_status = 'pending'
                OR (
-                    mirror_status IN ('error', 'quarantined')
+                    mirror_status IN ('error', 'quarantined', 'missing')
                     AND (next_retry_at IS NULL OR next_retry_at <= ?)
                )
             ORDER BY
@@ -364,6 +448,48 @@ class RelayIndex:
             """,
             (retry_cutoff,),
         )
+
+    def remove_source_rows_absent_from_listing(
+        self,
+        *,
+        raw_base_url: str,
+        filenames: list[str],
+    ) -> int:
+        if not filenames:
+            return 0
+        hours = [parse_archive_hour(filename) for filename in filenames]
+        min_hour = min(hours).isoformat()
+        max_hour = max(hours).isoformat()
+        source_prefix = f"{raw_base_url.rstrip('/')}/%"
+
+        def operation() -> int:
+            with self._conn:
+                self._conn.execute(
+                    "CREATE TEMP TABLE IF NOT EXISTS current_archive_listing "
+                    "(filename TEXT PRIMARY KEY)"
+                )
+                self._conn.execute("DELETE FROM current_archive_listing")
+                self._conn.executemany(
+                    "INSERT OR IGNORE INTO current_archive_listing (filename) VALUES (?)",
+                    ((filename,) for filename in filenames),
+                )
+                cursor = self._conn.execute(
+                    """
+                    DELETE FROM archive_hours
+                    WHERE source_url LIKE ?
+                      AND hour BETWEEN ? AND ?
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM current_archive_listing current
+                        WHERE current.filename = archive_hours.filename
+                      )
+                    """,
+                    (source_prefix, min_hour, max_hour),
+                )
+                self._conn.execute("DELETE FROM current_archive_listing")
+            return cursor.rowcount
+
+        return self._run_with_lock_retry(operation)
 
     def mark_mirroring(self, filename: str) -> None:
         self._run_with_lock_retry(
@@ -427,6 +553,22 @@ class RelayIndex:
             )
         )
 
+    def mark_mirror_missing(self, filename: str, *, error: str, next_retry_at: str) -> None:
+        self._run_with_lock_retry(
+            lambda: self._write_single_update(
+                """
+                UPDATE archive_hours
+                SET mirror_status = 'missing',
+                    last_error = ?,
+                    last_error_at = ?,
+                    next_retry_at = ?,
+                    error_count = error_count + 1
+                WHERE filename = ?
+                """,
+                (error, _utc_now(), next_retry_at, filename),
+            )
+        )
+
     def mark_mirrored(
         self,
         filename: str,
@@ -477,6 +619,7 @@ class RelayIndex:
                         filename,
                         hour,
                         source_url,
+                        source_priority,
                         archive_page,
                         discovered_at,
                         local_path,
@@ -484,7 +627,7 @@ class RelayIndex:
                         mirror_status,
                         mirrored_at,
                         error_count
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'ready', ?, 0)
+                    ) VALUES (?, ?, ?, 1000000, ?, ?, ?, ?, 'ready', ?, 0)
                     """,
                     (
                         filename,
@@ -591,40 +734,23 @@ class RelayIndex:
         )
 
     def count_missing_hours(self, *, now: datetime | None = None) -> int:
-        archive_hours = self._compute_elapsed_archive_hours(now=now)
-        if archive_hours == 0:
-            return 0
         now_reference = _utc_now_datetime() if now is None else now.astimezone(UTC)
         now_floor = now_reference.replace(minute=0, second=0, microsecond=0)
-        discovered_hours = int(
-            self._fetchscalar(
-                """
-                SELECT COUNT(DISTINCT hour)
-                FROM archive_hours
-                WHERE hour <= ?
-                """,
-                (now_floor.isoformat(),),
-                default=0,
-            )
-        )
-        return max(0, archive_hours - discovered_hours)
-
-    def count_empty_hours(self) -> int:
         return int(
             self._fetchscalar(
                 """
                 SELECT COUNT(*)
                 FROM archive_hours
-                WHERE mirror_status = 'ready'
-                  AND (
-                    (row_count IS NOT NULL AND row_count = 0)
-                    OR (content_length IS NOT NULL AND content_length < ?)
-                  )
+                WHERE mirror_status = 'missing'
+                  AND hour <= ?
                 """,
-                (_MIN_NONEMPTY_RAW_BYTES,),
+                (now_floor.isoformat(),),
                 default=0,
             )
         )
+
+    def count_empty_hours(self) -> int:
+        return 0
 
     def count_error_hours(self, *, now: datetime | None = None) -> int:
         now_reference = _utc_now_datetime() if now is None else now.astimezone(UTC)
@@ -635,44 +761,45 @@ class RelayIndex:
                 COUNT(DISTINCT hour) AS discovered_hours,
                 SUM(
                     CASE
-                        WHEN mirror_status = 'ready' AND (row_count IS NULL OR row_count > 0)
-                          AND (content_length IS NULL OR content_length >= ?)
-                        THEN 1
+                        WHEN mirror_status = 'ready' THEN 1
                         ELSE 0
                     END
                 ) AS mirrored_hours,
-                SUM(
-                    CASE
-                        WHEN mirror_status = 'ready'
-                          AND (
-                            (row_count IS NOT NULL AND row_count = 0)
-                            OR (content_length IS NOT NULL AND content_length < ?)
-                          )
-                        THEN 1
-                        ELSE 0
-                    END
-                ) AS empty_hours
+                0 AS empty_hours,
+                SUM(CASE WHEN mirror_status = 'missing' THEN 1 ELSE 0 END) AS missing_hours
             FROM archive_hours
             WHERE hour <= ?
             """,
-            (_MIN_NONEMPTY_RAW_BYTES, _MIN_NONEMPTY_RAW_BYTES, now_floor.isoformat()),
+            (now_floor.isoformat(),),
         )
         if row is None:
             return 0
         discovered_hours = int(row["discovered_hours"] or 0)
         mirrored_hours = int(row["mirrored_hours"] or 0)
         empty_hours = int(row["empty_hours"] or 0)
-        return max(0, discovered_hours - mirrored_hours - empty_hours)
+        missing_hours = int(row["missing_hours"] or 0)
+        return max(0, discovered_hours - mirrored_hours - empty_hours - missing_hours)
 
     def _compute_elapsed_archive_hours(self, *, now: datetime | None = None) -> int:
-        min_hour_value = self._fetchscalar("SELECT MIN(hour) FROM archive_hours", default=None)
-        min_hour = _parse_db_timestamp(min_hour_value if isinstance(min_hour_value, str) else None)
-        if min_hour is None:
-            return 0
-        min_floor = min_hour.replace(minute=0, second=0, microsecond=0)
         now_reference = _utc_now_datetime() if now is None else now.astimezone(UTC)
         now_floor = now_reference.replace(minute=0, second=0, microsecond=0)
-        delta_hours = int((now_floor - min_floor).total_seconds() // 3600) + 1
+        row = self._fetchone(
+            """
+            SELECT MIN(hour) AS min_hour, MAX(hour) AS max_hour
+            FROM archive_hours
+            WHERE hour <= ?
+            """,
+            (now_floor.isoformat(),),
+        )
+        if row is None:
+            return 0
+        min_hour = _parse_db_timestamp(row["min_hour"])
+        max_hour = _parse_db_timestamp(row["max_hour"])
+        if min_hour is None or max_hour is None:
+            return 0
+        min_floor = min_hour.replace(minute=0, second=0, microsecond=0)
+        max_floor = max_hour.replace(minute=0, second=0, microsecond=0)
+        delta_hours = int((max_floor - min_floor).total_seconds() // 3600) + 1
         return max(0, delta_hours)
 
     def stats(self, *, now: datetime | None = None) -> dict[str, int | str | None]:
@@ -681,17 +808,15 @@ class RelayIndex:
             SELECT
                 SUM(
                     CASE
-                        WHEN mirror_status = 'ready' AND (row_count IS NULL OR row_count > 0)
-                          AND (content_length IS NULL OR content_length >= ?)
-                        THEN 1
+                        WHEN mirror_status = 'ready' THEN 1
                         ELSE 0
                     END
                 ) AS mirrored_hours,
                 SUM(CASE WHEN mirror_status IN ('error', 'quarantined') THEN 1 ELSE 0 END) AS mirror_errors,
-                SUM(CASE WHEN mirror_status = 'quarantined' THEN 1 ELSE 0 END) AS mirror_quarantined
+                SUM(CASE WHEN mirror_status = 'quarantined' THEN 1 ELSE 0 END) AS mirror_quarantined,
+                SUM(CASE WHEN mirror_status = 'missing' THEN 1 ELSE 0 END) AS mirror_missing
             FROM archive_hours
             """,
-            (_MIN_NONEMPTY_RAW_BYTES,),
         )
         stats_row = dict(row) if row is not None else {}
         archive_hours = self._compute_elapsed_archive_hours(now=now)
@@ -704,6 +829,7 @@ class RelayIndex:
             "mirrored_hours": int(stats_row.get("mirrored_hours") or 0),
             "mirror_errors": int(stats_row.get("mirror_errors") or 0),
             "mirror_quarantined": int(stats_row.get("mirror_quarantined") or 0),
+            "mirror_missing": int(stats_row.get("mirror_missing") or 0),
             "last_event_at": last_event_at,
             "last_error_at": last_error_at,
         }
@@ -716,10 +842,11 @@ class RelayIndex:
                 SUM(CASE WHEN mirror_status = 'pending' THEN 1 ELSE 0 END) AS mirror_pending,
                 SUM(CASE WHEN mirror_status IN ('active', ?) THEN 1 ELSE 0 END) AS mirror_active,
                 SUM(CASE WHEN mirror_status IN ('error', 'quarantined') THEN 1 ELSE 0 END) AS mirror_error,
-                SUM(CASE WHEN mirror_status IN ('error', 'quarantined') AND (next_retry_at IS NULL OR next_retry_at <= ?) THEN 1 ELSE 0 END) AS mirror_retry_due,
-                SUM(CASE WHEN mirror_status IN ('error', 'quarantined') AND next_retry_at > ? THEN 1 ELSE 0 END) AS mirror_retry_waiting,
+                SUM(CASE WHEN mirror_status = 'missing' THEN 1 ELSE 0 END) AS mirror_missing,
+                SUM(CASE WHEN mirror_status IN ('error', 'quarantined', 'missing') AND (next_retry_at IS NULL OR next_retry_at <= ?) THEN 1 ELSE 0 END) AS mirror_retry_due,
+                SUM(CASE WHEN mirror_status IN ('error', 'quarantined', 'missing') AND next_retry_at > ? THEN 1 ELSE 0 END) AS mirror_retry_waiting,
                 SUM(CASE WHEN mirror_status = 'quarantined' THEN 1 ELSE 0 END) AS mirror_quarantined,
-                MIN(CASE WHEN mirror_status IN ('error', 'quarantined') THEN next_retry_at END) AS next_retry_at,
+                MIN(CASE WHEN mirror_status IN ('error', 'quarantined', 'missing') THEN next_retry_at END) AS next_retry_at,
                 MAX(CASE WHEN mirror_status = 'ready' THEN hour END) AS latest_mirrored_hour,
                 (
                     SELECT filename
@@ -737,6 +864,7 @@ class RelayIndex:
             "mirror_pending": int(queue_row.get("mirror_pending") or 0),
             "mirror_active": int(queue_row.get("mirror_active") or 0),
             "mirror_error": int(queue_row.get("mirror_error") or 0),
+            "mirror_missing": int(queue_row.get("mirror_missing") or 0),
             "mirror_retry_due": int(queue_row.get("mirror_retry_due") or 0),
             "mirror_retry_waiting": int(queue_row.get("mirror_retry_waiting") or 0),
             "mirror_quarantined": int(queue_row.get("mirror_quarantined") or 0),

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -112,17 +112,20 @@ class RelayWorker:
 
     def _discover_archive_hours(self) -> int:
         discovered = 0
-        # Process lower-priority sources first so higher-priority sources later
-        # refresh source_url for filenames exposed by multiple archive versions.
-        for archive_source in reversed(self._config.resolved_archive_sources):
+        for source_priority, archive_source in enumerate(self._config.resolved_archive_sources):
             discovered += self._discover_archive_source(
                 archive_listing_url=archive_source.listing_url,
                 raw_base_url=archive_source.raw_base_url,
+                source_priority=source_priority,
             )
         return discovered
 
-    def _discover_archive_source(self, *, archive_listing_url: str, raw_base_url: str) -> int:
+    def _discover_archive_source(
+        self, *, archive_listing_url: str, raw_base_url: str, source_priority: int
+    ) -> int:
         discovered = 0
+        source_seen: list[str] = []
+        source_seen_set: set[str] = set()
         page = 1
         stale_pages = 0
         while True:
@@ -135,8 +138,13 @@ class RelayWorker:
 
             page_new = 0
             for filename in filenames:
+                if filename not in source_seen_set:
+                    source_seen.append(filename)
+                    source_seen_set.add(filename)
                 source_url = f"{raw_base_url}/{filename}"
-                if self._index.upsert_discovered_hour(filename, source_url, page):
+                if self._index.upsert_discovered_hour(
+                    filename, source_url, page, source_priority=source_priority
+                ):
                     page_new += 1
 
             discovered += page_new
@@ -160,6 +168,26 @@ class RelayWorker:
                 stale_pages = 0
             page += 1
 
+        removed = self._index.remove_source_rows_absent_from_listing(
+            raw_base_url=raw_base_url,
+            filenames=source_seen,
+        )
+        if removed > 0:
+            self._record_event(
+                level="WARNING",
+                event_type="archive_unlisted",
+                message=f"Removed {removed} stale PMXT archive rows absent from current listing",
+                payload={
+                    "listing_url": archive_listing_url,
+                    "raw_base_url": raw_base_url,
+                    "removed_hours": removed,
+                },
+            )
+            LOG.warning(
+                "Removed %s stale PMXT archive rows absent from current %s listing",
+                removed,
+                raw_base_url,
+            )
         return discovered
 
     def _adopt_local_raw_hours(self) -> int:
@@ -224,6 +252,29 @@ class RelayWorker:
                 self._mirror_hour(row)
             except Exception as exc:
                 next_error_count = int(row["error_count"] or 0) + 1
+                if self._is_missing_raw(exc):
+                    next_retry_at = self._missing_retry_at()
+                    self._index.mark_mirror_missing(
+                        row["filename"], error=str(exc), next_retry_at=next_retry_at.isoformat()
+                    )
+                    self._record_event(
+                        level="WARNING",
+                        event_type="mirror_missing",
+                        filename=row["filename"],
+                        message=f"Raw archive object missing for {row['filename']}",
+                        payload={
+                            "error": str(exc),
+                            "error_count": next_error_count,
+                            "next_retry_at": next_retry_at.isoformat(),
+                        },
+                    )
+                    LOG.warning(
+                        "Raw archive object missing for %s until %s: %s",
+                        row["filename"],
+                        next_retry_at.isoformat(),
+                        exc,
+                    )
+                    continue
                 if self._should_quarantine_error(exc, error_count=next_error_count):
                     next_retry_at = self._quarantine_retry_at()
                     self._index.mark_mirror_quarantined(
@@ -278,19 +329,19 @@ class RelayWorker:
             try:
                 changed = self._check_upstream_changed(row)
             except Exception as exc:
-                if self._should_reclassify_ready_empty_as_error(row, exc):
+                if self._should_reclassify_ready_empty_as_missing(row, exc):
                     next_error_count = int(row["error_count"] or 0) + 1
-                    next_retry_at = self._next_retry_at(error_count=next_error_count)
-                    self._index.mark_mirror_retry(
+                    next_retry_at = self._missing_retry_at()
+                    self._index.mark_mirror_missing(
                         row["filename"], error=str(exc), next_retry_at=next_retry_at.isoformat()
                     )
                     self._record_event(
                         level="WARNING",
-                        event_type="verify_empty_unavailable",
+                        event_type="verify_empty_missing",
                         filename=row["filename"],
                         message=(
                             f"Upstream empty raw hour unavailable for {row['filename']}; "
-                            "moving to error"
+                            "moving to missing"
                         ),
                         payload={
                             "error": str(exc),
@@ -299,7 +350,7 @@ class RelayWorker:
                         },
                     )
                     LOG.warning(
-                        "Moving empty raw hour %s to error after verification failure: %s",
+                        "Moving empty raw hour %s to missing after verification failure: %s",
                         row["filename"],
                         exc,
                     )
@@ -335,7 +386,7 @@ class RelayWorker:
         return requeued
 
     @staticmethod
-    def _should_reclassify_ready_empty_as_error(row, exc: Exception) -> bool:  # type: ignore[no-untyped-def]
+    def _should_reclassify_ready_empty_as_missing(row, exc: Exception) -> bool:  # type: ignore[no-untyped-def]
         if not isinstance(exc, HTTPError) or exc.code != 404:
             return False
         row_count = row["row_count"]
@@ -396,6 +447,13 @@ class RelayWorker:
 
     def _quarantine_retry_at(self) -> datetime:
         return datetime.now(UTC) + timedelta(seconds=_MIRROR_QUARANTINE_RETRY_SECS)
+
+    def _missing_retry_at(self) -> datetime:
+        return datetime.now(UTC) + timedelta(seconds=_MIRROR_QUARANTINE_RETRY_SECS)
+
+    @staticmethod
+    def _is_missing_raw(exc: Exception) -> bool:
+        return isinstance(exc, HTTPError) and exc.code == 404
 
     def _should_quarantine_error(self, exc: Exception, *, error_count: int) -> bool:
         return (

--- a/scripts/_pmxt_raw_download.py
+++ b/scripts/_pmxt_raw_download.py
@@ -329,12 +329,10 @@ def _read_parquet_row_count(path: Path) -> int | None:
 
 def _local_raw_is_empty(path: Path) -> bool:
     try:
-        file_size = path.stat().st_size
+        path.stat()
     except OSError:
         return True
-    if file_size < _MIN_NONEMPTY_RAW_BYTES:
-        return True
-    return _read_parquet_row_count(path) == 0
+    return False
 
 
 def _existing_refresh_reason(
@@ -362,27 +360,12 @@ def _validate_local_raw_hours(
     *, destination: Path, filenames: list[str]
 ) -> tuple[list[str], list[str], list[str], list[str]]:
     missing: list[str] = []
-    empty: list[str] = []
-    zero_row: list[str] = []
-    small: list[str] = []
     for filename in filenames:
         hour_label = parse_archive_hour(filename).isoformat()
         destination_path = destination / raw_relative_path(filename)
         if not destination_path.exists():
             missing.append(hour_label)
-            continue
-        try:
-            file_size = destination_path.stat().st_size
-        except OSError:
-            file_size = 0
-        row_count = _read_parquet_row_count(destination_path)
-        if row_count == 0:
-            zero_row.append(hour_label)
-        if file_size < _MIN_NONEMPTY_RAW_BYTES:
-            small.append(hour_label)
-        if row_count == 0 or file_size < _MIN_NONEMPTY_RAW_BYTES:
-            empty.append(hour_label)
-    return missing, empty, zero_row, small
+    return missing, [], [], []
 
 
 def _pid_is_active(pid: int) -> bool:
@@ -586,7 +569,7 @@ def download_raw_hours(
     else:
         discovered_filenames: list[str] = []
         discovered_seen: set[str] = set()
-        for archive_source in reversed(resolved_archive_sources):
+        for archive_source in resolved_archive_sources:
             source_filenames = discover_archive_filenames(
                 archive_listing_url=archive_source.listing_url,
                 timeout_secs=timeout_secs,
@@ -594,9 +577,9 @@ def download_raw_hours(
                 max_pages=discovery_max_pages,
             )
             for filename in source_filenames:
-                discovered_archive_base_urls[filename] = archive_source.base_url
                 if filename in discovered_seen:
                     continue
+                discovered_archive_base_urls[filename] = archive_source.base_url
                 discovered_filenames.append(filename)
                 discovered_seen.add(filename)
         discovered_filenames = _sort_filenames_newest_first(discovered_filenames)
@@ -605,21 +588,15 @@ def download_raw_hours(
         )
         archive_listed_hours = len(discovered_filenames)
         if discovered_filenames:
-            discovered_hours = [parse_archive_hour(filename) for filename in discovered_filenames]
-            expected_start_hour = start_hour if start_hour is not None else min(discovered_hours)
-            expected_end_hour = end_hour if end_hour is not None else max(discovered_hours)
-            filenames = _hour_range_filenames(
-                start_hour=expected_start_hour, end_hour=expected_end_hour
-            )
-            discovered_set = set(discovered_filenames)
-            archive_missing_hours = [
-                parse_archive_hour(filename).isoformat()
-                for filename in _sort_filenames_newest_first(filenames)
-                if filename not in discovered_set
-            ]
+            filenames = list(discovered_filenames)
+            download_filenames = list(discovered_filenames)
         else:
             filenames = []
+            download_filenames = []
+    if start_hour is not None and end_hour is not None:
+        download_filenames = list(filenames)
     filenames = _sort_filenames_newest_first(filenames)
+    download_filenames = _sort_filenames_newest_first(download_filenames)
     if not filenames:
         if start_hour is not None and end_hour is not None and start_hour > end_hour:
             raise ValueError(
@@ -653,9 +630,9 @@ def download_raw_hours(
 
     progress_bar = (
         tqdm(
-            total=len(filenames),
+            total=len(download_filenames),
             desc=_progress_bar_description(
-                total_hours=len(filenames), completed_hours=0, active_hours=0
+                total_hours=len(download_filenames), completed_hours=0, active_hours=0
             ),
             unit="hr",
             leave=False,
@@ -666,13 +643,14 @@ def download_raw_hours(
     )
     source_hits: Counter[str] = Counter()
     failed_hours: list[str] = []
+    archive_object_missing_hours: list[str] = []
     downloaded_hours = 0
     skipped_existing_hours = 0
     refreshed_existing_hours = 0
     completed_hours = 0
 
     try:
-        for filename in filenames:
+        for filename in download_filenames:
             destination_path = normalized_destination / raw_relative_path(filename)
             _cleanup_stale_tmp_downloads(destination_path)
             hour_label = _hour_label_for_filename(filename)
@@ -709,7 +687,7 @@ def download_raw_hours(
                     completed_hours += 1
                     _set_status(
                         progress_bar,
-                        total_hours=len(filenames),
+                        total_hours=len(download_filenames),
                         completed_hours=completed_hours,
                         active_hours=0,
                         status="",
@@ -746,7 +724,7 @@ def download_raw_hours(
                             destination=destination_path,
                             timeout_secs=timeout_secs,
                             progress_bar=progress_bar,
-                            total_hours=len(filenames),
+                            total_hours=len(download_filenames),
                             completed_hours=completed_hours,
                             source=source,
                             hour_label=hour_label,
@@ -768,13 +746,20 @@ def download_raw_hours(
 
             elapsed_secs = time.perf_counter() - hour_started_at
             if last_error is not None:
-                failed_hours.append(parse_archive_hour(filename).isoformat())
+                hour_iso = parse_archive_hour(filename).isoformat()
+                missing_object = isinstance(last_error, HTTPError) and last_error.code == 404
+                if missing_object:
+                    archive_object_missing_hours.append(hour_iso)
+                    detail = "missing"
+                else:
+                    failed_hours.append(hour_iso)
+                    detail = "failed"
                 _write_progress_line(
                     progress_bar,
                     _hour_result_text(
                         hour_label=hour_label,
                         elapsed_secs=elapsed_secs,
-                        detail="failed",
+                        detail=detail,
                         source=(
                             f"{' -> '.join(source_sequence)}; "
                             f"last_error={_format_download_error(last_error)}"
@@ -796,7 +781,7 @@ def download_raw_hours(
             completed_hours += 1
             _set_status(
                 progress_bar,
-                total_hours=len(filenames),
+                total_hours=len(download_filenames),
                 completed_hours=completed_hours,
                 active_hours=0,
                 status="",
@@ -806,12 +791,20 @@ def download_raw_hours(
         if progress_bar is not None:
             progress_bar.close()
 
+    archive_object_missing_set = set(archive_object_missing_hours)
+    validation_filenames = [
+        filename
+        for filename in download_filenames
+        if parse_archive_hour(filename).isoformat() not in archive_object_missing_set
+    ]
     (
         missing_local_hours,
         empty_local_hours,
         zero_row_local_hours,
         small_local_hours,
-    ) = _validate_local_raw_hours(destination=normalized_destination, filenames=filenames)
+    ) = _validate_local_raw_hours(
+        destination=normalized_destination, filenames=validation_filenames
+    )
 
     return RawDownloadSummary(
         destination=str(normalized_destination),
@@ -820,7 +813,7 @@ def download_raw_hours(
         downloaded_hours=downloaded_hours,
         skipped_existing_hours=skipped_existing_hours,
         refreshed_existing_hours=refreshed_existing_hours,
-        archive_missing_hours=archive_missing_hours,
+        archive_missing_hours=archive_missing_hours + archive_object_missing_hours,
         failed_hours=failed_hours,
         missing_local_hours=missing_local_hours,
         empty_local_hours=empty_local_hours,

--- a/scripts/pmxt_download_raws.py
+++ b/scripts/pmxt_download_raws.py
@@ -96,12 +96,7 @@ def main() -> int:
         discovery_max_pages=args.discovery_max_pages,
     )
     print(json.dumps(summary.as_dict(), indent=2, sort_keys=True))
-    incomplete = (
-        summary.archive_missing_hours
-        or summary.failed_hours
-        or summary.missing_local_hours
-        or summary.empty_local_hours
-    )
+    incomplete = summary.failed_hours or summary.missing_local_hours
     return 1 if incomplete else 0
 
 

--- a/tests/test_pmxt_raw_download.py
+++ b/tests/test_pmxt_raw_download.py
@@ -303,7 +303,7 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
     assert bar.desc == "Downloading raw hours (2/2 done)"
 
 
-def test_download_raw_hours_reports_missing_and_empty_local_hours(
+def test_download_raw_hours_reports_404_as_archive_missing_and_accepts_empty_parquet(
     monkeypatch, tmp_path: Path
 ) -> None:
     empty_payload = _empty_parquet_payload()
@@ -329,9 +329,12 @@ def test_download_raw_hours_reports_missing_and_empty_local_hours(
         destination=tmp_path / "raws", source_order=["archive"], show_progress=False
     )
 
-    assert summary.failed_hours == ["2026-03-21T09:00:00+00:00"]
-    assert summary.missing_local_hours == ["2026-03-21T09:00:00+00:00"]
-    assert summary.empty_local_hours == ["2026-03-21T10:00:00+00:00"]
+    assert summary.archive_missing_hours == ["2026-03-21T09:00:00+00:00"]
+    assert summary.failed_hours == []
+    assert summary.missing_local_hours == []
+    assert summary.empty_local_hours == []
+    assert summary.zero_row_local_hours == []
+    assert summary.small_local_hours == []
 
 
 def test_download_raw_hours_progress_output_includes_failure_error(
@@ -365,9 +368,7 @@ def test_download_raw_hours_progress_output_includes_failure_error(
     assert any("failed" in line and "last_error=HTTP 503" in line for line in bars[0].writes)
 
 
-def test_download_raw_hours_requests_full_hour_range_and_reports_archive_gaps(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_download_raw_hours_ignores_unlisted_archive_gaps(monkeypatch, tmp_path: Path) -> None:
     payload = _raw_parquet_payload()
     requested_urls: list[str] = []
 
@@ -391,12 +392,14 @@ def test_download_raw_hours_requests_full_hour_range_and_reports_archive_gaps(
         destination=tmp_path / "raws", source_order=["archive"], show_progress=False
     )
 
-    assert summary.requested_hours == 3
+    assert summary.requested_hours == 2
     assert summary.archive_listed_hours == 2
-    assert summary.archive_missing_hours == ["2026-03-21T10:00:00+00:00"]
+    assert summary.downloaded_hours == 2
+    assert summary.failed_hours == []
+    assert summary.missing_local_hours == []
+    assert summary.archive_missing_hours == []
     assert requested_urls == [
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet",
-        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
     ]
 
@@ -409,6 +412,7 @@ def test_download_raw_hours_combines_v1_and_v2_archive_sources(monkeypatch, tmp_
             "polymarket_orderbook_2026-03-21T10.parquet",
         ],
         "https://archive.pmxt.dev/Polymarket/v1": [
+            "polymarket_orderbook_2026-03-21T10.parquet",
             "polymarket_orderbook_2026-03-21T09.parquet",
         ],
     }

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -483,6 +483,7 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
             "last_error_at",
             "last_event_at",
             "mirror_errors",
+            "mirror_missing",
             "mirror_quarantined",
             "mirrored_hours",
         ]
@@ -491,6 +492,7 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
             "latest_mirrored_hour",
             "mirror_active",
             "mirror_error",
+            "mirror_missing",
             "mirror_pending",
             "mirror_quarantined",
             "mirror_retry_due",
@@ -533,7 +535,7 @@ def test_missing_hours_badge_shows_count(tmp_path: Path):
 
         assert response.status == 200
         assert "Missing hours" in payload
-        assert "1/3" in payload
+        assert "0/3" in payload
 
     asyncio.run(scenario())
 
@@ -569,7 +571,7 @@ def test_empty_hours_badge_shows_count(tmp_path: Path):
 
         assert response.status == 200
         assert "Empty hours" in payload
-        assert "1/1" in payload
+        assert "0/2" in payload
 
     asyncio.run(scenario())
 

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -37,6 +37,7 @@ def test_relay_index_events_and_queue_summary_are_mirror_only(tmp_path: Path):
             "latest_mirrored_hour",
             "mirror_active",
             "mirror_error",
+            "mirror_missing",
             "mirror_pending",
             "mirror_quarantined",
             "mirror_retry_due",
@@ -78,6 +79,7 @@ def test_relay_index_events_and_queue_summary_are_mirror_only(tmp_path: Path):
             "last_error_at",
             "last_event_at",
             "mirror_errors",
+            "mirror_missing",
             "mirror_quarantined",
             "mirrored_hours",
         ]
@@ -117,6 +119,98 @@ def test_upsert_discovered_hour_refreshes_source_url_once(tmp_path: Path):
         assert row["source_url"] == (
             "https://mirror.example.com/polymarket_orderbook_2026-03-21T12.parquet"
         )
+
+
+def test_upsert_discovered_hour_preserves_higher_priority_source(tmp_path: Path):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        v2_url = f"https://r2v2.pmxt.dev/{filename}"
+        v1_url = f"https://r2.pmxt.dev/{filename}"
+
+        first_insert = index.upsert_discovered_hour(filename, v2_url, 1, source_priority=0)
+        downgraded = index.upsert_discovered_hour(filename, v1_url, 1, source_priority=1)
+
+        row = index._conn.execute(
+            """
+            SELECT source_url, source_priority
+            FROM archive_hours
+            WHERE filename = ?
+            """,
+            (filename,),
+        ).fetchone()
+
+        assert first_insert is True
+        assert downgraded is False
+        assert row is not None
+        assert row["source_url"] == v2_url
+        assert row["source_priority"] == 0
+
+
+def test_upsert_discovered_hour_requeues_ready_when_priority_source_changes(tmp_path: Path):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        filename = "polymarket_orderbook_2026-03-21T12.parquet"
+        v1_url = f"https://r2.pmxt.dev/{filename}"
+        v2_url = f"https://r2v2.pmxt.dev/{filename}"
+        index.upsert_discovered_hour(filename, v1_url, 1, source_priority=1)
+        index.mark_mirrored(
+            filename,
+            local_path=f"/srv/pmxt-relay/raw/{filename}",
+            etag="abc",
+            content_length=2 * 1024 * 1024,
+            last_modified=None,
+        )
+        index.update_row_count(filename, 10)
+
+        changed = index.upsert_discovered_hour(filename, v2_url, 1, source_priority=0)
+
+        row = index._conn.execute(
+            """
+            SELECT source_url, source_priority, mirror_status, last_error, row_count
+            FROM archive_hours
+            WHERE filename = ?
+            """,
+            (filename,),
+        ).fetchone()
+        assert changed is True
+        assert row is not None
+        assert row["source_url"] == v2_url
+        assert row["source_priority"] == 0
+        assert row["mirror_status"] == "pending"
+        assert row["last_error"] == "upstream content changed"
+        assert row["row_count"] is None
+
+
+def test_remove_source_rows_absent_from_listing_prunes_only_scanned_source_window(
+    tmp_path: Path,
+):
+    with RelayIndex(tmp_path / "relay.sqlite3") as index:
+        index.initialize()
+        keep = "polymarket_orderbook_2026-03-21T12.parquet"
+        stale = "polymarket_orderbook_2026-03-21T13.parquet"
+        outside_window = "polymarket_orderbook_2026-03-21T14.parquet"
+        lower_priority = "polymarket_orderbook_2026-03-21T13.parquet"
+        index.upsert_discovered_hour(keep, f"https://r2v2.pmxt.dev/{keep}", 1)
+        index.upsert_discovered_hour(stale, f"https://r2v2.pmxt.dev/{stale}", 1)
+        index.upsert_discovered_hour(outside_window, f"https://r2v2.pmxt.dev/{outside_window}", 1)
+        index.upsert_discovered_hour(
+            lower_priority, f"https://r2.pmxt.dev/{lower_priority}", 1, source_priority=1
+        )
+
+        removed = index.remove_source_rows_absent_from_listing(
+            raw_base_url="https://r2v2.pmxt.dev",
+            filenames=[keep, outside_window],
+        )
+
+        rows = {
+            row["filename"]: row["source_url"]
+            for row in index._conn.execute("SELECT filename, source_url FROM archive_hours")
+        }
+        assert removed == 1
+        assert keep in rows
+        assert outside_window in rows
+        assert stale not in rows
 
 
 def test_initialize_resets_stale_mirror_rows(tmp_path: Path):
@@ -478,7 +572,7 @@ def test_register_local_raw_does_not_adopt_content_changed_remirror(tmp_path: Pa
         assert row["last_error"] == "upstream content changed"
 
 
-def test_count_missing_hours_counts_unlisted_upstream_gaps(tmp_path: Path):
+def test_count_missing_hours_ignores_unlisted_upstream_gaps(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         ready = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -501,10 +595,10 @@ def test_count_missing_hours_counts_unlisted_upstream_gaps(tmp_path: Path):
 
         now = datetime(2026, 3, 21, 15, 10, tzinfo=timezone.utc)
 
-        assert index.count_missing_hours(now=now) == 1
+        assert index.count_missing_hours(now=now) == 0
 
 
-def test_count_missing_hours_wall_clock_gap_dominant(tmp_path: Path):
+def test_count_missing_hours_ignores_hours_after_latest_listing(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         ready = "polymarket_orderbook_2026-03-21T00.parquet"
@@ -519,7 +613,7 @@ def test_count_missing_hours_wall_clock_gap_dominant(tmp_path: Path):
 
         now = datetime(2026, 3, 21, 5, 0, tzinfo=timezone.utc)
 
-        assert index.count_missing_hours(now=now) == 5
+        assert index.count_missing_hours(now=now) == 0
 
 
 def test_coverage_gap_buckets_reconcile(tmp_path: Path):
@@ -555,12 +649,12 @@ def test_coverage_gap_buckets_reconcile(tmp_path: Path):
         error_hours = index.count_error_hours(now=now)
 
         assert archive_hours - mirrored == missing + empty_hours + error_hours
-        assert missing == 1
-        assert empty_hours == 1
+        assert missing == 0
+        assert empty_hours == 0
         assert error_hours == 3
 
 
-def test_stats_archive_hours_are_elapsed_wall_clock_hours(tmp_path: Path):
+def test_stats_archive_hours_are_discovered_coverage_hours(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         earliest = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -575,10 +669,10 @@ def test_stats_archive_hours_are_elapsed_wall_clock_hours(tmp_path: Path):
 
         stats = index.stats(now=datetime(2026, 3, 21, 15, 30, tzinfo=timezone.utc))
 
-        assert stats["archive_hours"] == 4
+        assert stats["archive_hours"] == 2
 
 
-def test_stats_mirrored_hours_exclude_known_empty_rows(tmp_path: Path):
+def test_stats_mirrored_hours_include_zero_row_files(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         empty = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -598,10 +692,10 @@ def test_stats_mirrored_hours_exclude_known_empty_rows(tmp_path: Path):
 
         stats = index.stats(now=datetime(2026, 3, 21, 14, 30, tzinfo=timezone.utc))
 
-        assert stats["mirrored_hours"] == 2
+        assert stats["mirrored_hours"] == 3
 
 
-def test_count_empty_hours(tmp_path: Path):
+def test_count_empty_hours_treats_zero_row_files_as_valid(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filenames = [
@@ -621,10 +715,10 @@ def test_count_empty_hours(tmp_path: Path):
         index.update_row_count(filenames[0], 0)
         index.update_row_count(filenames[1], 100)
 
-        assert index.count_empty_hours() == 1
+        assert index.count_empty_hours() == 0
 
 
-def test_count_empty_hours_includes_sub_one_mib_raws(tmp_path: Path):
+def test_count_empty_hours_treats_sub_one_mib_raws_as_valid(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -640,8 +734,8 @@ def test_count_empty_hours_includes_sub_one_mib_raws(tmp_path: Path):
 
         stats = index.stats(now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc))
 
-        assert index.count_empty_hours() == 1
-        assert stats["mirrored_hours"] == 0
+        assert index.count_empty_hours() == 0
+        assert stats["mirrored_hours"] == 1
 
 
 def test_update_row_count(tmp_path: Path):

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -96,13 +96,69 @@ def test_discover_archive_hours_uses_multiple_archive_sources(tmp_path: Path, mo
             for row in worker._index._fetchall("SELECT * FROM archive_hours ORDER BY filename")
         }
 
-    assert discovered == 3
+    assert discovered == 2
     assert rows["polymarket_orderbook_2026-03-21T11.parquet"]["source_url"] == (
         "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet"
     )
     assert rows["polymarket_orderbook_2026-03-21T12.parquet"]["source_url"] == (
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet"
     )
+    assert rows["polymarket_orderbook_2026-03-21T12.parquet"]["source_priority"] == 0
+
+
+def test_discover_archive_hours_does_not_downgrade_v2_overlap(tmp_path: Path, monkeypatch) -> None:
+    config = RelayConfig(
+        data_dir=tmp_path,
+        bind_host="127.0.0.1",
+        bind_port=8080,
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
+        poll_interval_secs=900,
+        http_timeout_secs=30,
+        archive_stale_pages=1,
+        archive_max_pages=None,
+        event_retention=1000,
+        api_rate_limit_per_minute=2400,
+        verify_batch_size=50,
+        archive_sources=(
+            ArchiveSource(
+                listing_url="https://archive.pmxt.dev/Polymarket/v2",
+                raw_base_url="https://r2v2.pmxt.dev",
+            ),
+            ArchiveSource(
+                listing_url="https://archive.pmxt.dev/Polymarket/v1",
+                raw_base_url="https://r2.pmxt.dev",
+            ),
+        ),
+    )
+    filename = "polymarket_orderbook_2026-03-21T12.parquet"
+    pages = {
+        ("https://archive.pmxt.dev/Polymarket/v2", 1): (
+            f'<a href="https://r2v2.pmxt.dev/{filename}">12</a>'
+        ),
+        ("https://archive.pmxt.dev/Polymarket/v2", 2): "",
+        ("https://archive.pmxt.dev/Polymarket/v1", 1): (
+            f'<a href="https://r2.pmxt.dev/{filename}">12</a>'
+        ),
+        ("https://archive.pmxt.dev/Polymarket/v1", 2): "",
+    }
+
+    monkeypatch.setattr(
+        "pmxt_relay.worker.fetch_archive_page",
+        lambda archive_listing_url, page, timeout_secs: pages[(archive_listing_url, page)],  # type: ignore[no-untyped-def]
+    )
+
+    with RelayWorker(config, reset_inflight=False) as worker:
+        assert worker._discover_archive_hours() == 1
+        assert worker._discover_archive_hours() == 0
+        row = worker._index._conn.execute(
+            "SELECT source_url, source_priority FROM archive_hours WHERE filename = ?",
+            (filename,),
+        ).fetchone()
+
+    assert row is not None
+    assert row["source_url"] == f"https://r2v2.pmxt.dev/{filename}"
+    assert row["source_priority"] == 0
 
 
 def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, monkeypatch) -> None:
@@ -280,7 +336,7 @@ def test_run_once_scans_full_local_tree_only_on_first_cycle(tmp_path: Path, monk
         assert calls == {"full": 1, "pending": 1}
 
 
-def test_repeated_404s_are_quarantined(tmp_path: Path, monkeypatch) -> None:
+def test_404s_are_classified_as_missing(tmp_path: Path, monkeypatch) -> None:
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -305,13 +361,16 @@ def test_repeated_404s_are_quarantined(tmp_path: Path, monkeypatch) -> None:
         stats = worker._index.stats()
         events = worker._index.recent_events(limit=1)
 
-        assert queue["mirror_quarantined"] == 1
-        assert queue["mirror_error"] == 1
+        assert queue["mirror_missing"] == 1
+        assert queue["mirror_quarantined"] == 0
+        assert queue["mirror_error"] == 0
         assert queue["mirror_retry_waiting"] == 1
         assert queue["next_retry_at"] is not None
-        assert stats["mirror_quarantined"] == 1
+        assert stats["mirror_missing"] == 1
+        assert stats["mirror_errors"] == 0
+        assert stats["mirror_quarantined"] == 0
         assert worker._index.list_hours_needing_mirror() == []
-        assert events[0]["event_type"] == "mirror_quarantined"
+        assert events[0]["event_type"] == "mirror_missing"
 
 
 def test_verify_ready_hours_requeues_changed_upstream(tmp_path: Path, monkeypatch) -> None:
@@ -409,7 +468,7 @@ def test_verify_ready_hours_tolerates_head_failure(tmp_path: Path, monkeypatch) 
         assert row["mirror_status"] == "ready"
 
 
-def test_verify_ready_empty_hour_404_moves_to_error(tmp_path: Path, monkeypatch) -> None:
+def test_verify_ready_empty_hour_404_moves_to_missing(tmp_path: Path, monkeypatch) -> None:
     config = _make_config(tmp_path)
     with RelayWorker(config, reset_inflight=False) as worker:
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -438,10 +497,11 @@ def test_verify_ready_empty_hour_404_moves_to_error(tmp_path: Path, monkeypatch)
             (filename,),
         ).fetchone()
         assert row is not None
-        assert row["mirror_status"] == "error"
+        assert row["mirror_status"] == "missing"
         assert row["last_error"] == "HTTP Error 404: Not Found"
         assert worker._index.count_empty_hours() == 0
-        assert worker._index.count_error_hours() == 1
+        assert worker._index.count_missing_hours() == 1
+        assert worker._index.count_error_hours() == 0
 
 
 def test_run_once_includes_verification_step(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Fixes PMXT raw archive source precedence and health accounting for the relay and local raw downloader.

- Persist source priority for archive rows so v2 wins over overlapping v1 entries.
- Prune stale archive rows that disappeared from a scanned source listing.
- Classify upstream raw 404s as missing instead of relay/download errors.
- Treat zero-row or tiny parquet files as mirrored data because they can be valid no-trade hours.
- Apply matching 404/missing and v2-first behavior to `scripts/pmxt_download_raws.py`.

## Root Cause

The relay and downloader were mixing source discovery with coverage accounting. Stale or lower-priority v1/v2 overlap could keep old error state alive, listed raw 404s were counted as errors, and valid tiny/zero-row parquet files were reported as broken/empty rows.

## Validation

- `uv run pytest tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py -q`
- `uv run ruff check pmxt_relay scripts tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py`
- `uv run ruff format --check pmxt_relay scripts tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py`
- Deployed to the public VPS and verified `/v1/stats`, `/v1/queue`, `/v1/system`, and badge counts.

Live VPS after deploy:

```json
{"mirror_errors": 0, "mirror_quarantined": 0, "mirror_missing": 1}
```

Badges reported:

- `Missing hours: 1/1333`
- `Error hours: 0/1333`
- `Empty hours: 0/1320`
