### PR TITLE
[codex] Fix PMXT empty hour accounting

### DIFF
--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -64,9 +64,8 @@ Coverage metrics separate upstream availability from local mirror state:
 
 - Missing hours are listed raw objects whose upstream URL currently returns
   404. Gaps in archive listings are not counted as relay failures.
-- Zero-row or tiny parquets are treated as mirrored hours because they can be
-  valid no-trade periods. If upstream later returns 404 for a mirrored file, the
-  verifier moves it to the missing bucket.
+- Zero-row or tiny parquets are counted as empty hours. They are not successful
+  mirrored coverage, and they are not source-404 missing hours.
 - Error hours are listed archive rows that are not currently represented by a
   mirror or known-missing 404. This includes pending, active, error, and
   quarantined mirror rows; detailed states are reported by `/v1/queue`.
@@ -167,8 +166,7 @@ The public badges separate relay health from `r2v2.pmxt.dev` availability:
   online or offline.
 - `/v1/badge/missing-hours.svg` shows listed raw objects whose upstream URL
   currently returns 404.
-- `/v1/badge/empty-hours.svg` is retained for compatibility, but zero-row or
-  tiny parquets are treated as mirrored hours because they can be valid no-trade
-  periods.
+- `/v1/badge/empty-hours.svg` shows zero-row or tiny parquet files. These are
+  excluded from mirrored coverage.
 - `/v1/badge/error-hours.svg` shows listed archive rows that are not currently
   represented by a mirror or known-missing 404.

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -750,7 +750,21 @@ class RelayIndex:
         )
 
     def count_empty_hours(self) -> int:
-        return 0
+        return int(
+            self._fetchscalar(
+                """
+                SELECT COUNT(*)
+                FROM archive_hours
+                WHERE mirror_status = 'ready'
+                  AND (
+                    (row_count IS NOT NULL AND row_count = 0)
+                    OR (content_length IS NOT NULL AND content_length < ?)
+                  )
+                """,
+                (_MIN_NONEMPTY_RAW_BYTES,),
+                default=0,
+            )
+        )
 
     def count_error_hours(self, *, now: datetime | None = None) -> int:
         now_reference = _utc_now_datetime() if now is None else now.astimezone(UTC)
@@ -761,16 +775,29 @@ class RelayIndex:
                 COUNT(DISTINCT hour) AS discovered_hours,
                 SUM(
                     CASE
-                        WHEN mirror_status = 'ready' THEN 1
+                        WHEN mirror_status = 'ready'
+                          AND (row_count IS NULL OR row_count > 0)
+                          AND (content_length IS NULL OR content_length >= ?)
+                        THEN 1
                         ELSE 0
                     END
                 ) AS mirrored_hours,
-                0 AS empty_hours,
+                SUM(
+                    CASE
+                        WHEN mirror_status = 'ready'
+                          AND (
+                            (row_count IS NOT NULL AND row_count = 0)
+                            OR (content_length IS NOT NULL AND content_length < ?)
+                          )
+                        THEN 1
+                        ELSE 0
+                    END
+                ) AS empty_hours,
                 SUM(CASE WHEN mirror_status = 'missing' THEN 1 ELSE 0 END) AS missing_hours
             FROM archive_hours
             WHERE hour <= ?
             """,
-            (now_floor.isoformat(),),
+            (_MIN_NONEMPTY_RAW_BYTES, _MIN_NONEMPTY_RAW_BYTES, now_floor.isoformat()),
         )
         if row is None:
             return 0
@@ -808,7 +835,10 @@ class RelayIndex:
             SELECT
                 SUM(
                     CASE
-                        WHEN mirror_status = 'ready' THEN 1
+                        WHEN mirror_status = 'ready'
+                          AND (row_count IS NULL OR row_count > 0)
+                          AND (content_length IS NULL OR content_length >= ?)
+                        THEN 1
                         ELSE 0
                     END
                 ) AS mirrored_hours,
@@ -817,6 +847,7 @@ class RelayIndex:
                 SUM(CASE WHEN mirror_status = 'missing' THEN 1 ELSE 0 END) AS mirror_missing
             FROM archive_hours
             """,
+            (_MIN_NONEMPTY_RAW_BYTES,),
         )
         stats_row = dict(row) if row is not None else {}
         archive_hours = self._compute_elapsed_archive_hours(now=now)
@@ -847,17 +878,35 @@ class RelayIndex:
                 SUM(CASE WHEN mirror_status IN ('error', 'quarantined', 'missing') AND next_retry_at > ? THEN 1 ELSE 0 END) AS mirror_retry_waiting,
                 SUM(CASE WHEN mirror_status = 'quarantined' THEN 1 ELSE 0 END) AS mirror_quarantined,
                 MIN(CASE WHEN mirror_status IN ('error', 'quarantined', 'missing') THEN next_retry_at END) AS next_retry_at,
-                MAX(CASE WHEN mirror_status = 'ready' THEN hour END) AS latest_mirrored_hour,
+                MAX(
+                    CASE
+                        WHEN mirror_status = 'ready'
+                          AND (row_count IS NULL OR row_count > 0)
+                          AND (content_length IS NULL OR content_length >= ?)
+                        THEN hour
+                    END
+                ) AS latest_mirrored_hour,
                 (
                     SELECT filename
                     FROM archive_hours latest_ready
                     WHERE latest_ready.mirror_status = 'ready'
+                      AND (latest_ready.row_count IS NULL OR latest_ready.row_count > 0)
+                      AND (
+                        latest_ready.content_length IS NULL
+                        OR latest_ready.content_length >= ?
+                      )
                     ORDER BY latest_ready.hour DESC, latest_ready.mirrored_at DESC, latest_ready.filename DESC
                     LIMIT 1
                 ) AS latest_mirrored_filename
             FROM archive_hours
             """,
-            (_LEGACY_ACTIVE_STATUS, retry_cutoff, retry_cutoff),
+            (
+                _LEGACY_ACTIVE_STATUS,
+                retry_cutoff,
+                retry_cutoff,
+                _MIN_NONEMPTY_RAW_BYTES,
+                _MIN_NONEMPTY_RAW_BYTES,
+            ),
         )
         queue_row = dict(row) if row is not None else {}
         return {

--- a/scripts/_pmxt_raw_download.py
+++ b/scripts/_pmxt_raw_download.py
@@ -329,10 +329,12 @@ def _read_parquet_row_count(path: Path) -> int | None:
 
 def _local_raw_is_empty(path: Path) -> bool:
     try:
-        path.stat()
+        file_size = path.stat().st_size
     except OSError:
         return True
-    return False
+    if file_size < _MIN_NONEMPTY_RAW_BYTES:
+        return True
+    return _read_parquet_row_count(path) == 0
 
 
 def _existing_refresh_reason(
@@ -360,12 +362,29 @@ def _validate_local_raw_hours(
     *, destination: Path, filenames: list[str]
 ) -> tuple[list[str], list[str], list[str], list[str]]:
     missing: list[str] = []
+    empty: list[str] = []
+    zero_row: list[str] = []
+    small: list[str] = []
     for filename in filenames:
         hour_label = parse_archive_hour(filename).isoformat()
         destination_path = destination / raw_relative_path(filename)
         if not destination_path.exists():
             missing.append(hour_label)
-    return missing, [], [], []
+            continue
+        try:
+            file_size = destination_path.stat().st_size
+        except OSError:
+            missing.append(hour_label)
+            continue
+        if file_size < _MIN_NONEMPTY_RAW_BYTES:
+            empty.append(hour_label)
+            small.append(hour_label)
+        row_count = _read_parquet_row_count(destination_path)
+        if row_count == 0:
+            if hour_label not in empty:
+                empty.append(hour_label)
+            zero_row.append(hour_label)
+    return missing, empty, zero_row, small
 
 
 def _pid_is_active(pid: int) -> bool:

--- a/scripts/pmxt_download_raws.py
+++ b/scripts/pmxt_download_raws.py
@@ -96,7 +96,7 @@ def main() -> int:
         discovery_max_pages=args.discovery_max_pages,
     )
     print(json.dumps(summary.as_dict(), indent=2, sort_keys=True))
-    incomplete = summary.failed_hours or summary.missing_local_hours
+    incomplete = summary.failed_hours or summary.missing_local_hours or summary.empty_local_hours
     return 1 if incomplete else 0
 
 

--- a/tests/test_pmxt_raw_download.py
+++ b/tests/test_pmxt_raw_download.py
@@ -303,7 +303,7 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
     assert bar.desc == "Downloading raw hours (2/2 done)"
 
 
-def test_download_raw_hours_reports_404_as_archive_missing_and_accepts_empty_parquet(
+def test_download_raw_hours_reports_404_as_archive_missing_and_empty_parquet_separately(
     monkeypatch, tmp_path: Path
 ) -> None:
     empty_payload = _empty_parquet_payload()
@@ -332,9 +332,9 @@ def test_download_raw_hours_reports_404_as_archive_missing_and_accepts_empty_par
     assert summary.archive_missing_hours == ["2026-03-21T09:00:00+00:00"]
     assert summary.failed_hours == []
     assert summary.missing_local_hours == []
-    assert summary.empty_local_hours == []
-    assert summary.zero_row_local_hours == []
-    assert summary.small_local_hours == []
+    assert summary.empty_local_hours == ["2026-03-21T10:00:00+00:00"]
+    assert summary.zero_row_local_hours == ["2026-03-21T10:00:00+00:00"]
+    assert summary.small_local_hours == ["2026-03-21T10:00:00+00:00"]
 
 
 def test_download_raw_hours_progress_output_includes_failure_error(

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -420,14 +420,14 @@ def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
             "polymarket_orderbook_2026-03-21T12.parquet",
             local_path=str(tmp_path / "a.parquet"),
             etag=None,
-            content_length=1,
+            content_length=2 * 1024 * 1024,
             last_modified=None,
         )
         index.mark_mirrored(
             "polymarket_orderbook_2026-03-21T13.parquet",
             local_path=str(tmp_path / "b.parquet"),
             etag=None,
-            content_length=1,
+            content_length=2 * 1024 * 1024,
             last_modified=None,
         )
 
@@ -461,7 +461,7 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
             filename,
             local_path=str(tmp_path / "hour.parquet"),
             etag=None,
-            content_length=1,
+            content_length=2 * 1024 * 1024,
             last_modified=None,
         )
 
@@ -571,7 +571,7 @@ def test_empty_hours_badge_shows_count(tmp_path: Path):
 
         assert response.status == 200
         assert "Empty hours" in payload
-        assert "0/2" in payload
+        assert "1/1" in payload
 
     asyncio.run(scenario())
 

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -650,7 +650,7 @@ def test_coverage_gap_buckets_reconcile(tmp_path: Path):
 
         assert archive_hours - mirrored == missing + empty_hours + error_hours
         assert missing == 0
-        assert empty_hours == 0
+        assert empty_hours == 1
         assert error_hours == 3
 
 
@@ -672,7 +672,7 @@ def test_stats_archive_hours_are_discovered_coverage_hours(tmp_path: Path):
         assert stats["archive_hours"] == 2
 
 
-def test_stats_mirrored_hours_include_zero_row_files(tmp_path: Path):
+def test_stats_mirrored_hours_exclude_zero_row_files(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         empty = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -692,10 +692,10 @@ def test_stats_mirrored_hours_include_zero_row_files(tmp_path: Path):
 
         stats = index.stats(now=datetime(2026, 3, 21, 14, 30, tzinfo=timezone.utc))
 
-        assert stats["mirrored_hours"] == 3
+        assert stats["mirrored_hours"] == 2
 
 
-def test_count_empty_hours_treats_zero_row_files_as_valid(tmp_path: Path):
+def test_count_empty_hours_counts_zero_row_files(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filenames = [
@@ -715,10 +715,10 @@ def test_count_empty_hours_treats_zero_row_files_as_valid(tmp_path: Path):
         index.update_row_count(filenames[0], 0)
         index.update_row_count(filenames[1], 100)
 
-        assert index.count_empty_hours() == 0
+        assert index.count_empty_hours() == 1
 
 
-def test_count_empty_hours_treats_sub_one_mib_raws_as_valid(tmp_path: Path):
+def test_count_empty_hours_counts_sub_one_mib_raws(tmp_path: Path):
     with RelayIndex(tmp_path / "relay.sqlite3") as index:
         index.initialize()
         filename = "polymarket_orderbook_2026-03-21T12.parquet"
@@ -734,8 +734,8 @@ def test_count_empty_hours_treats_sub_one_mib_raws_as_valid(tmp_path: Path):
 
         stats = index.stats(now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc))
 
-        assert index.count_empty_hours() == 0
-        assert stats["mirrored_hours"] == 1
+        assert index.count_empty_hours() == 1
+        assert stats["mirrored_hours"] == 0
 
 
 def test_update_row_count(tmp_path: Path):


### PR DESCRIPTION
## Summary

Corrects PMXT raw coverage accounting after the v2/v1 priority fix.

- Excludes zero-row or sub-1 MiB parquet files from successful `mirrored_hours`.
- Counts those files in the separate empty-hours bucket, not the source-404 missing bucket and not worker errors.
- Keeps source 404s classified as missing, so expected upstream absence does not inflate error metrics.
- Applies the same validation to the local PMXT raw download script: zero-row/tiny local raws are reported as empty local hours and make the CLI exit incomplete.

## Root Cause

The previous fix went too far and treated zero-row/tiny market-wide hourly raw files as valid mirrored data. That made the relay and downloader metrics hide zero-row hours instead of surfacing them through the empty-hours path.

## Validation

- `uv run pytest tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py -q`
- `uv run ruff check pmxt_relay scripts tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py`
- `uv run ruff format --check pmxt_relay scripts tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py`
- `git diff --check -- pmxt_relay/index_db.py pmxt_relay/worker.py scripts/_pmxt_raw_download.py scripts/pmxt_download_raws.py pmxt_relay/README.md tests/test_pmxt_raw_download.py tests/test_pmxt_relay_index_db.py tests/test_pmxt_relay_worker.py tests/test_pmxt_relay_api.py`

VPS deploy and live verification will be added after deployment.
