### PR TITLE
[codex] redesign PMXT relay archive coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,16 @@
 ![GitHub open issues](https://img.shields.io/github/issues/evan-kolberg/prediction-market-backtesting)
 
 [![Relay Status](https://209-209-10-83.sslip.io/v1/badge/status.svg)](https://209-209-10-83.sslip.io/v1/stats)
-[![r2.pmxt.dev](https://209-209-10-83.sslip.io/v1/badge/upstream.svg)](https://209-209-10-83.sslip.io/v1/queue)
+[![r2v2.pmxt.dev](https://209-209-10-83.sslip.io/v1/badge/upstream.svg)](https://209-209-10-83.sslip.io/v1/queue)
+[![r2.pmxt.dev](https://209-209-10-83.sslip.io/v1/badge/upstream-r2.svg)](https://209-209-10-83.sslip.io/v1/queue)
 [![CPU Load](https://209-209-10-83.sslip.io/v1/badge/cpu.svg)](https://209-209-10-83.sslip.io/v1/system)
 [![I/O Wait](https://209-209-10-83.sslip.io/v1/badge/iowait.svg)](https://209-209-10-83.sslip.io/v1/system)
 [![RAM](https://209-209-10-83.sslip.io/v1/badge/mem.svg)](https://209-209-10-83.sslip.io/v1/system)
 [![Disk](https://209-209-10-83.sslip.io/v1/badge/disk.svg)](https://209-209-10-83.sslip.io/v1/system)
 [![Mirror Service](https://209-209-10-83.sslip.io/v1/badge/worker.svg)](https://209-209-10-83.sslip.io/v1/system)
-[![Hours Mirrored](https://209-209-10-83.sslip.io/v1/badge/mirrored.svg)](https://209-209-10-83.sslip.io/v1/stats)
-[![Missing Hours](https://209-209-10-83.sslip.io/v1/badge/missing-hours.svg)](https://209-209-10-83.sslip.io/v1/stats)
-[![Empty Hours](https://209-209-10-83.sslip.io/v1/badge/empty-hours.svg)](https://209-209-10-83.sslip.io/v1/stats)
-[![Error Hours](https://209-209-10-83.sslip.io/v1/badge/error-hours.svg)](https://209-209-10-83.sslip.io/v1/queue)
-[![Latest File](https://209-209-10-83.sslip.io/v1/badge/latest-file.svg)](https://209-209-10-83.sslip.io/v1/stats)
+[![Hour Files](https://209-209-10-83.sslip.io/v1/badge/hour-files.svg)](https://209-209-10-83.sslip.io/v1/stats)
+[![Hours Since First](https://209-209-10-83.sslip.io/v1/badge/hours-since-first.svg)](https://209-209-10-83.sslip.io/v1/stats)
+[![Latest Hour](https://209-209-10-83.sslip.io/v1/badge/latest-hour.svg)](https://209-209-10-83.sslip.io/v1/stats)
 
 **Thanks to [PMXT](https://github.com/pmxt-dev/pmxt) for providing this data for free!**
 

--- a/docs/pmxt-byod.md
+++ b/docs/pmxt-byod.md
@@ -104,24 +104,24 @@ To mirror raw archive hours locally for this repo's runners, use:
 make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
 ```
 
-The downloader walks every archive listing page newest-first, defaults to the
-PMXT v2 and v1 Polymarket listings, builds the full hourly range from the newest
-listed hour to the oldest listed hour, then reports the upstream listed-hour
-count, gaps in that covered span, requested hours still missing locally, and
-local parquet files with zero rows or less than 1 MiB of data. Existing local
-files are refreshed when they are empty or when an upstream source advertises a
-larger object. It also prints per-hour completion lines plus the active
-transfer. Example output:
+The downloader walks direct hourly filenames from `2026-02-21T16:00:00Z`
+through the current floored UTC hour newest-first, probes `r2v2.pmxt.dev` and
+`r2.pmxt.dev`, and keeps the larger archive object when both exist for the same
+hour. It reports the direct-hour count, hours missing from all configured
+sources, and requested hours still missing locally. Existing local files are
+refreshed when they are empty or when an upstream source advertises a larger
+object. It also prints per-hour completion lines plus the active transfer.
+Example output:
 
 ```text
-PMXT raw source: explicit priority (archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+PMXT raw source: direct hour probes (archive best-of https://r2v2.pmxt.dev, https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
 Downloading PMXT raw hours to /path/to/pmxt_raws (requested_hours=3, window_start=2026-02-27T11, window_end=2026-02-27T13)...
   2026-02-27T13  12.431s   445.9 MiB  archive
   2026-02-27T12   0.000s    existing  skip
 Downloading raw hours (2/3 done, 1 active):  67%|████████████████████████████████████████████████████████████▏                              | [00:41<00:20]active: relay 2026-02-27T11 392.0/445.9 MiB 14.8s
 ```
 
-Those values vary with the archive listing and whatever hour is currently in
+Those values vary with the direct-hour window and whatever hour is currently in
 flight.
 
 ### Supported Local File Layout

--- a/docs/pmxt-relay.md
+++ b/docs/pmxt-relay.md
@@ -17,7 +17,7 @@ The active `pmxt_relay/` service is mirror-only.
 
 What it does today:
 
-- discovers PMXT archive hours
+- discovers PMXT archive hours by direct raw URL pattern probes
 - adopts already mirrored local raw hours on startup
 - mirrors raw parquet files onto disk
 - exposes raw files under `/v1/raw/*`
@@ -38,17 +38,19 @@ The current deployment and operations details live in:
 Operational note:
 
 - the public relay status badge reports relay health only
-- the public PMXT upstream badge reports source polling as online or offline;
-  missing archive hours, zero-row mirrored files, and listed-but-uncovered
-  mirror rows have separate badges
+- the public PMXT upstream badges report `r2v2.pmxt.dev` and `r2.pmxt.dev`
+  source polling as online or offline;
+- the coverage badges are only actual hour files on disk and elapsed archive
+  hours since `2026-02-21T16:00:00+00:00`
 
 Deployment facts for the active box:
 
 - live checkout path: `/opt/prediction-market-backtesting`
 - env file: `/etc/pmxt-relay.env`
-- active PMXT archive sources:
-  `https://archive.pmxt.dev/Polymarket/v2|https://r2v2.pmxt.dev`,
-  then `https://archive.pmxt.dev/Polymarket/v1|https://r2.pmxt.dev`
+- active PMXT raw origins:
+  `https://r2v2.pmxt.dev`, then `https://r2.pmxt.dev`
+- overlap rule:
+  keep the raw URL with the larger reported `Content-Length`
 - systemd units:
   `pmxt-relay-api.service` and `pmxt-relay-worker.service`
 - public URL:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -114,20 +114,19 @@ To mirror PMXT raw archive hours locally, run:
 make download-pmxt-raws DESTINATION=/path/to/pmxt_raws
 ```
 
-The download is long-running, walks every archive listing page newest-first,
-defaults to the PMXT v2 and v1 Polymarket listings, builds the full hourly range
-from the newest listed hour to the oldest listed hour, and prints per-hour
-completion lines plus the currently active transfer.
-The final JSON summary includes `archive_listed_hours` for the number of hours
-actually exposed by the upstream listing, `archive_missing_hours` for gaps in
-the upstream listing's covered time span, `missing_local_hours` for requested
-hours still absent on disk, and `empty_local_hours` for local parquet files with
-zero rows or less than 1 MiB of data. Existing local files are refreshed when
-they are empty or when an upstream source advertises a larger object. Example
-output:
+The download is long-running, walks direct hourly filenames from
+`2026-02-21T16:00:00Z` through the current floored UTC hour newest-first, probes
+`r2v2.pmxt.dev` and `r2.pmxt.dev`, and keeps the larger archive object when both
+exist for the same hour. It prints per-hour completion lines plus the currently
+active transfer.
+The final JSON summary includes `archive_listed_hours` for the number of direct
+hours attempted, `archive_missing_hours` for hours missing from all configured
+sources, and `missing_local_hours` for requested hours still absent on disk.
+Existing local files are refreshed when they are empty or when an upstream
+source advertises a larger object. Example output:
 
 ```text
-PMXT raw source: explicit priority (archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
+PMXT raw source: direct hour probes (archive best-of https://r2v2.pmxt.dev, https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)
 Downloading PMXT raw hours to /path/to/pmxt_raws (requested_hours=3, window_start=2026-02-27T11, window_end=2026-02-27T13)...
   2026-02-27T13  12.431s   445.9 MiB  archive
   2026-02-27T12   0.000s    existing  skip

--- a/pmxt_relay/README.md
+++ b/pmxt_relay/README.md
@@ -46,6 +46,13 @@ On startup the worker adopts any already mirrored local raw hours into the
 state DB. During steady-state polling it only checks for incremental additions
 instead of rescanning the full raw tree every cycle.
 
+Archive discovery does not trust listing pages. Each worker cycle walks the
+expected hourly filenames from the current UTC hour back through
+`2026-02-21T16:00:00+00:00`, probes `r2v2.pmxt.dev` and `r2.pmxt.dev` by direct
+raw URL, and queues the largest object when both origins have the same hour.
+If neither origin has the hour, stale unmirrored queue rows for that filename
+are removed.
+
 Repeated upstream 404s are no longer retried every poll forever. The active
 relay now backs off failed mirrors and temporarily quarantines repeated 404s on
 a slower retry cadence so one stale archive reference does not dominate every
@@ -60,27 +67,20 @@ are tracked to detect empty/broken files.
 
 ## Self-Healing Coverage
 
-Coverage metrics separate upstream availability from local mirror state:
+Coverage metrics stay deliberately simple:
 
-- Missing hours are listed raw objects whose upstream URL currently returns
-  404. Gaps in archive listings are not counted as relay failures.
-- Zero-row or tiny parquets are treated as mirrored hours because they can be
-  valid no-trade periods. If upstream later returns 404 for a mirrored file, the
-  verifier moves it to the missing bucket.
-- Error hours are listed archive rows that are not currently represented by a
-  mirror or known-missing 404. This includes pending, active, error, and
-  quarantined mirror rows; detailed states are reported by `/v1/queue`.
-- The coverage gap is expected to reconcile as:
-  `archive_hours - mirrored_hours == missing + empty + error`.
-- Updated bytes for filenames already on disk: same HEAD re-verifier path;
-  filename does not need to change.
+- `dump_files_on_disk` / `mirrored_hours` counts valid hour files,
+  `polymarket_orderbook_*.parquet` dump files physically present under
+  `raw/`.
+- `archive_hours` counts hours since the first expected archive hour,
+  elapsed UTC hours from
+  `PMXT_RELAY_ARCHIVE_START_HOUR` through the current UTC hour.
 
-The one blind spot: if upstream introduces *brand-new filenames* deep in
-older archive pages (not page 1) — e.g. backfilling a historical hour
-never previously listed — discovery may miss them with
-`PMXT_RELAY_ARCHIVE_STALE_PAGES=1` (default), since the loop stops at the
-first page that adds zero new filenames. Bump that env to 3-5 if upstream
-ever does deep historical backfills.
+The mirror queue still tracks pending, active, retrying, and quarantined work
+in SQLite, but those states do not define the public coverage denominator. The
+overlap rule is also intentionally simple: when both raw origins expose the same
+hour, keep the URL with the larger reported `Content-Length`; if sizes tie or
+are unknown, prefer the earlier configured origin.
 
 ## Fresh Box Setup
 
@@ -114,20 +114,18 @@ If you front the relay with Caddy, nginx, or another reverse proxy, serve
 `/v1/raw/*` directly from `/srv/pmxt-relay/raw` when possible instead of
 proxying large parquet downloads through Python.
 
-Edit `/etc/pmxt-relay.env` before starting the services. The active relay does
-not bake in archive or raw-origin URLs; set your mirror's upstream listing URL
-and raw origin URL explicitly for the environment you run.
+Edit `/etc/pmxt-relay.env` before starting the services. The active public
+relay defaults to direct raw URL probing against `r2v2.pmxt.dev` and
+`r2.pmxt.dev`.
 
 Important env knobs from `pmxt_relay/systemd/pmxt-relay.env.example`:
 
 - `PMXT_RELAY_DATA_DIR` for relay-owned state under `/srv/pmxt-relay`
-- `PMXT_RELAY_ARCHIVE_SOURCES` for ordered archive source pairs in
-  `LISTING_URL|RAW_BASE_URL` form. PMXT Polymarket currently uses v2 first and
-  v1 second because upstream split the archive across both listings.
-- `PMXT_RELAY_ARCHIVE_LISTING_URL` for the upstream archive listing to poll
-  when `PMXT_RELAY_ARCHIVE_SOURCES` is unset
-  (PMXT Polymarket v2 uses `https://archive.pmxt.dev/Polymarket/v2`)
-- `PMXT_RELAY_RAW_BASE_URL` for the upstream raw object base URL
+- `PMXT_RELAY_RAW_BASE_URLS` for ordered raw origins to probe by filename
+  pattern. The default public order is `https://r2v2.pmxt.dev`,
+  `https://r2.pmxt.dev`.
+- `PMXT_RELAY_ARCHIVE_START_HOUR` for the first expected archive hour. The
+  public PMXT mirror uses `2026-02-21T16:00:00+00:00`.
 - `PMXT_RELAY_TRUSTED_PROXY_IPS` if the API sits behind Caddy, nginx, or
   another reverse proxy and should trust forwarded client IPs from that proxy
 - `PMXT_RELAY_VERIFY_BATCH_SIZE` (default 50) how many mirrored files to
@@ -159,16 +157,15 @@ Active mirror-focused endpoints:
 state. The active relay path is limited to mirroring, health, and raw file
 serving.
 
-The public badges separate relay health from `r2v2.pmxt.dev` availability:
+The public badges separate relay health from raw-origin availability:
 
 - `/v1/badge/status(.svg)` reports whether the relay itself is up, recent, and
   has active API/worker services.
 - `/v1/badge/upstream(.svg)` reports whether recent `r2v2.pmxt.dev` polling is
   online or offline.
-- `/v1/badge/missing-hours.svg` shows listed raw objects whose upstream URL
-  currently returns 404.
-- `/v1/badge/empty-hours.svg` is retained for compatibility, but zero-row or
-  tiny parquets are treated as mirrored hours because they can be valid no-trade
-  periods.
-- `/v1/badge/error-hours.svg` shows listed archive rows that are not currently
-  represented by a mirror or known-missing 404.
+- `/v1/badge/upstream-r2(.svg)` reports the same polling health for
+  `r2.pmxt.dev`.
+- `/v1/badge/hour-files(.svg)` reports actual hour files on disk.
+- `/v1/badge/hours-since-first(.svg)` reports elapsed hours since
+  `2026-02-21T16:00:00+00:00`.
+- `/v1/badge/latest-hour.svg` reports the latest mirrored hour on disk.

--- a/pmxt_relay/api.py
+++ b/pmxt_relay/api.py
@@ -17,6 +17,7 @@ from xml.sax.saxutils import escape
 from aiohttp import web
 
 from pmxt_relay.config import RelayConfig
+from pmxt_relay.coverage import count_raw_dump_files, elapsed_archive_hours
 from pmxt_relay.index_db import RelayIndex
 
 _RAW_FILENAME_RE = re.compile(
@@ -379,17 +380,15 @@ def _badge_payload(*, label: str, message: str, color: str) -> dict[str, object]
     }
 
 
-def _progress_color(*, numerator: int, denominator: int) -> str:
-    if denominator <= 0:
-        return "lightgrey"
-    progress = numerator / denominator
-    if progress >= 1.0:
-        return "brightgreen"
-    if progress >= 0.5:
-        return "green"
-    if progress >= 0.1:
-        return "yellowgreen"
-    return "orange"
+def _raw_source_label(raw_base_url: str) -> str:
+    return urlparse(raw_base_url).netloc or raw_base_url or "PMXT archive"
+
+
+def _raw_source_for_badge(config: RelayConfig, index: int = 0) -> str:
+    raw_base_urls = config.resolved_raw_base_urls
+    if raw_base_urls:
+        return raw_base_urls[min(index, len(raw_base_urls) - 1)]
+    return config.raw_base_url
 
 
 def _status_badge_payload(
@@ -455,12 +454,13 @@ def _upstream_badge_payload(
     stats: dict[str, int | str | None],
     queue: dict[str, int | str | None],
     config: RelayConfig,
+    raw_base_url: str | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
     del queue
     current = datetime.now(timezone.utc) if now is None else now.astimezone(timezone.utc)
     last_event_at = _parse_db_timestamp(stats.get("last_event_at"))  # type: ignore[arg-type]
-    upstream_label = urlparse(config.raw_base_url).netloc or config.raw_base_url
+    upstream_label = _raw_source_label(raw_base_url or _raw_source_for_badge(config))
 
     if last_event_at is None:
         return _badge_payload(
@@ -485,92 +485,27 @@ def _upstream_badge_payload(
     )
 
 
-def _ratio_badge_payload(*, label: str, numerator: int, denominator: int) -> dict[str, object]:
-    if denominator <= 0:
-        return _badge_payload(
-            label=label,
-            message="0/0 hrs",
-            color="lightgrey",
-        )
-
-    return _badge_payload(
-        label=label,
-        message=f"{numerator}/{denominator} hrs",
-        color=_progress_color(numerator=numerator, denominator=denominator),
-    )
+def _dump_files_badge_payload(*, stats: dict[str, int | str | None]) -> dict[str, object]:
+    dump_files = int(stats.get("dump_files_on_disk") or stats.get("mirrored_hours") or 0)
+    color = "brightgreen" if dump_files > 0 else "lightgrey"
+    return _badge_payload(label="Hour files", message=f"{dump_files} files", color=color)
 
 
-def _mirrored_badge_payload(*, stats: dict[str, int | str | None]) -> dict[str, object]:
-    mirrored_hours = int(stats.get("mirrored_hours") or 0)
+def _archive_hours_badge_payload(*, stats: dict[str, int | str | None]) -> dict[str, object]:
     archive_hours = int(stats.get("archive_hours") or 0)
-    return _ratio_badge_payload(
-        label="Hours mirrored", numerator=mirrored_hours, denominator=archive_hours
-    )
+    color = "blue" if archive_hours > 0 else "lightgrey"
+    return _badge_payload(label="Hours since first", message=f"{archive_hours} hrs", color=color)
 
 
-def _latest_file_badge_payload(*, queue: dict[str, int | str | None]) -> dict[str, object]:
-    latest_filename = queue.get("latest_mirrored_filename")
-    filename_label = (
-        latest_filename if isinstance(latest_filename, str) and latest_filename else None
-    )
+def _latest_hour_badge_payload(*, queue: dict[str, int | str | None]) -> dict[str, object]:
+    latest_hour = queue.get("latest_mirrored_hour")
+    hour_label = latest_hour if isinstance(latest_hour, str) and latest_hour else None
+    if hour_label is not None:
+        hour_label = hour_label.replace(":00:00+00:00", "").replace("+00:00", "")
     return _badge_payload(
-        label="Latest file",
-        message=filename_label or "none",
-        color="blue" if filename_label is not None else "lightgrey",
-    )
-
-
-def _missing_hours_badge_payload(*, index: RelayIndex) -> dict[str, object]:
-    missing = index.count_missing_hours()
-    total = int(index.stats().get("archive_hours") or 0)
-    if total == 0:
-        color = "lightgrey"
-    elif missing == 0:
-        color = "brightgreen"
-    elif missing <= 5:
-        color = "yellow"
-    else:
-        color = "orange"
-    return _badge_payload(
-        label="Missing hours",
-        message=f"{missing}/{total}",
-        color=color,
-    )
-
-
-def _empty_hours_badge_payload(*, index: RelayIndex) -> dict[str, object]:
-    empty = index.count_empty_hours()
-    mirrored = int(index.stats().get("mirrored_hours") or 0)
-    if mirrored == 0:
-        color = "lightgrey"
-    elif empty == 0:
-        color = "brightgreen"
-    elif empty <= 3:
-        color = "yellow"
-    else:
-        color = "orange"
-    return _badge_payload(
-        label="Empty hours",
-        message=f"{empty}/{mirrored}",
-        color=color,
-    )
-
-
-def _error_hours_badge_payload(*, index: RelayIndex) -> dict[str, object]:
-    errors = index.count_error_hours()
-    total = int(index.stats().get("archive_hours") or 0)
-    if total == 0:
-        color = "lightgrey"
-    elif errors == 0:
-        color = "brightgreen"
-    elif errors <= 5:
-        color = "yellow"
-    else:
-        color = "red"
-    return _badge_payload(
-        label="Error hours",
-        message=f"{errors}/{total}",
-        color=color,
+        label="Latest hour",
+        message=hour_label or "none",
+        color="blue" if hour_label is not None else "lightgrey",
     )
 
 
@@ -735,6 +670,27 @@ async def _index_stats_async(index: object) -> dict[str, object]:
     return await asyncio.to_thread(index.stats)
 
 
+def _coverage_stats(config: RelayConfig) -> dict[str, object]:
+    dump_files_on_disk = count_raw_dump_files(config.raw_root)
+    archive_hours = elapsed_archive_hours(start_hour=config.archive_start_hour)
+    return {
+        "archive_start_hour": config.archive_start_hour.isoformat(),
+        "archive_hours": archive_hours,
+        "dump_files_on_disk": dump_files_on_disk,
+        "mirrored_hours": dump_files_on_disk,
+    }
+
+
+async def _relay_stats_async(config: RelayConfig, index: RelayIndex) -> dict[str, object]:
+    index_payload, coverage_payload = await asyncio.gather(
+        _index_stats_async(index),
+        asyncio.to_thread(_coverage_stats, config),
+    )
+    payload = dict(index_payload)
+    payload.update(coverage_payload)
+    return payload
+
+
 async def _index_queue_summary_async(index: object) -> dict[str, object]:
     return await asyncio.to_thread(index.queue_summary)
 
@@ -744,8 +700,9 @@ async def _index_recent_events_async(index: object, limit: int):
 
 
 async def stats(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
-    return web.json_response(await _index_stats_async(index))
+    return web.json_response(await _relay_stats_async(config, index))
 
 
 async def queue(request: web.Request) -> web.Response:
@@ -800,7 +757,7 @@ async def badge_status(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
     stats_payload, system_payload = await asyncio.gather(
-        _index_stats_async(index), asyncio.to_thread(_system_metrics_snapshot, config)
+        _relay_stats_async(config, index), asyncio.to_thread(_system_metrics_snapshot, config)
     )
     return web.json_response(
         _status_badge_payload(
@@ -811,9 +768,20 @@ async def badge_status(request: web.Request) -> web.Response:
     )
 
 
-async def badge_mirrored(request: web.Request) -> web.Response:
+async def badge_dump_files(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
-    return web.json_response(_mirrored_badge_payload(stats=await _index_stats_async(index)))
+    return web.json_response(
+        _dump_files_badge_payload(stats=await _relay_stats_async(config, index))
+    )
+
+
+async def badge_archive_hours(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
+    index = request.app[INDEX_APP_KEY]
+    return web.json_response(
+        _archive_hours_badge_payload(stats=await _relay_stats_async(config, index))
+    )
 
 
 async def badge_cpu_svg(request: web.Request) -> web.Response:
@@ -887,7 +855,7 @@ async def badge_status_svg(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
     stats_payload, system_payload = await asyncio.gather(
-        _index_stats_async(index), asyncio.to_thread(_system_metrics_snapshot, config)
+        _relay_stats_async(config, index), asyncio.to_thread(_system_metrics_snapshot, config)
     )
     return _badge_svg_response(
         _status_badge_payload(
@@ -902,7 +870,7 @@ async def badge_upstream(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
     stats_payload, queue_payload = await asyncio.gather(
-        _index_stats_async(index), _index_queue_summary_async(index)
+        _relay_stats_async(config, index), _index_queue_summary_async(index)
     )
     return web.json_response(
         _upstream_badge_payload(
@@ -913,11 +881,27 @@ async def badge_upstream(request: web.Request) -> web.Response:
     )
 
 
+async def badge_upstream_r2(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
+    index = request.app[INDEX_APP_KEY]
+    stats_payload, queue_payload = await asyncio.gather(
+        _relay_stats_async(config, index), _index_queue_summary_async(index)
+    )
+    return web.json_response(
+        _upstream_badge_payload(
+            stats=stats_payload,
+            queue=queue_payload,
+            config=config,
+            raw_base_url="https://r2.pmxt.dev",
+        )
+    )
+
+
 async def badge_upstream_svg(request: web.Request) -> web.Response:
     config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
     stats_payload, queue_payload = await asyncio.gather(
-        _index_stats_async(index), _index_queue_summary_async(index)
+        _relay_stats_async(config, index), _index_queue_summary_async(index)
     )
     return _badge_svg_response(
         _upstream_badge_payload(
@@ -928,34 +912,43 @@ async def badge_upstream_svg(request: web.Request) -> web.Response:
     )
 
 
-async def badge_mirrored_svg(request: web.Request) -> web.Response:
+async def badge_upstream_r2_svg(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
-    return _badge_svg_response(_mirrored_badge_payload(stats=await _index_stats_async(index)))
-
-
-async def badge_latest_file_svg(request: web.Request) -> web.Response:
-    index = request.app[INDEX_APP_KEY]
+    stats_payload, queue_payload = await asyncio.gather(
+        _relay_stats_async(config, index), _index_queue_summary_async(index)
+    )
     return _badge_svg_response(
-        _latest_file_badge_payload(queue=await _index_queue_summary_async(index))
+        _upstream_badge_payload(
+            stats=stats_payload,
+            queue=queue_payload,
+            config=config,
+            raw_base_url="https://r2.pmxt.dev",
+        )
     )
 
 
-async def badge_missing_hours_svg(request: web.Request) -> web.Response:
+async def badge_dump_files_svg(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
-    payload = await asyncio.to_thread(_missing_hours_badge_payload, index=index)
-    return _badge_svg_response(payload)
+    return _badge_svg_response(
+        _dump_files_badge_payload(stats=await _relay_stats_async(config, index))
+    )
 
 
-async def badge_empty_hours_svg(request: web.Request) -> web.Response:
+async def badge_archive_hours_svg(request: web.Request) -> web.Response:
+    config = request.app[CONFIG_APP_KEY]
     index = request.app[INDEX_APP_KEY]
-    payload = await asyncio.to_thread(_empty_hours_badge_payload, index=index)
-    return _badge_svg_response(payload)
+    return _badge_svg_response(
+        _archive_hours_badge_payload(stats=await _relay_stats_async(config, index))
+    )
 
 
-async def badge_error_hours_svg(request: web.Request) -> web.Response:
+async def badge_latest_hour_svg(request: web.Request) -> web.Response:
     index = request.app[INDEX_APP_KEY]
-    payload = await asyncio.to_thread(_error_hours_badge_payload, index=index)
-    return _badge_svg_response(payload)
+    return _badge_svg_response(
+        _latest_hour_badge_payload(queue=await _index_queue_summary_async(index))
+    )
 
 
 async def serve_raw(request: web.Request) -> web.StreamResponse:
@@ -989,11 +982,16 @@ def create_app(config: RelayConfig) -> web.Application:
     app.router.add_get("/v1/system", system_metrics)
     app.router.add_get("/v1/badge/status", badge_status)
     app.router.add_get("/v1/badge/upstream", badge_upstream)
-    app.router.add_get("/v1/badge/mirrored", badge_mirrored)
+    app.router.add_get("/v1/badge/upstream-r2", badge_upstream_r2)
+    app.router.add_get("/v1/badge/hour-files", badge_dump_files)
+    app.router.add_get("/v1/badge/hours-since-first", badge_archive_hours)
     app.router.add_get("/v1/badge/status.svg", badge_status_svg)
     app.router.add_get("/v1/badge/upstream.svg", badge_upstream_svg)
-    app.router.add_get("/v1/badge/mirrored.svg", badge_mirrored_svg)
-    app.router.add_get("/v1/badge/latest-file.svg", badge_latest_file_svg)
+    app.router.add_get("/v1/badge/upstream-r2.svg", badge_upstream_r2_svg)
+    app.router.add_get("/v1/badge/hour-files.svg", badge_dump_files_svg)
+    app.router.add_get("/v1/badge/hours-since-first.svg", badge_archive_hours_svg)
+    app.router.add_get("/v1/badge/latest-hour.svg", badge_latest_hour_svg)
+    app.router.add_get("/v1/badge/latest-file.svg", badge_latest_hour_svg)
     app.router.add_get("/v1/badge/cpu.svg", badge_cpu_svg)
     app.router.add_get("/v1/badge/load.svg", badge_load_svg)
     app.router.add_get("/v1/badge/mem.svg", badge_mem_svg)
@@ -1002,8 +1000,5 @@ def create_app(config: RelayConfig) -> web.Application:
     app.router.add_get("/v1/badge/api.svg", badge_api_svg)
     app.router.add_get("/v1/badge/worker.svg", badge_worker_svg)
     app.router.add_get("/v1/badge/mirroring.svg", badge_mirroring_svg)
-    app.router.add_get("/v1/badge/missing-hours.svg", badge_missing_hours_svg)
-    app.router.add_get("/v1/badge/empty-hours.svg", badge_empty_hours_svg)
-    app.router.add_get("/v1/badge/error-hours.svg", badge_error_hours_svg)
     app.router.add_get("/v1/raw/{filename:.*}", serve_raw)
     return app

--- a/pmxt_relay/cli.py
+++ b/pmxt_relay/cli.py
@@ -9,6 +9,7 @@ from aiohttp import web
 
 from pmxt_relay.api import create_app
 from pmxt_relay.config import RelayConfig
+from pmxt_relay.coverage import count_raw_dump_files, elapsed_archive_hours
 from pmxt_relay.index_db import RelayIndex
 from pmxt_relay.raw_mirror_verifier import verify_local_raw_mirror
 from pmxt_relay.worker import RelayWorker
@@ -88,7 +89,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "stats":
         with RelayIndex(config.db_path) as index:
             index.initialize(apply_maintenance=False)
-            print(json.dumps(index.stats(), indent=2, sort_keys=True))
+            payload = dict(index.stats())
+            dump_files_on_disk = count_raw_dump_files(config.raw_root)
+            payload.update(
+                {
+                    "archive_start_hour": config.archive_start_hour.isoformat(),
+                    "archive_hours": elapsed_archive_hours(start_hour=config.archive_start_hour),
+                    "dump_files_on_disk": dump_files_on_disk,
+                    "mirrored_hours": dump_files_on_disk,
+                }
+            )
+            print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
     if args.command == "verify-raw-mirror":

--- a/pmxt_relay/config.py
+++ b/pmxt_relay/config.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import os
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
+
+from pmxt_relay.coverage import PMXT_ARCHIVE_START_HOUR
+
+
+_DEFAULT_RAW_BASE_URLS = ("https://r2v2.pmxt.dev", "https://r2.pmxt.dev")
+_DEFAULT_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/Polymarket/v2"
 
 
 def _env_int(name: str, default: int) -> int:
@@ -22,6 +29,19 @@ def _env_csv(name: str, default: tuple[str, ...] = ()) -> tuple[str, ...]:
         return default
     parts = tuple(part.strip() for part in value.split(",") if part.strip())
     return parts or default
+
+
+def _env_utc_hour(name: str, default: datetime) -> datetime:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
 
 
 @dataclass(frozen=True)
@@ -64,6 +84,8 @@ class RelayConfig:
     verify_batch_size: int = 50
     trusted_proxy_ips: tuple[str, ...] = ("127.0.0.1", "::1")
     archive_sources: tuple[ArchiveSource, ...] = ()
+    raw_base_urls: tuple[str, ...] = ()
+    archive_start_hour: datetime = PMXT_ARCHIVE_START_HOUR
 
     @classmethod
     def from_env(cls) -> RelayConfig:
@@ -71,15 +93,24 @@ class RelayConfig:
         data_dir = Path(os.getenv("PMXT_RELAY_DATA_DIR", str(default_data_dir))).expanduser()
         archive_max_pages = _env_int("PMXT_RELAY_ARCHIVE_MAX_PAGES", 0)
         archive_sources = _env_archive_sources("PMXT_RELAY_ARCHIVE_SOURCES")
-        archive_listing_url = (os.getenv("PMXT_RELAY_ARCHIVE_LISTING_URL") or "").strip()
+        configured_raw_base_urls = _env_csv("PMXT_RELAY_RAW_BASE_URLS")
+        archive_listing_url = (
+            os.getenv("PMXT_RELAY_ARCHIVE_LISTING_URL") or _DEFAULT_ARCHIVE_LISTING_URL
+        ).strip()
         raw_base_url = (os.getenv("PMXT_RELAY_RAW_BASE_URL") or "").strip()
         if archive_sources:
             archive_listing_url = archive_sources[0].listing_url
             raw_base_url = archive_sources[0].raw_base_url
-        if not archive_listing_url:
-            raise ValueError("PMXT_RELAY_ARCHIVE_LISTING_URL is required.")
+        raw_base_urls = configured_raw_base_urls
+        if not raw_base_urls and archive_sources:
+            raw_base_urls = tuple(source.raw_base_url for source in archive_sources)
+        if not raw_base_urls and raw_base_url:
+            raw_base_urls = (raw_base_url.rstrip("/"),)
+        if not raw_base_urls:
+            raw_base_urls = _DEFAULT_RAW_BASE_URLS
+        raw_base_urls = tuple(url.rstrip("/") for url in raw_base_urls)
         if not raw_base_url:
-            raise ValueError("PMXT_RELAY_RAW_BASE_URL is required.")
+            raw_base_url = raw_base_urls[0]
         return cls(
             data_dir=data_dir,
             bind_host=os.getenv("PMXT_RELAY_BIND_HOST", "0.0.0.0"),
@@ -97,6 +128,10 @@ class RelayConfig:
             verify_batch_size=max(1, _env_int("PMXT_RELAY_VERIFY_BATCH_SIZE", 50)),
             trusted_proxy_ips=_env_csv("PMXT_RELAY_TRUSTED_PROXY_IPS", ("127.0.0.1", "::1")),
             archive_sources=archive_sources,
+            raw_base_urls=raw_base_urls,
+            archive_start_hour=_env_utc_hour(
+                "PMXT_RELAY_ARCHIVE_START_HOUR", PMXT_ARCHIVE_START_HOUR
+            ),
         )
 
     @property
@@ -107,6 +142,12 @@ class RelayConfig:
                 raw_base_url=self.raw_base_url.rstrip("/"),
             ),
         )
+
+    @property
+    def resolved_raw_base_urls(self) -> tuple[str, ...]:
+        if self.raw_base_urls:
+            return tuple(url.rstrip("/") for url in self.raw_base_urls)
+        return tuple(source.raw_base_url.rstrip("/") for source in self.resolved_archive_sources)
 
     @property
     def raw_root(self) -> Path:

--- a/pmxt_relay/coverage.py
+++ b/pmxt_relay/coverage.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pmxt_relay.storage import ARCHIVE_FILENAME_RE
+
+PMXT_ARCHIVE_START_HOUR = datetime(2026, 2, 21, 16, tzinfo=UTC)
+
+
+def floor_utc_hour(value: datetime) -> datetime:
+    return value.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
+
+
+def elapsed_archive_hours(
+    *, start_hour: datetime = PMXT_ARCHIVE_START_HOUR, now: datetime | None = None
+) -> int:
+    current = floor_utc_hour(datetime.now(UTC) if now is None else now)
+    start = floor_utc_hour(start_hour)
+    if current < start:
+        return 0
+    return int((current - start).total_seconds() // 3600) + 1
+
+
+def iter_archive_hours_desc(
+    *, start_hour: datetime = PMXT_ARCHIVE_START_HOUR, now: datetime | None = None
+):
+    current = floor_utc_hour(datetime.now(UTC) if now is None else now)
+    start = floor_utc_hour(start_hour)
+    while current >= start:
+        yield current
+        current -= timedelta(hours=1)
+
+
+def count_raw_dump_files(raw_root: Path) -> int:
+    if not raw_root.exists():
+        return 0
+    count = 0
+    for path in raw_root.rglob("polymarket_orderbook_*.parquet"):
+        if path.is_file() and ARCHIVE_FILENAME_RE.fullmatch(path.name):
+            count += 1
+    return count

--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -320,7 +320,13 @@ class RelayIndex:
         return self._run_with_lock_retry(operation)
 
     def upsert_discovered_hour(
-        self, filename: str, source_url: str, archive_page: int, *, source_priority: int = 0
+        self,
+        filename: str,
+        source_url: str,
+        archive_page: int,
+        *,
+        source_priority: int = 0,
+        allow_lower_priority_source: bool = False,
     ) -> bool:
         hour = parse_archive_hour(filename).isoformat()
         normalized_source_priority = max(0, source_priority)
@@ -397,6 +403,10 @@ class RelayIndex:
                       AND (
                         source_priority > ?
                         OR (
+                            ?
+                            AND source_url != ?
+                        )
+                        OR (
                             source_priority = ?
                             AND (
                                 archive_page != ?
@@ -420,6 +430,8 @@ class RelayIndex:
                         source_url,
                         filename,
                         normalized_source_priority,
+                        allow_lower_priority_source,
+                        source_url,
                         normalized_source_priority,
                         archive_page,
                         source_url,
@@ -487,6 +499,37 @@ class RelayIndex:
                     (source_prefix, min_hour, max_hour),
                 )
                 self._conn.execute("DELETE FROM current_archive_listing")
+            return cursor.rowcount
+
+        return self._run_with_lock_retry(operation)
+
+    def remove_unmirrored_rows_for_filenames(self, filenames: list[str]) -> int:
+        if not filenames:
+            return 0
+
+        def operation() -> int:
+            with self._conn:
+                self._conn.execute(
+                    "CREATE TEMP TABLE IF NOT EXISTS absent_archive_scrape "
+                    "(filename TEXT PRIMARY KEY)"
+                )
+                self._conn.execute("DELETE FROM absent_archive_scrape")
+                self._conn.executemany(
+                    "INSERT OR IGNORE INTO absent_archive_scrape (filename) VALUES (?)",
+                    ((filename,) for filename in filenames),
+                )
+                cursor = self._conn.execute(
+                    """
+                    DELETE FROM archive_hours
+                    WHERE mirror_status != 'ready'
+                      AND EXISTS (
+                        SELECT 1
+                        FROM absent_archive_scrape absent
+                        WHERE absent.filename = archive_hours.filename
+                      )
+                    """
+                )
+                self._conn.execute("DELETE FROM absent_archive_scrape")
             return cursor.rowcount
 
         return self._run_with_lock_retry(operation)

--- a/pmxt_relay/storage.py
+++ b/pmxt_relay/storage.py
@@ -7,6 +7,11 @@ from pathlib import Path
 ARCHIVE_FILENAME_RE = re.compile(r"^polymarket_orderbook_(\d{4}-\d{2}-\d{2}T\d{2})\.parquet$")
 
 
+def archive_filename_for_hour(hour: datetime) -> str:
+    normalized = hour.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
+    return f"polymarket_orderbook_{normalized:%Y-%m-%dT%H}.parquet"
+
+
 def parse_archive_hour(filename: str) -> datetime:
     match = ARCHIVE_FILENAME_RE.match(filename)
     if match is None:

--- a/pmxt_relay/systemd/pmxt-relay.env.example
+++ b/pmxt_relay/systemd/pmxt-relay.env.example
@@ -1,9 +1,8 @@
 PMXT_RELAY_DATA_DIR=/srv/pmxt-relay
 PMXT_RELAY_BIND_HOST=0.0.0.0
 PMXT_RELAY_BIND_PORT=8080
-PMXT_RELAY_ARCHIVE_SOURCES=https://archive.pmxt.dev/Polymarket/v2|https://r2v2.pmxt.dev,https://archive.pmxt.dev/Polymarket/v1|https://r2.pmxt.dev
-PMXT_RELAY_ARCHIVE_LISTING_URL=https://archive.pmxt.dev/Polymarket/v2
-PMXT_RELAY_RAW_BASE_URL=https://r2v2.pmxt.dev
+PMXT_RELAY_RAW_BASE_URLS=https://r2v2.pmxt.dev,https://r2.pmxt.dev
+PMXT_RELAY_ARCHIVE_START_HOUR=2026-02-21T16:00:00+00:00
 PMXT_RELAY_POLL_INTERVAL_SECS=900
 PMXT_RELAY_EVENT_RETENTION=50000
 PMXT_RELAY_API_RATE_LIMIT_PER_MINUTE=2400

--- a/pmxt_relay/worker.py
+++ b/pmxt_relay/worker.py
@@ -5,15 +5,16 @@ import os
 import shutil
 import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
 from pmxt_relay.config import RelayConfig
+from pmxt_relay.coverage import iter_archive_hours_desc
 from pmxt_relay.index_db import REMIRROR_CONTENT_CHANGED_REASON, RelayIndex
-from pmxt_relay.storage import raw_relative_path
+from pmxt_relay.storage import archive_filename_for_hour, raw_relative_path
 
 LOG = logging.getLogger(__name__)
 _MIRROR_404_QUARANTINE_AFTER = 3
@@ -21,6 +22,13 @@ _MIRROR_RETRY_BACKOFF_CAP_SECS = 6 * 3600
 _MIRROR_QUARANTINE_RETRY_SECS = 3600
 _VERIFY_HTTP_TIMEOUT_CAP_SECS = 2
 _MIN_NONEMPTY_RAW_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class _RawUrlCandidate:
+    source_url: str
+    source_priority: int
+    content_length: int | None
 
 
 class RelayWorker:
@@ -110,85 +118,138 @@ class RelayWorker:
         )
         return total
 
-    def _discover_archive_hours(self) -> int:
+    def _discover_archive_hours(self, *, now: datetime | None = None) -> int:
         discovered = 0
-        for source_priority, archive_source in enumerate(self._config.resolved_archive_sources):
-            discovered += self._discover_archive_source(
-                archive_listing_url=archive_source.listing_url,
-                raw_base_url=archive_source.raw_base_url,
-                source_priority=source_priority,
-            )
-        return discovered
-
-    def _discover_archive_source(
-        self, *, archive_listing_url: str, raw_base_url: str, source_priority: int
-    ) -> int:
-        discovered = 0
-        source_seen: list[str] = []
-        source_seen_set: set[str] = set()
-        page = 1
-        stale_pages = 0
-        while True:
-            if self._config.archive_max_pages is not None and page > self._config.archive_max_pages:
-                break
-            html = fetch_archive_page(archive_listing_url, page, self._config.http_timeout_secs)
-            filenames = extract_archive_filenames(html)
-            if not filenames:
-                break
-
-            page_new = 0
-            for filename in filenames:
-                if filename not in source_seen_set:
-                    source_seen.append(filename)
-                    source_seen_set.add(filename)
-                source_url = f"{raw_base_url}/{filename}"
-                if self._index.upsert_discovered_hour(
-                    filename, source_url, page, source_priority=source_priority
-                ):
-                    page_new += 1
-
-            discovered += page_new
-            if page_new == 0:
-                stale_pages += 1
-                if stale_pages >= self._config.archive_stale_pages:
-                    break
-            else:
-                self._record_event(
-                    level="INFO",
-                    event_type="discover_page",
-                    message=f"Discovered {page_new} new PMXT archive hours on page {page}",
-                    payload={
-                        "listing_url": archive_listing_url,
-                        "raw_base_url": raw_base_url,
-                        "page": page,
-                        "new_hours": page_new,
-                        "total_entries": len(filenames),
-                    },
+        probed = 0
+        available = 0
+        absent_filenames: list[str] = []
+        source_errors = 0
+        source_error_samples: list[dict[str, str]] = []
+        raw_base_urls = self._config.resolved_raw_base_urls
+        for hour in iter_archive_hours_desc(
+            start_hour=self._config.archive_start_hour,
+            now=now,
+        ):
+            probed += 1
+            filename = archive_filename_for_hour(hour)
+            best_candidate: _RawUrlCandidate | None = None
+            probe_error = False
+            for source_priority, raw_base_url in enumerate(raw_base_urls):
+                candidate_url = f"{raw_base_url}/{filename}"
+                try:
+                    exists, content_length = self._raw_url_probe(candidate_url)
+                except Exception as exc:
+                    source_errors += 1
+                    probe_error = True
+                    if len(source_error_samples) < 10:
+                        source_error_samples.append(
+                            {
+                                "filename": filename,
+                                "source_url": candidate_url,
+                                "error": str(exc),
+                            }
+                        )
+                        LOG.warning("Failed to probe %s: %s", candidate_url, exc)
+                    continue
+                if not exists:
+                    continue
+                candidate = _RawUrlCandidate(
+                    source_url=candidate_url,
+                    source_priority=source_priority,
+                    content_length=content_length,
                 )
-                stale_pages = 0
-            page += 1
+                if self._is_better_raw_candidate(candidate, best_candidate):
+                    best_candidate = candidate
+            if best_candidate is None:
+                if not probe_error:
+                    absent_filenames.append(filename)
+                continue
+            available += 1
+            if self._index.upsert_discovered_hour(
+                filename,
+                best_candidate.source_url,
+                0,
+                source_priority=best_candidate.source_priority,
+                allow_lower_priority_source=True,
+            ):
+                discovered += 1
 
-        removed = self._index.remove_source_rows_absent_from_listing(
-            raw_base_url=raw_base_url,
-            filenames=source_seen,
+        removed = self._index.remove_unmirrored_rows_for_filenames(absent_filenames)
+        self._record_event(
+            level="WARNING" if source_errors else "INFO",
+            event_type="discover_scrape",
+            message="Scraped PMXT raw archive URL patterns",
+            payload={
+                "start_hour": self._config.archive_start_hour.isoformat(),
+                "probed_hours": probed,
+                "available_hours": available,
+                "new_or_changed_hours": discovered,
+                "absent_hours": len(absent_filenames),
+                "removed_stale_unmirrored_rows": removed,
+                "source_errors": source_errors,
+                "source_error_samples": source_error_samples,
+                "raw_base_urls": list(raw_base_urls),
+            },
         )
         if removed > 0:
-            self._record_event(
-                level="WARNING",
-                event_type="archive_unlisted",
-                message=f"Removed {removed} stale PMXT archive rows absent from current listing",
-                payload={
-                    "listing_url": archive_listing_url,
-                    "raw_base_url": raw_base_url,
-                    "removed_hours": removed,
-                },
-            )
-            LOG.warning(
-                "Removed %s stale PMXT archive rows absent from current %s listing",
-                removed,
-                raw_base_url,
-            )
+            LOG.warning("Removed %s stale unmirrored PMXT archive rows after URL scrape", removed)
         return discovered
+
+    @staticmethod
+    def _is_better_raw_candidate(
+        candidate: _RawUrlCandidate, best_candidate: _RawUrlCandidate | None
+    ) -> bool:
+        if best_candidate is None:
+            return True
+        if candidate.content_length is not None and best_candidate.content_length is not None:
+            if candidate.content_length != best_candidate.content_length:
+                return candidate.content_length > best_candidate.content_length
+        if candidate.content_length is not None and best_candidate.content_length is None:
+            return True
+        if candidate.content_length is None and best_candidate.content_length is not None:
+            return False
+        return candidate.source_priority < best_candidate.source_priority
+
+    @staticmethod
+    def _content_length_from_headers(headers) -> int | None:  # type: ignore[no-untyped-def]
+        content_range = headers.get("Content-Range")
+        if content_range and "/" in content_range:
+            total = content_range.rsplit("/", 1)[1].strip()
+            if total and total != "*":
+                try:
+                    return int(total)
+                except ValueError:
+                    pass
+        length_value = headers.get("Content-Length")
+        if not length_value:
+            return None
+        try:
+            return int(length_value)
+        except ValueError:
+            return None
+
+    def _raw_url_probe(self, source_url: str) -> tuple[bool, int | None]:
+        head_request = Request(source_url, method="HEAD", headers={"User-Agent": "pmxt-relay/1.0"})
+        try:
+            with urlopen(head_request, timeout=self._config.http_timeout_secs) as response:
+                return True, self._content_length_from_headers(response.headers)
+        except HTTPError as exc:
+            if exc.code == 404:
+                return False, None
+            if exc.code not in {403, 405}:
+                raise
+
+        range_request = Request(
+            source_url,
+            headers={"User-Agent": "pmxt-relay/1.0", "Range": "bytes=0-0"},
+        )
+        try:
+            with urlopen(range_request, timeout=self._config.http_timeout_secs) as response:
+                return True, self._content_length_from_headers(response.headers)
+        except HTTPError as exc:
+            if exc.code == 404:
+                return False, None
+            raise
 
     def _adopt_local_raw_hours(self) -> int:
         if not self._initial_local_raw_adoption_complete:
@@ -226,7 +287,7 @@ class RelayWorker:
             filename,
             local_path=str(raw_path),
             content_length=byte_size,
-            source_url=f"{self._config.raw_base_url}/{filename}",
+            source_url=f"{self._config.resolved_raw_base_urls[0]}/{filename}",
         )
         if changed:
             row_count = self._read_parquet_row_count(raw_path)

--- a/scripts/_pmxt_raw_download.py
+++ b/scripts/_pmxt_raw_download.py
@@ -13,13 +13,18 @@ import pyarrow.parquet as pq
 from tqdm.auto import tqdm
 
 from pmxt_relay.archive import extract_archive_filenames, fetch_archive_page
-from pmxt_relay.storage import parse_archive_hour, raw_relative_path
+from pmxt_relay.coverage import PMXT_ARCHIVE_START_HOUR, floor_utc_hour
+from pmxt_relay.storage import archive_filename_for_hour, parse_archive_hour, raw_relative_path
 
 _USER_AGENT = "prediction-market-backtesting/1.0"
 _DEFAULT_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/Polymarket/v2"
 _DEFAULT_ARCHIVE_BASE_URL = "https://r2v2.pmxt.dev"
 _DEFAULT_V1_ARCHIVE_LISTING_URL = "https://archive.pmxt.dev/Polymarket/v1"
 _DEFAULT_V1_ARCHIVE_BASE_URL = "https://r2.pmxt.dev"
+_DEFAULT_ARCHIVE_SOURCES = (
+    (_DEFAULT_ARCHIVE_LISTING_URL, _DEFAULT_ARCHIVE_BASE_URL),
+    (_DEFAULT_V1_ARCHIVE_LISTING_URL, _DEFAULT_V1_ARCHIVE_BASE_URL),
+)
 _DEFAULT_RELAY_BASE_URL = "https://209-209-10-83.sslip.io"
 _DOWNLOAD_CHUNK_SIZE = 8 * 1024 * 1024
 _STATUS_REFRESH_SECS = 0.2
@@ -147,7 +152,7 @@ def _sort_filenames_newest_first(filenames: list[str]) -> list[str]:
 
 
 def _filename_for_hour(hour: datetime) -> str:
-    return f"polymarket_orderbook_{hour.strftime('%Y-%m-%dT%H')}.parquet"
+    return archive_filename_for_hour(hour)
 
 
 def _hour_range_filenames(*, start_hour: datetime, end_hour: datetime) -> list[str]:
@@ -183,6 +188,14 @@ def _archive_sources_from_args(
     archive_base_url: str,
 ) -> list[ArchiveSource]:
     if archive_sources is None:
+        if (
+            archive_listing_url == _DEFAULT_ARCHIVE_LISTING_URL
+            and archive_base_url == _DEFAULT_ARCHIVE_BASE_URL
+        ):
+            return [
+                ArchiveSource(listing_url.rstrip("/"), base_url.rstrip("/"))
+                for listing_url, base_url in _DEFAULT_ARCHIVE_SOURCES
+            ]
         return [ArchiveSource(archive_listing_url.rstrip("/"), archive_base_url.rstrip("/"))]
     normalized: list[ArchiveSource] = []
     seen: set[tuple[str, str]] = set()
@@ -218,6 +231,33 @@ def _archive_candidate_urls(
     ]
 
 
+def _ranked_archive_candidate_urls(
+    *,
+    filename: str,
+    archive_sources: list[ArchiveSource],
+    discovered_archive_base_urls: dict[str, str],
+    timeout_secs: int,
+) -> list[tuple[str, str]]:
+    candidates = _archive_candidate_urls(
+        filename=filename,
+        archive_sources=archive_sources,
+        discovered_archive_base_urls=discovered_archive_base_urls,
+    )
+    ranked: list[tuple[int, str, str, int]] = []
+    unknown: list[tuple[int, str, str]] = []
+    for index, (url, source_label) in enumerate(candidates):
+        size = _remote_content_length(url=url, timeout_secs=timeout_secs)
+        if size is None:
+            unknown.append((index, url, source_label))
+        else:
+            ranked.append((size, url, source_label, index))
+
+    ranked.sort(key=lambda item: (-item[0], item[3]))
+    return [(url, source_label) for _size, url, source_label, _index in ranked] + [
+        (url, source_label) for _index, url, source_label in unknown
+    ]
+
+
 def _candidate_urls(
     *,
     source: str,
@@ -225,8 +265,16 @@ def _candidate_urls(
     archive_sources: list[ArchiveSource],
     discovered_archive_base_urls: dict[str, str],
     relay_base_url: str,
+    timeout_secs: int | None = None,
 ) -> list[tuple[str, str]]:
     if source == "archive":
+        if timeout_secs is not None:
+            return _ranked_archive_candidate_urls(
+                filename=filename,
+                archive_sources=archive_sources,
+                discovered_archive_base_urls=discovered_archive_base_urls,
+                timeout_secs=timeout_secs,
+            )
         return _archive_candidate_urls(
             filename=filename,
             archive_sources=archive_sources,
@@ -235,18 +283,46 @@ def _candidate_urls(
     return [(_relay_url(relay_base_url, filename), f"relay:{relay_base_url.rstrip('/')}")]
 
 
-def _remote_content_length(*, url: str, timeout_secs: int) -> int | None:
-    request = Request(url, method="HEAD", headers={"User-Agent": _USER_AGENT})
+def _content_length_from_headers(headers) -> int | None:  # type: ignore[no-untyped-def]
+    value = headers.get("Content-Length")
+    if value is not None:
+        try:
+            return int(value)
+        except ValueError:
+            pass
+
+    content_range = headers.get("Content-Range")
+    if content_range is None or "/" not in content_range:
+        return None
+    total = content_range.rsplit("/", maxsplit=1)[-1]
+    if total == "*":
+        return None
     try:
+        return int(total)
+    except ValueError:
+        return None
+
+
+def _remote_content_length(*, url: str, timeout_secs: int) -> int | None:
+    try:
+        request = Request(url, method="HEAD", headers={"User-Agent": _USER_AGENT})
         with urlopen(request, timeout=timeout_secs) as response:
-            value = response.headers.get("Content-Length")
+            return _content_length_from_headers(response.headers)
+    except HTTPError as exc:
+        if exc.code not in {403, 405}:
+            return None
     except Exception:
         return None
-    if value is None:
-        return None
+
+    request = Request(
+        url,
+        method="GET",
+        headers={"User-Agent": _USER_AGENT, "Range": "bytes=0-0"},
+    )
     try:
-        return int(value)
-    except ValueError:
+        with urlopen(request, timeout=timeout_secs) as response:
+            return _content_length_from_headers(response.headers)
+    except Exception:
         return None
 
 
@@ -307,10 +383,10 @@ def _source_priority_summary(
     for source in source_sequence:
         if source == "archive":
             archive_labels = ", ".join(source.base_url.rstrip("/") for source in archive_sources)
-            parts.append(f"archive {archive_labels}")
+            parts.append(f"archive best-of {archive_labels}")
         else:
             parts.append(f"relay {relay_base_url.rstrip('/')}")
-    return "PMXT raw source: explicit priority (" + " -> ".join(parts) + ")"
+    return "PMXT raw source: direct hour probes (" + " -> ".join(parts) + ")"
 
 
 def _window_label_from_filenames(filenames: list[str]) -> tuple[str | None, str | None]:
@@ -562,52 +638,28 @@ def download_raw_hours(
     start_hour = _parse_hour_bound(start_time)
     end_hour = _parse_hour_bound(end_time)
     archive_missing_hours: list[str] = []
-    archive_listed_hours = 0
     discovered_archive_base_urls: dict[str, str] = {}
-    if start_hour is not None and end_hour is not None:
-        filenames = _hour_range_filenames(start_hour=start_hour, end_hour=end_hour)
-    else:
-        discovered_filenames: list[str] = []
-        discovered_seen: set[str] = set()
-        for archive_source in resolved_archive_sources:
-            source_filenames = discover_archive_filenames(
-                archive_listing_url=archive_source.listing_url,
-                timeout_secs=timeout_secs,
-                stale_pages=discovery_stale_pages,
-                max_pages=discovery_max_pages,
-            )
-            for filename in source_filenames:
-                if filename in discovered_seen:
-                    continue
-                discovered_archive_base_urls[filename] = archive_source.base_url
-                discovered_filenames.append(filename)
-                discovered_seen.add(filename)
-        discovered_filenames = _sort_filenames_newest_first(discovered_filenames)
-        discovered_filenames = _filter_filenames_to_window(
-            discovered_filenames, start_hour=start_hour, end_hour=end_hour
+    del discovery_stale_pages, discovery_max_pages
+
+    if start_hour is None:
+        start_hour = PMXT_ARCHIVE_START_HOUR
+    if end_hour is None:
+        end_hour = floor_utc_hour(datetime.now(UTC))
+    if start_hour > end_hour:
+        raise ValueError(
+            f"PMXT raw download window is empty: start_time {start_time!r} is after "
+            f"end_time {end_time!r}."
         )
-        archive_listed_hours = len(discovered_filenames)
-        if discovered_filenames:
-            filenames = list(discovered_filenames)
-            download_filenames = list(discovered_filenames)
-        else:
-            filenames = []
-            download_filenames = []
-    if start_hour is not None and end_hour is not None:
-        download_filenames = list(filenames)
+
+    filenames = _hour_range_filenames(start_hour=start_hour, end_hour=end_hour)
+    download_filenames = list(filenames)
+    archive_listed_hours = len(filenames)
     filenames = _sort_filenames_newest_first(filenames)
     download_filenames = _sort_filenames_newest_first(download_filenames)
     if not filenames:
-        if start_hour is not None and end_hour is not None and start_hour > end_hour:
-            raise ValueError(
-                f"PMXT raw download window is empty: start_time {start_time!r} is after "
-                f"end_time {end_time!r}."
-            )
         raise RuntimeError(
-            "No PMXT raw archive hours were discovered or selected. "
-            "Checked listings "
-            f"{[source.listing_url for source in resolved_archive_sources]!r}. "
-            "Pass --start-time/--end-time for an explicit window or check the archive listing URL."
+            "No PMXT raw archive hours were selected. "
+            "Pass --start-time/--end-time for an explicit non-empty window."
         )
 
     if show_progress:
@@ -664,6 +716,7 @@ def download_raw_hours(
                         archive_sources=resolved_archive_sources,
                         discovered_archive_base_urls=discovered_archive_base_urls,
                         relay_base_url=relay_base_url,
+                        timeout_secs=timeout_secs,
                     )
                 ]
                 refresh_reason = _existing_refresh_reason(
@@ -716,6 +769,7 @@ def download_raw_hours(
                     archive_sources=resolved_archive_sources,
                     discovered_archive_base_urls=discovered_archive_base_urls,
                     relay_base_url=relay_base_url,
+                    timeout_secs=timeout_secs,
                 )
                 for url, source_label in source_candidates:
                     try:

--- a/scripts/pmxt_download_raws.py
+++ b/scripts/pmxt_download_raws.py
@@ -30,10 +30,11 @@ def _parse_archive_source(value: str) -> tuple[str, str]:
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Download PMXT v2 raw archive hours into a local mirror. With no time "
-            "window, the script discovers all archive hours and downloads them "
-            "newest-first to the destination using archive first and relay as "
-            "fallback, then reports missing and zero-row local hours."
+            "Download PMXT raw archive hours into a local mirror. With no time "
+            "window, the script walks direct hourly filenames from the first PMXT "
+            "Polymarket raw hour through the current UTC hour, probes r2v2 and r2, "
+            "keeps the larger archive object when both exist, and uses relay as "
+            "fallback."
         )
     )
     parser.add_argument("--destination", type=Path, required=True)
@@ -46,7 +47,8 @@ def main() -> int:
         default=[],
         help=(
             "Archive source pair in LISTING_URL|RAW_BASE_URL form. May be repeated. "
-            "Defaults to PMXT Polymarket v2 first, then v1."
+            "The listing URL is retained for compatibility; direct downloads use "
+            "the raw base URL. Defaults to r2v2.pmxt.dev and r2.pmxt.dev."
         ),
     )
     parser.add_argument("--relay-base-url", default="https://209-209-10-83.sslip.io")
@@ -62,8 +64,18 @@ def main() -> int:
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--no-progress", action="store_true")
     parser.add_argument("--timeout-secs", type=int, default=60)
-    parser.add_argument("--discovery-stale-pages", type=int, default=1)
-    parser.add_argument("--discovery-max-pages", type=int, default=None)
+    parser.add_argument(
+        "--discovery-stale-pages",
+        type=int,
+        default=1,
+        help="Deprecated compatibility flag; direct-hour downloads do not read listings.",
+    )
+    parser.add_argument(
+        "--discovery-max-pages",
+        type=int,
+        default=None,
+        help="Deprecated compatibility flag; direct-hour downloads do not read listings.",
+    )
     args = parser.parse_args()
 
     archive_sources = args.archive_source or None

--- a/tests/test_pmxt_raw_download.py
+++ b/tests/test_pmxt_raw_download.py
@@ -97,6 +97,10 @@ def _empty_parquet_payload() -> bytes:
     return buffer.getvalue()
 
 
+def _window_kwargs(start: str = "2026-03-21T09", end: str = "2026-03-21T10") -> dict[str, str]:
+    return {"start_time": start, "end_time": end}
+
+
 def test_discover_archive_hours_reads_listing_pages(monkeypatch) -> None:
     pages = {
         1: (
@@ -133,18 +137,10 @@ def test_download_raw_hours_fetches_archive_then_relay_fallback(
     payload = _raw_parquet_payload()
     requested_urls: list[str] = []
 
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda **_: [
-            "polymarket_orderbook_2026-03-21T09.parquet",
-            "polymarket_orderbook_2026-03-21T10.parquet",
-        ],
-    )
-
     def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
         del timeout
-        requested_urls.append(request.full_url)
+        if request.get_method() != "HEAD":
+            requested_urls.append(request.full_url)
         if (
             request.full_url.endswith("2026-03-21T10.parquet")
             and "/v1/raw/" not in request.full_url
@@ -154,7 +150,9 @@ def test_download_raw_hours_fetches_archive_then_relay_fallback(
 
     monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
 
-    summary = raw_download.download_raw_hours(destination=tmp_path / "raws", show_progress=False)
+    summary = raw_download.download_raw_hours(
+        destination=tmp_path / "raws", show_progress=False, **_window_kwargs()
+    )
 
     assert summary.requested_hours == 2
     assert summary.downloaded_hours == 2
@@ -166,6 +164,7 @@ def test_download_raw_hours_fetches_archive_then_relay_fallback(
     }
     assert requested_urls == [
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
+        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
         "https://209-209-10-83.sslip.io/v1/raw/2026/03/21/polymarket_orderbook_2026-03-21T10.parquet",
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
     ]
@@ -185,20 +184,14 @@ def test_download_raw_hours_skips_existing_files(monkeypatch, tmp_path: Path) ->
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_filenames",
-        lambda **_: [
-            "polymarket_orderbook_2026-03-21T09.parquet",
-            "polymarket_orderbook_2026-03-21T10.parquet",
-        ],
-    )
-    monkeypatch.setattr(
-        raw_download,
         "urlopen",
         lambda request, timeout=60: _Response(payload),  # type: ignore[arg-type]
     )
     monkeypatch.setattr(raw_download, "_existing_refresh_reason", lambda **_: None)
 
-    summary = raw_download.download_raw_hours(destination=destination, show_progress=False)
+    summary = raw_download.download_raw_hours(
+        destination=destination, show_progress=False, **_window_kwargs()
+    )
 
     assert summary.downloaded_hours == 1
     assert summary.skipped_existing_hours == 1
@@ -221,12 +214,6 @@ def test_download_raw_hours_removes_stale_temp_files_before_skipping(
     pid_tmp_path = existing_path.with_name(f"{existing_path.name}.tmp.999999")
     pid_tmp_path.write_bytes(b"stale-pid-tmp")
 
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda **_: ["polymarket_orderbook_2026-03-21T09.parquet"],
-    )
-
     def fake_pid_is_active(pid: int) -> bool:
         del pid
         return False
@@ -239,7 +226,11 @@ def test_download_raw_hours_removes_stale_temp_files_before_skipping(
     monkeypatch.setattr(raw_download, "_existing_refresh_reason", lambda **_: None)
     monkeypatch.setattr(raw_download, "urlopen", unexpected_urlopen)
 
-    summary = raw_download.download_raw_hours(destination=destination, show_progress=False)
+    summary = raw_download.download_raw_hours(
+        destination=destination,
+        show_progress=False,
+        **_window_kwargs("2026-03-21T09", "2026-03-21T09"),
+    )
 
     assert summary.downloaded_hours == 0
     assert summary.skipped_existing_hours == 1
@@ -253,15 +244,6 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
 ) -> None:
     payload = _raw_parquet_payload()
     bars: list[_FakeTqdm] = []
-
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda **_: [
-            "polymarket_orderbook_2026-03-21T09.parquet",
-            "polymarket_orderbook_2026-03-21T10.parquet",
-        ],
-    )
 
     def fake_tqdm(*args, **kwargs):  # type: ignore[no-untyped-def]
         bar = _FakeTqdm(*args, **kwargs)
@@ -280,7 +262,9 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
     monkeypatch.setattr(raw_download, "tqdm", fake_tqdm)
     monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
 
-    summary = raw_download.download_raw_hours(destination=tmp_path / "raws", show_progress=True)
+    summary = raw_download.download_raw_hours(
+        destination=tmp_path / "raws", show_progress=True, **_window_kwargs()
+    )
 
     assert summary.downloaded_hours == 2
     assert len(bars) == 1
@@ -289,7 +273,7 @@ def test_download_raw_hours_progress_output_uses_short_hour_labels(
     captured = capsys.readouterr()
 
     assert (
-        "PMXT raw source: explicit priority (archive https://r2v2.pmxt.dev -> relay https://209-209-10-83.sslip.io)"
+        "PMXT raw source: direct hour probes (archive best-of https://r2v2.pmxt.dev, https://r2.pmxt.dev -> relay https://209-209-10-83.sslip.io)"
     ) in captured.out
     assert "window_start=2026-03-21T09" in captured.out
     assert "window_end=2026-03-21T10" in captured.out
@@ -308,15 +292,6 @@ def test_download_raw_hours_reports_404_as_archive_missing_and_accepts_empty_par
 ) -> None:
     empty_payload = _empty_parquet_payload()
 
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda **_: [
-            "polymarket_orderbook_2026-03-21T09.parquet",
-            "polymarket_orderbook_2026-03-21T10.parquet",
-        ],
-    )
-
     def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
         del timeout
         if request.full_url.endswith("2026-03-21T09.parquet"):
@@ -326,7 +301,10 @@ def test_download_raw_hours_reports_404_as_archive_missing_and_accepts_empty_par
     monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
 
     summary = raw_download.download_raw_hours(
-        destination=tmp_path / "raws", source_order=["archive"], show_progress=False
+        destination=tmp_path / "raws",
+        source_order=["archive"],
+        show_progress=False,
+        **_window_kwargs(),
     )
 
     assert summary.archive_missing_hours == ["2026-03-21T09:00:00+00:00"]
@@ -344,11 +322,6 @@ def test_download_raw_hours_progress_output_includes_failure_error(
 
     monkeypatch.setattr(
         raw_download,
-        "discover_archive_filenames",
-        lambda **_: ["polymarket_orderbook_2026-03-21T09.parquet"],
-    )
-    monkeypatch.setattr(
-        raw_download,
         "tqdm",
         lambda *args, **kwargs: bars.append(_FakeTqdm(*args, **kwargs)) or bars[-1],
     )  # type: ignore[func-returns-value]
@@ -360,7 +333,10 @@ def test_download_raw_hours_progress_output_includes_failure_error(
     monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
 
     summary = raw_download.download_raw_hours(
-        destination=tmp_path / "raws", source_order=["archive"], show_progress=True
+        destination=tmp_path / "raws",
+        source_order=["archive"],
+        show_progress=True,
+        **_window_kwargs("2026-03-21T09", "2026-03-21T09"),
     )
 
     assert summary.failed_hours == ["2026-03-21T09:00:00+00:00"]
@@ -368,64 +344,49 @@ def test_download_raw_hours_progress_output_includes_failure_error(
     assert any("failed" in line and "last_error=HTTP 503" in line for line in bars[0].writes)
 
 
-def test_download_raw_hours_ignores_unlisted_archive_gaps(monkeypatch, tmp_path: Path) -> None:
+def test_download_raw_hours_uses_direct_hour_window(monkeypatch, tmp_path: Path) -> None:
     payload = _raw_parquet_payload()
     requested_urls: list[str] = []
 
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda **_: [
-            "polymarket_orderbook_2026-03-21T09.parquet",
-            "polymarket_orderbook_2026-03-21T11.parquet",
-        ],
-    )
-
     def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
         del timeout
-        requested_urls.append(request.full_url)
+        if request.get_method() != "HEAD":
+            requested_urls.append(request.full_url)
         return _Response(payload, headers={"Content-Length": str(len(payload))})
 
     monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
 
     summary = raw_download.download_raw_hours(
-        destination=tmp_path / "raws", source_order=["archive"], show_progress=False
+        destination=tmp_path / "raws",
+        source_order=["archive"],
+        show_progress=False,
+        **_window_kwargs("2026-03-21T09", "2026-03-21T11"),
     )
 
-    assert summary.requested_hours == 2
-    assert summary.archive_listed_hours == 2
-    assert summary.downloaded_hours == 2
+    assert summary.requested_hours == 3
+    assert summary.archive_listed_hours == 3
+    assert summary.downloaded_hours == 3
     assert summary.failed_hours == []
     assert summary.missing_local_hours == []
     assert summary.archive_missing_hours == []
     assert requested_urls == [
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet",
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
         "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
     ]
 
 
-def test_download_raw_hours_combines_v1_and_v2_archive_sources(monkeypatch, tmp_path: Path) -> None:
-    payload = _raw_parquet_payload()
-    pages = {
-        "https://archive.pmxt.dev/Polymarket/v2": [
-            "polymarket_orderbook_2026-03-21T11.parquet",
-            "polymarket_orderbook_2026-03-21T10.parquet",
-        ],
-        "https://archive.pmxt.dev/Polymarket/v1": [
-            "polymarket_orderbook_2026-03-21T10.parquet",
-            "polymarket_orderbook_2026-03-21T09.parquet",
-        ],
-    }
+def test_download_raw_hours_keeps_larger_overlap_source(monkeypatch, tmp_path: Path) -> None:
+    small_payload = b"s" * 10
+    large_payload = b"l" * 20
     requested_urls: list[str] = []
-
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda archive_listing_url, **_: pages[archive_listing_url],  # type: ignore[no-untyped-def]
-    )
 
     def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
         del timeout
+        is_r2 = request.full_url.startswith("https://r2.pmxt.dev/")
+        payload = large_payload if is_r2 else small_payload
+        if request.get_method() == "HEAD":
+            return _Response(b"", headers={"Content-Length": str(len(payload))})
         requested_urls.append(request.full_url)
         return _Response(payload, headers={"Content-Length": str(len(payload))})
 
@@ -439,16 +400,19 @@ def test_download_raw_hours_combines_v1_and_v2_archive_sources(monkeypatch, tmp_
         ],
         source_order=["archive"],
         show_progress=False,
+        **_window_kwargs("2026-03-21T10", "2026-03-21T10"),
     )
 
-    assert summary.archive_listed_hours == 3
-    assert summary.requested_hours == 3
+    assert summary.archive_listed_hours == 1
+    assert summary.requested_hours == 1
     assert summary.archive_sources == ["https://r2v2.pmxt.dev", "https://r2.pmxt.dev"]
     assert requested_urls == [
-        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet",
-        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
-        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T09.parquet",
+        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T10.parquet",
     ]
+    downloaded = (
+        tmp_path / "raws" / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T10.parquet"
+    )
+    assert downloaded.read_bytes() == large_payload
 
 
 def test_download_raw_hours_refreshes_existing_when_upstream_is_larger(
@@ -462,11 +426,6 @@ def test_download_raw_hours_refreshes_existing_when_upstream_is_larger(
     existing_path.parent.mkdir(parents=True, exist_ok=True)
     existing_path.write_bytes(b"old")
 
-    monkeypatch.setattr(
-        raw_download,
-        "discover_archive_filenames",
-        lambda **_: ["polymarket_orderbook_2026-03-21T09.parquet"],
-    )
     monkeypatch.setattr(raw_download, "_local_raw_is_empty", lambda path: False)
 
     def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
@@ -478,7 +437,10 @@ def test_download_raw_hours_refreshes_existing_when_upstream_is_larger(
     monkeypatch.setattr(raw_download, "urlopen", fake_urlopen)
 
     summary = raw_download.download_raw_hours(
-        destination=destination, source_order=["archive"], show_progress=False
+        destination=destination,
+        source_order=["archive"],
+        show_progress=False,
+        **_window_kwargs("2026-03-21T09", "2026-03-21T09"),
     )
 
     assert summary.downloaded_hours == 1

--- a/tests/test_pmxt_relay_api.py
+++ b/tests/test_pmxt_relay_api.py
@@ -36,6 +36,7 @@ def _make_config(tmp_path: Path) -> RelayConfig:
         event_retention=1000,
         api_rate_limit_per_minute=2400,
         verify_batch_size=50,
+        raw_base_urls=("https://r2v2.pmxt.dev", "https://r2.pmxt.dev"),
     )
 
 
@@ -171,12 +172,20 @@ def test_active_api_has_no_processing_badge_routes(tmp_path: Path):
             processing_response = await client.get("/v1/badge/processing.svg")
             file_response = await client.get("/v1/badge/file.svg")
             rows_response = await client.get("/v1/badge/rows.svg")
+            mirrored_response = await client.get("/v1/badge/mirrored.svg")
+            missing_response = await client.get("/v1/badge/missing-hours.svg")
+            empty_response = await client.get("/v1/badge/empty-hours.svg")
+            error_response = await client.get("/v1/badge/error-hours.svg")
         finally:
             await client.close()
 
         assert processing_response.status == 404
         assert file_response.status == 404
         assert rows_response.status == 404
+        assert mirrored_response.status == 404
+        assert missing_response.status == 404
+        assert empty_response.status == 404
+        assert error_response.status == 404
 
     asyncio.run(scenario())
 
@@ -358,6 +367,23 @@ def test_upstream_badge_stays_online_for_fresh_unresolved_mirror_gaps(tmp_path: 
     assert payload["color"] == "brightgreen"
 
 
+def test_upstream_r2_badge_uses_separate_r2_label(tmp_path: Path):
+    config = _make_config(tmp_path)
+    now = datetime(2026, 4, 3, 20, 0, tzinfo=timezone.utc)
+
+    payload = _upstream_badge_payload(
+        stats={"last_event_at": (now - timedelta(minutes=1)).isoformat()},
+        queue={},
+        config=config,
+        raw_base_url="https://r2.pmxt.dev",
+        now=now,
+    )
+
+    assert payload["label"] == "r2.pmxt.dev"
+    assert payload["message"] == "online"
+    assert payload["color"] == "brightgreen"
+
+
 def test_upstream_badge_stays_online_for_backlog_with_old_latest_mirror(tmp_path: Path):
     config = _make_config(tmp_path)
     now = datetime(2026, 4, 3, 20, 0, tzinfo=timezone.utc)
@@ -400,7 +426,7 @@ def test_upstream_badge_uses_offline_for_stale_polling(tmp_path: Path):
     assert payload["color"] == "red"
 
 
-def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
+def test_latest_hour_badge_reports_latest_mirrored_hour(tmp_path: Path):
     async def scenario() -> None:
         config = _make_config(tmp_path)
         config.ensure_directories()
@@ -435,14 +461,18 @@ def test_latest_file_badge_reports_latest_mirrored_filename(tmp_path: Path):
         client = TestClient(server)
         await client.start_server()
         try:
-            response = await client.get("/v1/badge/latest-file.svg")
+            response = await client.get("/v1/badge/latest-hour.svg")
             payload = await response.text()
+            alias_response = await client.get("/v1/badge/latest-file.svg")
+            alias_payload = await alias_response.text()
         finally:
             await client.close()
 
         assert response.status == 200
-        assert "Latest file" in payload
-        assert "polymarket_orderbook_2026-03-21T13.parquet" in payload
+        assert alias_response.status == 200
+        assert "Latest hour" in payload
+        assert "2026-03-21T13" in payload
+        assert "Latest hour" in alias_payload
 
     asyncio.run(scenario())
 
@@ -459,11 +489,22 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
         )
         index.mark_mirrored(
             filename,
-            local_path=str(tmp_path / "hour.parquet"),
+            local_path=str(
+                config.raw_root
+                / "2026"
+                / "03"
+                / "21"
+                / "polymarket_orderbook_2026-03-21T12.parquet"
+            ),
             etag=None,
             content_length=1,
             last_modified=None,
         )
+        raw_path = (
+            config.raw_root / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T12.parquet"
+        )
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_path.write_bytes(b"raw-payload")
 
         server = TestServer(app)
         client = TestClient(server)
@@ -480,6 +521,8 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
         assert queue_response.status == 200
         assert sorted(stats_payload.keys()) == [
             "archive_hours",
+            "archive_start_hour",
+            "dump_files_on_disk",
             "last_error_at",
             "last_event_at",
             "mirror_errors",
@@ -487,6 +530,8 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
             "mirror_quarantined",
             "mirrored_hours",
         ]
+        assert stats_payload["dump_files_on_disk"] == 1
+        assert stats_payload["mirrored_hours"] == 1
         assert sorted(queue_payload.keys()) == [
             "latest_mirrored_filename",
             "latest_mirrored_hour",
@@ -504,108 +549,34 @@ def test_stats_and_queue_payloads_are_mirror_only(tmp_path: Path):
     asyncio.run(scenario())
 
 
-def test_missing_hours_badge_shows_count(tmp_path: Path):
+def test_simple_coverage_badges_use_disk_files_and_elapsed_hours(tmp_path: Path):
     async def scenario() -> None:
         config = _make_config(tmp_path)
         config.ensure_directories()
-        app = create_app(config)
-        index = app[INDEX_APP_KEY]
-        current_hour = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
-        two_hours_ago = current_hour - timedelta(hours=2)
-        earlier = f"polymarket_orderbook_{two_hours_ago:%Y-%m-%dT%H}.parquet"
-        ready = f"polymarket_orderbook_{current_hour:%Y-%m-%dT%H}.parquet"
-        index.upsert_discovered_hour(earlier, f"https://raw.example.com/{earlier}", 1)
-        index.upsert_discovered_hour(ready, f"https://raw.example.com/{ready}", 1)
-        index.mark_mirrored(
-            ready,
-            local_path=str(tmp_path / ready),
-            etag=None,
-            content_length=1,
-            last_modified=None,
+        raw_path = (
+            config.raw_root / "2026" / "03" / "21" / "polymarket_orderbook_2026-03-21T12.parquet"
         )
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_path.write_bytes(b"raw-payload")
 
-        server = TestServer(app)
-        client = TestClient(server)
-        await client.start_server()
-        try:
-            response = await client.get("/v1/badge/missing-hours.svg")
-            payload = await response.text()
-        finally:
-            await client.close()
-
-        assert response.status == 200
-        assert "Missing hours" in payload
-        assert "0/3" in payload
-
-    asyncio.run(scenario())
-
-
-def test_empty_hours_badge_shows_count(tmp_path: Path):
-    async def scenario() -> None:
-        config = _make_config(tmp_path)
-        config.ensure_directories()
         app = create_app(config)
-        index = app[INDEX_APP_KEY]
-        empty = "polymarket_orderbook_2026-03-21T12.parquet"
-        nonempty = "polymarket_orderbook_2026-03-21T13.parquet"
-        for filename in [empty, nonempty]:
-            index.upsert_discovered_hour(filename, f"https://raw.example.com/{filename}", 1)
-            index.mark_mirrored(
-                filename,
-                local_path=str(tmp_path / filename),
-                etag=None,
-                content_length=2 * 1024 * 1024,
-                last_modified=None,
-            )
-        index.update_row_count(empty, 0)
-        index.update_row_count(nonempty, 100)
-
         server = TestServer(app)
         client = TestClient(server)
         await client.start_server()
         try:
-            response = await client.get("/v1/badge/empty-hours.svg")
-            payload = await response.text()
+            dump_response = await client.get("/v1/badge/hour-files.svg")
+            hours_response = await client.get("/v1/badge/hours-since-first.svg")
+            dump_payload = await dump_response.text()
+            hours_payload = await hours_response.text()
         finally:
             await client.close()
 
-        assert response.status == 200
-        assert "Empty hours" in payload
-        assert "0/2" in payload
-
-    asyncio.run(scenario())
-
-
-def test_error_hours_badge_shows_listed_uncovered_count(tmp_path: Path):
-    async def scenario() -> None:
-        config = _make_config(tmp_path)
-        config.ensure_directories()
-        app = create_app(config)
-        index = app[INDEX_APP_KEY]
-        current_hour = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
-        previous_hour = current_hour - timedelta(hours=1)
-        pending = f"polymarket_orderbook_{previous_hour:%Y-%m-%dT%H}.parquet"
-        errored = f"polymarket_orderbook_{current_hour:%Y-%m-%dT%H}.parquet"
-        index.upsert_discovered_hour(pending, f"https://raw.example.com/{pending}", 1)
-        index.upsert_discovered_hour(errored, f"https://raw.example.com/{errored}", 1)
-        index.mark_mirror_retry(
-            errored,
-            error="HTTP 500",
-            next_retry_at=(current_hour + timedelta(hours=1)).isoformat(),
-        )
-
-        server = TestServer(app)
-        client = TestClient(server)
-        await client.start_server()
-        try:
-            response = await client.get("/v1/badge/error-hours.svg")
-            payload = await response.text()
-        finally:
-            await client.close()
-
-        assert response.status == 200
-        assert "Error hours" in payload
-        assert "2/2" in payload
+        assert dump_response.status == 200
+        assert hours_response.status == 200
+        assert "Hour files" in dump_payload
+        assert "1 files" in dump_payload
+        assert "Hours since first" in hours_payload
+        assert "#007ec6" in hours_payload
 
     asyncio.run(scenario())
 

--- a/tests/test_pmxt_relay_worker.py
+++ b/tests/test_pmxt_relay_worker.py
@@ -71,26 +71,27 @@ def test_discover_archive_hours_uses_multiple_archive_sources(tmp_path: Path, mo
                 raw_base_url="https://r2.pmxt.dev",
             ),
         ),
+        archive_start_hour=datetime(2026, 3, 21, 11, tzinfo=timezone.utc),
     )
-    pages = {
-        ("https://archive.pmxt.dev/Polymarket/v2", 1): (
-            '<a href="https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet">12</a>'
-        ),
-        ("https://archive.pmxt.dev/Polymarket/v2", 2): "",
-        ("https://archive.pmxt.dev/Polymarket/v1", 1): (
-            '<a href="https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet">11</a>'
-            '<a href="https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet">12</a>'
-        ),
-        ("https://archive.pmxt.dev/Polymarket/v1", 2): "",
+    existing_urls = {
+        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
+        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T11.parquet",
+        "https://r2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
     }
 
     monkeypatch.setattr(
-        "pmxt_relay.worker.fetch_archive_page",
-        lambda archive_listing_url, page, timeout_secs: pages[(archive_listing_url, page)],  # type: ignore[no-untyped-def]
+        RelayWorker,
+        "_raw_url_probe",
+        lambda self, source_url: (
+            source_url in existing_urls,
+            10 if source_url in existing_urls else None,
+        ),  # type: ignore[no-untyped-def]
     )
 
     with RelayWorker(config, reset_inflight=False) as worker:
-        discovered = worker._discover_archive_hours()
+        discovered = worker._discover_archive_hours(
+            now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc)
+        )
         rows = {
             row["filename"]: row
             for row in worker._index._fetchall("SELECT * FROM archive_hours ORDER BY filename")
@@ -130,27 +131,28 @@ def test_discover_archive_hours_does_not_downgrade_v2_overlap(tmp_path: Path, mo
                 raw_base_url="https://r2.pmxt.dev",
             ),
         ),
+        archive_start_hour=datetime(2026, 3, 21, 12, tzinfo=timezone.utc),
     )
     filename = "polymarket_orderbook_2026-03-21T12.parquet"
-    pages = {
-        ("https://archive.pmxt.dev/Polymarket/v2", 1): (
-            f'<a href="https://r2v2.pmxt.dev/{filename}">12</a>'
-        ),
-        ("https://archive.pmxt.dev/Polymarket/v2", 2): "",
-        ("https://archive.pmxt.dev/Polymarket/v1", 1): (
-            f'<a href="https://r2.pmxt.dev/{filename}">12</a>'
-        ),
-        ("https://archive.pmxt.dev/Polymarket/v1", 2): "",
+    existing_urls = {
+        f"https://r2v2.pmxt.dev/{filename}",
+        f"https://r2.pmxt.dev/{filename}",
     }
 
-    monkeypatch.setattr(
-        "pmxt_relay.worker.fetch_archive_page",
-        lambda archive_listing_url, page, timeout_secs: pages[(archive_listing_url, page)],  # type: ignore[no-untyped-def]
-    )
+    def fake_raw_url_probe(self, source_url):  # type: ignore[no-untyped-def]
+        return source_url in existing_urls, 10 if source_url in existing_urls else None
+
+    monkeypatch.setattr(RelayWorker, "_raw_url_probe", fake_raw_url_probe)
 
     with RelayWorker(config, reset_inflight=False) as worker:
-        assert worker._discover_archive_hours() == 1
-        assert worker._discover_archive_hours() == 0
+        assert (
+            worker._discover_archive_hours(now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc))
+            == 1
+        )
+        assert (
+            worker._discover_archive_hours(now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc))
+            == 0
+        )
         row = worker._index._conn.execute(
             "SELECT source_url, source_priority FROM archive_hours WHERE filename = ?",
             (filename,),
@@ -159,6 +161,55 @@ def test_discover_archive_hours_does_not_downgrade_v2_overlap(tmp_path: Path, mo
     assert row is not None
     assert row["source_url"] == f"https://r2v2.pmxt.dev/{filename}"
     assert row["source_priority"] == 0
+
+
+def test_discover_archive_hours_keeps_larger_overlap_file(tmp_path: Path, monkeypatch) -> None:
+    config = RelayConfig(
+        data_dir=tmp_path,
+        bind_host="127.0.0.1",
+        bind_port=8080,
+        archive_listing_url="https://archive.pmxt.dev/Polymarket/v2",
+        raw_base_url="https://r2v2.pmxt.dev",
+        poll_interval_secs=900,
+        http_timeout_secs=30,
+        archive_stale_pages=1,
+        archive_max_pages=None,
+        event_retention=1000,
+        api_rate_limit_per_minute=2400,
+        verify_batch_size=50,
+        raw_base_urls=("https://r2v2.pmxt.dev", "https://r2.pmxt.dev"),
+        archive_start_hour=datetime(2026, 3, 21, 12, tzinfo=timezone.utc),
+    )
+    filename = "polymarket_orderbook_2026-03-21T12.parquet"
+    sizes = {
+        f"https://r2v2.pmxt.dev/{filename}": 4 * 1024 * 1024,
+        f"https://r2.pmxt.dev/{filename}": 9 * 1024 * 1024,
+    }
+
+    def fake_raw_url_probe(self, source_url):  # type: ignore[no-untyped-def]
+        return source_url in sizes, sizes.get(source_url)
+
+    monkeypatch.setattr(RelayWorker, "_raw_url_probe", fake_raw_url_probe)
+
+    with RelayWorker(config, reset_inflight=False) as worker:
+        worker._index.upsert_discovered_hour(
+            filename,
+            f"https://r2v2.pmxt.dev/{filename}",
+            0,
+            source_priority=0,
+        )
+        assert (
+            worker._discover_archive_hours(now=datetime(2026, 3, 21, 12, 30, tzinfo=timezone.utc))
+            == 1
+        )
+        row = worker._index._conn.execute(
+            "SELECT source_url, source_priority FROM archive_hours WHERE filename = ?",
+            (filename,),
+        ).fetchone()
+
+    assert row is not None
+    assert row["source_url"] == f"https://r2.pmxt.dev/{filename}"
+    assert row["source_priority"] == 1
 
 
 def test_mirror_hour_falls_back_to_get_when_head_is_rejected(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Redesigns PMXT relay archive coverage around direct hourly raw-file probing instead of tracking derived coverage states.

- Makes the relay worker walk hourly filenames from `2026-02-21T16:00:00Z` through the current floored UTC hour, probing `r2v2.pmxt.dev` and `r2.pmxt.dev` directly and keeping the larger object when both exist.
- Simplifies public coverage badges to split upstream badges, `Hour files`, `Hours since first`, and `Latest hour`, removing the old missing/empty/error/mirrored coverage badges.
- Applies the same direct-hour, larger-overlap behavior to `make download-pmxt-raws` while keeping relay fallback and existing-file refresh behavior.
- Updates relay and downloader docs plus env examples for the new source model.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mkdocs build --strict`
- `uv run pytest tests/ -q`
- Deployed relay changes to the live VPS and verified both services active plus `/healthz`, `/v1/system`, latest-hour/latest-file badges, and removed badge routes returning 404.
