### PR TITLE
fix(relay): commit schema-bootstrap UPDATE so worker can take WAL lock

### DIFF
--- a/pmxt_relay/index_db.py
+++ b/pmxt_relay/index_db.py
@@ -209,6 +209,11 @@ class RelayIndex:
             """,
             (_LEGACY_ACTIVE_STATUS,),
         )
+        # The UPDATE above runs inside Python's implicit deferred transaction;
+        # without an explicit commit the WAL write lock stays held for the life
+        # of the connection. On a fresh DB this blocks the worker process from
+        # acquiring its own write lock during initialize().
+        self._conn.commit()
 
     def _ensure_archive_column(self, sql: str) -> None:
         try:

--- a/tests/test_pmxt_relay_index_db.py
+++ b/tests/test_pmxt_relay_index_db.py
@@ -429,6 +429,9 @@ def test_initialize_tolerates_duplicate_column_race_during_schema_upgrade(tmp_pa
             def executescript(self, sql: str):  # type: ignore[no-untyped-def]
                 return self._wrapped.executescript(sql)
 
+            def commit(self) -> None:
+                self._wrapped.commit()
+
             def execute(self, sql: str, params=()):  # type: ignore[no-untyped-def]
                 if (
                     not self._raised
@@ -447,6 +450,43 @@ def test_initialize_tolerates_duplicate_column_race_during_schema_upgrade(tmp_pa
         }
         assert "last_error_at" in columns
         assert "next_retry_at" in columns
+
+
+def test_initialize_releases_write_lock_so_second_process_can_write(tmp_path: Path):
+    """Second writer (worker) must be able to take the WAL write lock after the
+    first writer (API) finishes initializing on a fresh DB. Regression: the
+    legacy-status UPDATE in `_ensure_schema` previously left an open implicit
+    transaction, holding the WAL write lock for the lifetime of the connection
+    and silently deadlocking the worker on a fresh database.
+    """
+    db_path = tmp_path / "relay.sqlite3"
+
+    api_index = RelayIndex(db_path)
+    api_index.initialize(apply_maintenance=False)
+    try:
+        worker_conn = sqlite3.connect(db_path, timeout=2)
+        try:
+            worker_conn.execute("PRAGMA busy_timeout=2000")
+            worker_conn.execute("PRAGMA journal_mode=WAL")
+            with worker_conn:
+                worker_conn.execute(
+                    "INSERT INTO archive_hours "
+                    "(filename, hour, source_url, archive_page, discovered_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        "polymarket_orderbook_2026-03-21T12.parquet",
+                        "2026-03-21T12:00:00+00:00",
+                        "https://r2v2.pmxt.dev/polymarket_orderbook_2026-03-21T12.parquet",
+                        1,
+                        "2026-03-21T12:00:00+00:00",
+                    ),
+                )
+            (count,) = worker_conn.execute("SELECT COUNT(*) FROM archive_hours").fetchone()
+            assert count == 1
+        finally:
+            worker_conn.close()
+    finally:
+        api_index.close()
 
 
 def test_list_hours_needing_verification_returns_oldest_first(tmp_path: Path):


### PR DESCRIPTION
## Summary

- Fix a fresh-DB deadlock in `pmxt_relay/index_db.py::_ensure_schema`: the legacy-status `UPDATE` ran inside Python's implicit deferred transaction with no commit, so the WAL write lock was held for the lifetime of the connection. On a fresh DB the API process initialized first, took the lock, and silently deadlocked the worker — the worker sat in `nanosleep` indefinitely producing zero discoveries and zero mirrored files.
- Add `self._conn.commit()` immediately after the UPDATE.
- Add a regression test (`test_initialize_releases_write_lock_so_second_process_can_write`) that opens a second sqlite3 connection with a 2 s `busy_timeout` and verifies it can write to `archive_hours` right after `initialize()` returns. Without the fix this fails with `database is locked`.
- Add `commit()` to the `_DuplicateColumnRaceConn` mock so the existing race test still passes.

## Symptom we hit

After a full wipe of the VPS relay state, the worker produced no DB rows for >8 minutes. `/proc/PID/stack` showed `hrtimer_nanosleep`; `/proc/locks` showed the API holding a POSIX advisory write lock on shm byte 120. Hot-patched the VPS via `sed`, observed immediate discovery + mirroring; this PR replaces that hot-patch with the proper fix.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -q` (383 passed, 1 skipped)
- [x] New regression test fails without the commit fix and passes with it
- [x] Deploy to VPS, verify `/healthz` + `/v1/stats`, observe steady mirror progression

🤖 Generated with [Claude Code](https://claude.com/claude-code)