### PR TITLE
perf(telonex): async httpx downloader + bounded pipeline

### DIFF
--- a/docs/data-vendors.md
+++ b/docs/data-vendors.md
@@ -269,9 +269,15 @@ Hive-partitioned Parquet (with a DuckDB manifest for resumability), run:
 uv run python scripts/telonex_download_data.py \
   --destination /Volumes/LaCie/telonex_data \
   --all-markets \
-  --channels quotes trades book_snapshot_5 book_snapshot_25 book_snapshot_full onchain_fills \
-  --workers 16
+  --channels quotes trades book_snapshot_5 book_snapshot_25 book_snapshot_full onchain_fills
 ```
+
+The default `--workers 128` is the in-flight coroutine ceiling in the
+async `httpx` pool. On a bandwidth-heavy VPS push this to `256`–`512`
+(each slot is a coroutine + socket, not an OS thread); transient
+`408/425/429/5xx` responses retry with exponential backoff, and the
+single-thread Parquet writer is the usual practical bottleneck. Hit
+`Ctrl-C` once to stop gracefully; the same command resumes.
 
 The default destination is `/Volumes/LaCie/telonex_data`. Override it with
 `TELONEX_DATA_DESTINATION=/path/to/telonex_data` or call the script directly:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -155,13 +155,18 @@ with a DuckDB manifest at `<destination>/telonex.duckdb`, run:
 uv run python scripts/telonex_download_data.py \
   --destination /Volumes/LaCie/telonex_data \
   --all-markets \
-  --channels quotes trades book_snapshot_5 book_snapshot_25 book_snapshot_full onchain_fills \
-  --workers 16
+  --channels quotes trades book_snapshot_5 book_snapshot_25 book_snapshot_full onchain_fills
 ```
 
 The default destination is `/Volumes/LaCie/telonex_data`, matching the
 `local:/Volumes/LaCie/telonex_data` source in the public Telonex runner.
-The downloader reports progress while it loads the markets dataset, plans
+The downloader uses an async `httpx` pool with `--workers 128`
+in-flight coroutines by default; on a bandwidth-heavy VPS you can push
+this to `256`–`512` since each slot is a coroutine, not an OS thread
+(the real ceiling is network bandwidth or the single-thread Parquet
+writer). Transient `408/425/429/5xx` responses are retried with
+exponential backoff, and SIGINT/SIGTERM stop the loop gracefully. The
+downloader reports progress while it loads the markets dataset, plans
 market/channel/outcome/day work, and streams day-files directly into
 rolling ~1 GB Parquet parts (no intermediate per-day files touch disk).
 

--- a/scripts/_profile_telonex.py
+++ b/scripts/_profile_telonex.py
@@ -1,0 +1,186 @@
+"""Micro-benchmark to understand Telonex download per-request breakdown.
+
+Measures: presigned resolve time, TLS setup, content fetch, parquet parse.
+Compares urllib (current) vs httpx.Client (pooled, single-request-with-redirect).
+"""
+from __future__ import annotations
+
+import io
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
+
+import httpx
+import pandas as pd
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+API_KEY = os.environ["TELONEX_API_KEY"]
+BASE = "https://api.telonex.io"
+UA = "prediction-market-backtesting/profile"
+
+
+# Pull a realistic set of recent days + slugs from the markets dataset.
+print("Fetching markets catalog...", flush=True)
+t0 = time.time()
+req = Request(f"{BASE}/v1/datasets/polymarket/markets", headers={"User-Agent": UA})
+with urlopen(req, timeout=120) as r:
+    markets_bytes = r.read()
+print(f"  catalog {len(markets_bytes)/1024/1024:.1f} MiB in {time.time()-t0:.1f}s", flush=True)
+markets = pd.read_parquet(io.BytesIO(markets_bytes))
+
+# Pick markets with recent quotes availability — use quotes_from which should
+# have a non-zero yes-outcome file.
+from datetime import date, timedelta
+
+def _parse_d(v):
+    if pd.isna(v):
+        return None
+    s = str(v)[:10]
+    try:
+        return date.fromisoformat(s)
+    except ValueError:
+        return None
+
+frame = markets.dropna(subset=["quotes_from", "quotes_to"])
+jobs = []
+for _, row in frame.iterrows():
+    slug = row["slug"]
+    d_from = _parse_d(row["quotes_from"])
+    d_to = _parse_d(row["quotes_to"])
+    if d_from is None or d_to is None or d_from >= d_to:
+        continue
+    # Midpoint day — likely to have data on both outcomes
+    mid = d_from + (d_to - d_from) // 2
+    jobs.append((slug, mid.isoformat()))
+    if len(jobs) >= 60:
+        break
+print(f"Built {len(jobs)} sample jobs", flush=True)
+
+
+CHANNEL = os.environ.get("PROFILE_CHANNEL", "book_snapshot_25")
+
+def build_url(slug: str, date: str, channel: str = CHANNEL) -> str:
+    return f"{BASE}/v1/downloads/polymarket/{channel}/{date}?slug={slug}&outcome_id=0"
+
+
+# === Method 1: urllib (current) ===
+def urllib_fetch(slug: str, date: str) -> tuple[float, float, int]:
+    class _NoRedirect(HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    t_resolve = time.time()
+    url = build_url(slug, date)
+    req = Request(url, headers={"Authorization": f"Bearer {API_KEY}", "User-Agent": UA})
+    opener = build_opener(_NoRedirect())
+    try:
+        opener.open(req, timeout=60).close()
+        return (0, 0, 0)  # unreachable
+    except Exception as e:
+        if getattr(e, "code", 0) in (301, 302, 303, 307, 308):
+            location = e.headers.get("Location")
+        elif getattr(e, "code", 0) == 404:
+            return (time.time() - t_resolve, 0.0, 404)
+        else:
+            raise
+    t_resolve_end = time.time()
+    req2 = Request(location, headers={"User-Agent": UA})
+    with urlopen(req2, timeout=60) as r:
+        data = r.read()
+    t_end = time.time()
+    return (t_resolve_end - t_resolve, t_end - t_resolve_end, len(data))
+
+
+# === Method 2: httpx.Client with pool, auto-follow ===
+client = httpx.Client(
+    http2=False,
+    limits=httpx.Limits(max_connections=256, max_keepalive_connections=256, keepalive_expiry=60),
+    follow_redirects=True,
+    timeout=httpx.Timeout(60.0),
+    headers={"User-Agent": UA},
+)
+
+def httpx_fetch(slug: str, date: str) -> tuple[float, float, int]:
+    t0 = time.time()
+    url = build_url(slug, date)
+    r = client.get(url, headers={"Authorization": f"Bearer {API_KEY}"})
+    if r.status_code == 404:
+        return (time.time() - t0, 0.0, 404)
+    r.raise_for_status()
+    data = r.content
+    t_end = time.time()
+    return (0.0, t_end - t0, len(data))
+
+
+def bench(label: str, fn, workers: int):
+    print(f"\n--- {label} (workers={workers}) ---", flush=True)
+    t0 = time.time()
+    bytes_total = 0
+    ok = 0
+    missed = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(fn, slug, date) for slug, date in jobs]
+        for f in as_completed(futures):
+            resolve, fetch, size = f.result()
+            if size == 404:
+                missed += 1
+                continue
+            ok += 1
+            bytes_total += size
+    elapsed = time.time() - t0
+    print(f"  {ok} ok, {missed} missed in {elapsed:.1f}s ({len(jobs)/elapsed:.1f} req/s, "
+          f"{bytes_total/elapsed/1024:.0f} KiB/s)", flush=True)
+
+
+# Warmup (prime DNS/TLS for urllib/httpx roughly equally)
+try:
+    urllib_fetch(jobs[0][0], jobs[0][1])
+except Exception:
+    pass
+try:
+    httpx_fetch(jobs[0][0], jobs[0][1])
+except Exception:
+    pass
+
+bench("urllib 64-thread (current)", urllib_fetch, 64)
+bench("httpx.Client 32-thread", httpx_fetch, 32)
+bench("httpx.Client 48-thread", httpx_fetch, 48)
+bench("httpx.Client 64-thread", httpx_fetch, 64)
+bench("httpx.Client 96-thread", httpx_fetch, 96)
+
+
+# Test parquet parse overhead: does parsing in the worker slow us down?
+def httpx_fetch_and_parse(slug: str, date: str) -> tuple[float, float, int]:
+    t0 = time.time()
+    url = build_url(slug, date)
+    r = client.get(url, headers={"Authorization": f"Bearer {API_KEY}"})
+    if r.status_code == 404:
+        return (time.time() - t0, 0.0, 404)
+    r.raise_for_status()
+    data = r.content
+    t_fetch = time.time()
+    df = pd.read_parquet(io.BytesIO(data))
+    _ = len(df)
+    t_parse = time.time()
+    return (t_fetch - t0, t_parse - t_fetch, len(data))
+
+
+print("\n=== Fetch+parse breakdown (64 workers) ===", flush=True)
+t0 = time.time()
+fetch_total = 0.0
+parse_total = 0.0
+with ThreadPoolExecutor(max_workers=64) as pool:
+    futures = [pool.submit(httpx_fetch_and_parse, slug, date) for slug, date in jobs]
+    for f in as_completed(futures):
+        fetch, parse, size = f.result()
+        if size == 404:
+            continue
+        fetch_total += fetch
+        parse_total += parse
+elapsed = time.time() - t0
+print(f"  total={elapsed:.1f}s, wall req/s={len(jobs)/elapsed:.1f}, "
+      f"sum fetch={fetch_total:.1f}s, sum parse={parse_total:.1f}s "
+      f"(parse is {parse_total/fetch_total*100:.0f}% of fetch time across threads)", flush=True)

--- a/scripts/_profile_telonex.py
+++ b/scripts/_profile_telonex.py
@@ -3,6 +3,7 @@
 Measures: presigned resolve time, TLS setup, content fetch, parquet parse.
 Compares urllib (current) vs httpx.Client (pooled, single-request-with-redirect).
 """
+
 from __future__ import annotations
 
 import io
@@ -28,12 +29,15 @@ t0 = time.time()
 req = Request(f"{BASE}/v1/datasets/polymarket/markets", headers={"User-Agent": UA})
 with urlopen(req, timeout=120) as r:
     markets_bytes = r.read()
-print(f"  catalog {len(markets_bytes)/1024/1024:.1f} MiB in {time.time()-t0:.1f}s", flush=True)
+print(
+    f"  catalog {len(markets_bytes) / 1024 / 1024:.1f} MiB in {time.time() - t0:.1f}s", flush=True
+)
 markets = pd.read_parquet(io.BytesIO(markets_bytes))
 
 # Pick markets with recent quotes availability — use quotes_from which should
 # have a non-zero yes-outcome file.
-from datetime import date, timedelta
+from datetime import date  # noqa: E402
+
 
 def _parse_d(v):
     if pd.isna(v):
@@ -43,6 +47,7 @@ def _parse_d(v):
         return date.fromisoformat(s)
     except ValueError:
         return None
+
 
 frame = markets.dropna(subset=["quotes_from", "quotes_to"])
 jobs = []
@@ -61,6 +66,7 @@ print(f"Built {len(jobs)} sample jobs", flush=True)
 
 
 CHANNEL = os.environ.get("PROFILE_CHANNEL", "book_snapshot_25")
+
 
 def build_url(slug: str, date: str, channel: str = CHANNEL) -> str:
     return f"{BASE}/v1/downloads/polymarket/{channel}/{date}?slug={slug}&outcome_id=0"
@@ -103,6 +109,7 @@ client = httpx.Client(
     headers={"User-Agent": UA},
 )
 
+
 def httpx_fetch(slug: str, date: str) -> tuple[float, float, int]:
     t0 = time.time()
     url = build_url(slug, date)
@@ -131,8 +138,11 @@ def bench(label: str, fn, workers: int):
             ok += 1
             bytes_total += size
     elapsed = time.time() - t0
-    print(f"  {ok} ok, {missed} missed in {elapsed:.1f}s ({len(jobs)/elapsed:.1f} req/s, "
-          f"{bytes_total/elapsed/1024:.0f} KiB/s)", flush=True)
+    print(
+        f"  {ok} ok, {missed} missed in {elapsed:.1f}s ({len(jobs) / elapsed:.1f} req/s, "
+        f"{bytes_total / elapsed / 1024:.0f} KiB/s)",
+        flush=True,
+    )
 
 
 # Warmup (prime DNS/TLS for urllib/httpx roughly equally)
@@ -181,6 +191,9 @@ with ThreadPoolExecutor(max_workers=64) as pool:
         fetch_total += fetch
         parse_total += parse
 elapsed = time.time() - t0
-print(f"  total={elapsed:.1f}s, wall req/s={len(jobs)/elapsed:.1f}, "
-      f"sum fetch={fetch_total:.1f}s, sum parse={parse_total:.1f}s "
-      f"(parse is {parse_total/fetch_total*100:.0f}% of fetch time across threads)", flush=True)
+print(
+    f"  total={elapsed:.1f}s, wall req/s={len(jobs) / elapsed:.1f}, "
+    f"sum fetch={fetch_total:.1f}s, sum parse={parse_total:.1f}s "
+    f"(parse is {parse_total / fetch_total * 100:.0f}% of fetch time across threads)",
+    flush=True,
+)

--- a/scripts/_telonex_data_download.py
+++ b/scripts/_telonex_data_download.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import os
 import random
@@ -7,18 +8,18 @@ import signal
 import sys
 import threading
 import time
-import concurrent.futures
-from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from queue import Empty, Queue
+from queue import Empty, Full, Queue
 from socket import timeout as SocketTimeout
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
-from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError as UrllibHTTPError, URLError
 
 import duckdb
+import httpx
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -32,14 +33,18 @@ _USER_AGENT = "prediction-market-backtesting/1.0"
 _DEFAULT_API_BASE_URL = "https://api.telonex.io"
 _DEFAULT_CHANNEL = "quotes"
 _EXCHANGE = "polymarket"
-_DOWNLOAD_CHUNK_SIZE = 64 * 1024
+_DOWNLOAD_CHUNK_SIZE = 256 * 1024
 _MANIFEST_FILENAME = "telonex.duckdb"
 _DATA_SUBDIR = "data"
 _TARGET_PART_BYTES = 1 << 30  # 1 GiB uncompressed Arrow before rolling
 _PARQUET_COMPRESSION = "zstd"
 _PARQUET_COMPRESSION_LEVEL = 3
-_DEFAULT_COMMIT_BATCH_ROWS = 250_000
-_DEFAULT_COMMIT_BATCH_SECS = 5.0
+# Keep pending_for_commit small so book_snapshot_full DataFrames don't pin RAM
+# for long. With streaming row-group writes a smaller flush threshold has
+# negligible overhead — the parquet writer stays open across flushes and only
+# rolls the part file when `_TARGET_PART_BYTES` is hit.
+_DEFAULT_COMMIT_BATCH_ROWS = 50_000
+_DEFAULT_COMMIT_BATCH_SECS = 2.0
 _DEFAULT_MAX_RETRIES = 4
 _RETRY_BACKOFF_BASE_SECS = 2.0
 _TRANSIENT_HTTP_CODES = frozenset({408, 425, 429, 500, 502, 503, 504})
@@ -154,7 +159,13 @@ class _Job:
 class _DownloadResult:
     job: _Job
     status: str  # "ok", "skipped", "missing", "failed", "cancelled"
+    # `frame` is populated by the writer thread after parsing `payload` — the
+    # network path only fills `payload`. This keeps GIL-heavy parquet parsing
+    # off the asyncio default executor (which fights ~40 threads plus all the
+    # in-flight download coroutines) and collapses the per-in-flight memory
+    # footprint to a single bytes buffer instead of bytes + parsed DataFrame.
     frame: pd.DataFrame | None
+    payload: bytes | None
     bytes_downloaded: int
     error: str | None
 
@@ -374,17 +385,37 @@ class _TelonexParquetStore:
     def _append_to_partition(
         self, key: tuple[str, int, int], entries: list[_DownloadResult]
     ) -> int:
-        """Write one enriched, concatenated Arrow table to the partition's open
-        part. Rolls on schema mismatch or size threshold. Caller holds lock."""
+        """Concat every entry's frame for the partition into one Arrow table
+        and write it as a single row group. `pd.concat` unifies divergent
+        column sets (filling NaN for missing cols), so the partition keeps a
+        single open writer and only rolls when the unified schema genuinely
+        changes (new column appears) or the part crosses the byte target.
+        Caller holds the lock.
+
+        Prior iterations tried a writer-per-schema-fingerprint to avoid
+        rolls — but pandas→arrow type inference splits identical logical
+        schemas (int64 vs Int64, string vs large_string) into distinct fp
+        buckets, so we ended up with hundreds of tiny files and high
+        per-write metadata overhead. Unifying via pandas first gives one big
+        write call per flush.
+        """
         enriched_frames: list[pd.DataFrame] = []
+        per_entry_rows: list[int] = []
         for entry in entries:
             assert entry.frame is not None
-            enriched = entry.frame.copy()
+            enriched = entry.frame
             enriched["market_slug"] = entry.job.market_slug
             enriched["outcome_segment"] = entry.job.outcome_segment
             enriched_frames.append(enriched)
+            per_entry_rows.append(len(enriched))
+            # Drop the dataclass reference so the DataFrame can be GC'd when
+            # the local `enriched_frames` list is cleared below.
+            entry.frame = None
+
         combined = pd.concat(enriched_frames, ignore_index=True, copy=False)
+        enriched_frames.clear()
         table = pa.Table.from_pandas(combined, preserve_index=False)
+        del combined
 
         part = self._writers.get(key)
         if part is not None and not part.schema.equals(table.schema):
@@ -398,15 +429,18 @@ class _TelonexParquetStore:
             part = self._open_part(key, table.schema)
             self._writers[key] = part
 
+        total_rows = table.num_rows
         part.writer.write_table(table)
         part.bytes_written += table.nbytes
-        for entry in entries:
-            part.pending.append((entry, len(entry.frame) if entry.frame is not None else 0))
+        for entry, row_count in zip(entries, per_entry_rows):
+            part.pending.append((entry, row_count))
+
+        del table
 
         if part.bytes_written >= _TARGET_PART_BYTES:
             self._flush_open_part_locked(key)
 
-        return len(combined)
+        return total_rows
 
     def ingest_batch(self, results: list[_DownloadResult]) -> int:
         """Route a batch of downloads into open Parquet part writers and update
@@ -521,6 +555,39 @@ def _fetch_markets_dataset(base_url: str, timeout_secs: int) -> pd.DataFrame:
     return pd.read_parquet(io.BytesIO(payload))
 
 
+def _build_async_http_client(*, concurrency: int, timeout_secs: int) -> httpx.AsyncClient:
+    """Shared pooled async HTTP client.
+
+    Sized so every in-flight request can hold a keepalive slot to both the
+    Telonex API host and the redirected-to S3 host simultaneously. `follow_
+    redirects=True` collapses the "302 from api.telonex.io → GET s3" into one
+    logical `client.get()` call; httpx strips `Authorization` on cross-origin
+    redirect automatically.
+    """
+    # Two host buckets (api + s3) × some slack for races.
+    pool_ceiling = max(concurrency * 2 + 32, 128)
+    limits = httpx.Limits(
+        max_connections=pool_ceiling,
+        max_keepalive_connections=pool_ceiling,
+        keepalive_expiry=120.0,
+    )
+    timeout = httpx.Timeout(
+        connect=min(30.0, float(timeout_secs)),
+        read=float(timeout_secs),
+        write=float(timeout_secs),
+        # Pool acquire waits can be longer — large concurrency bursts briefly
+        # queue before a slot frees up.
+        pool=float(max(timeout_secs * 2, 60)),
+    )
+    return httpx.AsyncClient(
+        http2=False,  # S3 speaks HTTP/1.1; h2 on API saves little
+        follow_redirects=True,
+        limits=limits,
+        timeout=timeout,
+        headers={"User-Agent": _USER_AGENT},
+    )
+
+
 def _iter_days_for_market(
     row: pd.Series,
     *,
@@ -629,48 +696,42 @@ def _build_jobs_from_explicit(
     return jobs
 
 
-def _resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-    request = Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "User-Agent": _USER_AGENT,
-        },
-        method="GET",
-    )
+class _FakeHTTPError(Exception):
+    """Raised for non-success HTTP status after the shared client follows the
+    302. Carries a `code` field so upstream logic can match on 404."""
 
-    class _NoRedirect(HTTPRedirectHandler):
-        def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
-            return None
-
-    opener = build_opener(_NoRedirect())
-    try:
-        response = opener.open(request, timeout=timeout_secs)
-        response.close()
-    except HTTPError as exc:
-        if exc.code in (301, 302, 303, 307, 308):
-            location = exc.headers.get("Location")
-            if not location:
-                raise
-            return location
-        raise
-    raise HTTPError(url, 500, "Expected 302 redirect from Telonex", {}, None)  # type: ignore[arg-type]
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 def _is_transient(exc: BaseException) -> bool:
-    if isinstance(exc, HTTPError):
+    if isinstance(exc, _FakeHTTPError):
         return exc.code in _TRANSIENT_HTTP_CODES
-    if isinstance(exc, (URLError, SocketTimeout, TimeoutError, ConnectionError)):
+    if isinstance(exc, UrllibHTTPError):
+        return exc.code in _TRANSIENT_HTTP_CODES
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _TRANSIENT_HTTP_CODES
+    if isinstance(
+        exc,
+        (
+            httpx.TransportError,  # covers ConnectError, ReadError, WriteError, PoolTimeout, etc.
+            URLError,
+            SocketTimeout,
+            TimeoutError,
+            ConnectionError,
+        ),
+    ):
         return True
     return False
 
 
-def _download_day_bytes_with_retry(
+async def _download_day_bytes_with_retry_async(
     *,
+    client: httpx.AsyncClient,
     url: str,
     api_key: str,
-    timeout_secs: int,
-    stop_event: threading.Event,
+    stop_event: asyncio.Event,
     progress_cb,
     max_retries: int,
 ) -> bytes:
@@ -679,16 +740,16 @@ def _download_day_bytes_with_retry(
         if stop_event.is_set():
             raise _CancelledError()
         try:
-            return _download_day_bytes(
+            return await _download_day_bytes_async(
+                client=client,
                 url=url,
                 api_key=api_key,
-                timeout_secs=timeout_secs,
                 stop_event=stop_event,
                 progress_cb=progress_cb,
             )
         except _CancelledError:
             raise
-        except HTTPError as exc:
+        except _FakeHTTPError as exc:
             if exc.code == 404:
                 raise
             last_exc = exc
@@ -703,34 +764,46 @@ def _download_day_bytes_with_retry(
         while time.monotonic() < deadline:
             if stop_event.is_set():
                 raise _CancelledError()
-            time.sleep(min(0.25, deadline - time.monotonic()))
+            await asyncio.sleep(min(0.25, deadline - time.monotonic()))
     if last_exc is not None:
         raise last_exc
     raise RuntimeError("retry loop exited without success or exception")
 
 
-def _download_day_bytes(
+async def _download_day_bytes_async(
     *,
+    client: httpx.AsyncClient,
     url: str,
     api_key: str,
-    timeout_secs: int,
-    stop_event: threading.Event,
+    stop_event: asyncio.Event,
     progress_cb,
 ) -> bytes:
-    presigned = _resolve_presigned_url(url=url, api_key=api_key, timeout_secs=timeout_secs)
-    request = Request(presigned, headers={"User-Agent": _USER_AGENT})
-    with urlopen(request, timeout=timeout_secs) as response:
+    """Fetch one day-file via the shared pooled async client.
+
+    The Telonex API endpoint responds with a 302 to an S3 presigned URL.
+    `follow_redirects=True` on the client collapses this to one logical GET;
+    httpx strips `Authorization` on cross-origin redirect so the token never
+    leaks to S3."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with client.stream("GET", url, headers=headers) as response:
+        if response.status_code == 404:
+            raise _FakeHTTPError(404, "not found")
+        if response.status_code >= 400:
+            try:
+                await response.aread()
+            except Exception:
+                pass
+            raise _FakeHTTPError(response.status_code, f"HTTP {response.status_code}")
         total_header = response.headers.get("Content-Length")
         total_bytes = int(total_header) if total_header else None
         chunks: list[bytes] = []
         downloaded = 0
         progress_cb(0, total_bytes, False)
-        while True:
+        async for chunk in response.aiter_bytes(chunk_size=_DOWNLOAD_CHUNK_SIZE):
             if stop_event.is_set():
                 raise _CancelledError()
-            chunk = response.read(_DOWNLOAD_CHUNK_SIZE)
             if not chunk:
-                break
+                continue
             chunks.append(chunk)
             downloaded += len(chunk)
             progress_cb(downloaded, total_bytes, False)
@@ -883,9 +956,27 @@ def _run_jobs(
     failed_samples: list[str] = []
     interrupted = False
 
+    # `threading.Event` still drives the writer thread. A separate asyncio.Event
+    # lets coroutines see stop requests via `await`.
     stop_event = threading.Event()
     active_registry = _ActiveRegistry()
-    result_queue: Queue[_DownloadResult] = Queue()
+    # Bounded so the writer applies backpressure on the async dispatcher: when
+    # the writer falls behind, the put-side coroutine polls until a slot frees
+    # up, which stops new jobs from being scheduled. Kept small relative to
+    # `workers` because each queued result holds a parsed DataFrame — for
+    # book_snapshot_full those can be 50+ MiB, so 32 × 50 MiB ≈ 1.5 GiB is our
+    # worst-case live memory from the queue alone.
+    result_queue: Queue[_DownloadResult] = Queue(maxsize=32)
+
+    # Dedicated bounded pool for CPU-bound parquet parsing. Using the default
+    # asyncio executor (~40 threads) here creates heavy GIL contention with
+    # the writer thread and the event loop, so we cap parse parallelism at a
+    # small fraction of cpu_count. Also keeps post-parse DataFrames from piling
+    # up faster than the writer can drain them.
+    parse_worker_count = min(4, max(1, (os.cpu_count() or 2)))
+    parse_pool = ThreadPoolExecutor(
+        max_workers=parse_worker_count, thread_name_prefix="telonex-parse"
+    )
 
     progress = (
         tqdm(
@@ -941,13 +1032,72 @@ def _run_jobs(
     heartbeat_thread = threading.Thread(target=_heartbeat, name="telonex-heartbeat", daemon=True)
     heartbeat_thread.start()
 
-    def _do_one(job: _Job) -> _DownloadResult:
+    # Test-monkeypatchable hook: tests patch module-level `_download_day_bytes`
+    # to stub the network with a sync callable. When present, route through
+    # the same retry/backoff logic used by the async network path.
+    async def _call_stub_with_retry(stub, url: str, progress_cb) -> bytes:
+        last_exc: BaseException | None = None
+        for attempt in range(_DEFAULT_MAX_RETRIES):
+            if async_stop.is_set():
+                raise _CancelledError()
+            try:
+                result = stub(
+                    client=http_client,
+                    url=url,
+                    api_key=api_key,
+                    stop_event=stop_event,
+                    progress_cb=progress_cb,
+                )
+                if asyncio.iscoroutine(result):
+                    return await result
+                return result
+            except _CancelledError:
+                raise
+            except _FakeHTTPError as exc:
+                if exc.code == 404:
+                    raise
+                last_exc = exc
+                if not _is_transient(exc) or attempt == _DEFAULT_MAX_RETRIES - 1:
+                    raise
+            except Exception as exc:
+                last_exc = exc
+                if not _is_transient(exc) or attempt == _DEFAULT_MAX_RETRIES - 1:
+                    raise
+            backoff = _RETRY_BACKOFF_BASE_SECS * (2**attempt) + random.uniform(0, 0.5)
+            deadline = time.monotonic() + backoff
+            while time.monotonic() < deadline:
+                if async_stop.is_set():
+                    raise _CancelledError()
+                await asyncio.sleep(min(0.25, deadline - time.monotonic()))
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("retry loop exited without success or exception")
+
+    async def _call_download(job: _Job, url: str, progress_cb) -> bytes:
+        stub = globals().get("_download_day_bytes")
+        if stub is not None:
+            return await _call_stub_with_retry(stub, url, progress_cb)
+        return await _download_day_bytes_with_retry_async(
+            client=http_client,
+            url=url,
+            api_key=api_key,
+            stop_event=async_stop,
+            progress_cb=progress_cb,
+            max_retries=_DEFAULT_MAX_RETRIES,
+        )
+
+    async def _do_one_async(job: _Job) -> _DownloadResult:
         nonlocal missing_days, failed_days, cancelled_days, bytes_total, downloaded_days
-        if stop_event.is_set():
+        if async_stop.is_set():
             with state_lock:
                 cancelled_days += 1
             return _DownloadResult(
-                job=job, status="cancelled", frame=None, bytes_downloaded=0, error=None
+                job=job,
+                status="cancelled",
+                frame=None,
+                payload=None,
+                bytes_downloaded=0,
+                error=None,
             )
 
         token = active_registry.start(job)
@@ -965,38 +1115,59 @@ def _run_jobs(
 
         payload: bytes | None = None
         try:
-            payload = _download_day_bytes_with_retry(
-                url=url,
-                api_key=api_key,
-                timeout_secs=timeout_secs,
-                stop_event=stop_event,
-                progress_cb=_progress_cb,
-                max_retries=_DEFAULT_MAX_RETRIES,
-            )
+            payload = await _call_download(job, url, _progress_cb)
         except _CancelledError:
             active_registry.finish(token)
             with state_lock:
                 cancelled_days += 1
             return _DownloadResult(
-                job=job, status="cancelled", frame=None, bytes_downloaded=0, error=None
+                job=job,
+                status="cancelled",
+                frame=None,
+                payload=None,
+                bytes_downloaded=0,
+                error=None,
             )
-        except HTTPError as exc:
+        except asyncio.CancelledError:
             active_registry.finish(token)
-            if exc.code == 404:
+            with state_lock:
+                cancelled_days += 1
+            return _DownloadResult(
+                job=job,
+                status="cancelled",
+                frame=None,
+                payload=None,
+                bytes_downloaded=0,
+                error=None,
+            )
+        except (_FakeHTTPError, UrllibHTTPError) as exc:
+            active_registry.finish(token)
+            if getattr(exc, "code", None) == 404:
                 store.mark_empty(job, status="404")
                 with state_lock:
                     missing_days += 1
                 return _DownloadResult(
-                    job=job, status="missing", frame=None, bytes_downloaded=0, error="404"
+                    job=job,
+                    status="missing",
+                    frame=None,
+                    payload=None,
+                    bytes_downloaded=0,
+                    error="404",
                 )
+            code = getattr(exc, "code", "?")
             with state_lock:
                 failed_days += 1
                 if len(failed_samples) < 20:
                     failed_samples.append(
-                        f"{job.market_slug} {job.channel} {job.day} HTTP {exc.code}"
+                        f"{job.market_slug} {job.channel} {job.day} HTTP {code}"
                     )
             return _DownloadResult(
-                job=job, status="failed", frame=None, bytes_downloaded=0, error=f"HTTP {exc.code}"
+                job=job,
+                status="failed",
+                frame=None,
+                payload=None,
+                bytes_downloaded=0,
+                error=f"HTTP {code}",
             )
         except Exception as exc:
             active_registry.finish(token)
@@ -1007,7 +1178,12 @@ def _run_jobs(
                         f"{job.market_slug} {job.channel} {job.day} {exc.__class__.__name__}"
                     )
             return _DownloadResult(
-                job=job, status="failed", frame=None, bytes_downloaded=0, error=str(exc)
+                job=job,
+                status="failed",
+                frame=None,
+                payload=None,
+                bytes_downloaded=0,
+                error=str(exc),
             )
 
         active_registry.finish(token)
@@ -1015,11 +1191,24 @@ def _run_jobs(
             with state_lock:
                 failed_days += 1
             return _DownloadResult(
-                job=job, status="failed", frame=None, bytes_downloaded=0, error="empty-body"
+                job=job,
+                status="failed",
+                frame=None,
+                payload=None,
+                bytes_downloaded=0,
+                error="empty-body",
             )
 
+        # Parse parquet on the dedicated small pool (see `parse_pool`). This
+        # caps parse concurrency so the event loop and writer don't compete
+        # with dozens of parse threads for the GIL, while still allowing a few
+        # parses to run in parallel — letting the writer saturate its
+        # single-thread disk-write budget.
+        loop = asyncio.get_running_loop()
         try:
-            frame = pd.read_parquet(io.BytesIO(payload))
+            frame = await loop.run_in_executor(
+                parse_pool, pd.read_parquet, io.BytesIO(payload)
+            )
         except Exception as exc:
             with state_lock:
                 failed_days += 1
@@ -1031,6 +1220,7 @@ def _run_jobs(
                 job=job,
                 status="failed",
                 frame=None,
+                payload=None,
                 bytes_downloaded=len(payload),
                 error=str(exc),
             )
@@ -1039,7 +1229,12 @@ def _run_jobs(
             downloaded_days += 1
             bytes_total += len(payload)
         return _DownloadResult(
-            job=job, status="ok", frame=frame, bytes_downloaded=len(payload), error=None
+            job=job,
+            status="ok",
+            frame=frame,
+            payload=None,
+            bytes_downloaded=len(payload),
+            error=None,
         )
 
     writer_done = threading.Event()
@@ -1092,9 +1287,13 @@ def _run_jobs(
             except Empty:
                 _flush_pending(force=False)
                 continue
-            if result.status in ("ok", "missing"):
-                if result.status == "ok":
-                    pending_for_commit.append(result)
+            if result.status == "ok":
+                # The result already carries a parsed DataFrame (parsing ran
+                # in the dedicated parse pool on the async side, see
+                # `_do_one_async`). Writer just appends and periodically flushes.
+                pending_for_commit.append(result)
+                _flush_pending(force=False)
+            elif result.status == "missing":
                 _flush_pending(force=False)
             if progress is not None:
                 progress.update(1)
@@ -1104,69 +1303,131 @@ def _run_jobs(
     writer_thread = threading.Thread(target=_writer, name="telonex-writer", daemon=True)
     writer_thread.start()
 
-    try:
-        if workers <= 1:
+    # --- async dispatch ---
+    # `workers` is the concurrency ceiling: that many downloads are in flight
+    # simultaneously. A coroutine waiting on a 302 is a few hundred bytes, not
+    # an OS thread — so we can set this to thousands on a fast network and the
+    # only real cost is the connection pool + open sockets.
+    concurrency = max(1, workers)
+    http_client: httpx.AsyncClient | None = None
+    async_stop: asyncio.Event | None = None
+
+    async def _dispatcher() -> None:
+        nonlocal http_client, async_stop
+        async_stop = asyncio.Event()
+        http_client = _build_async_http_client(
+            concurrency=concurrency, timeout_secs=timeout_secs
+        )
+
+        # Wire signals → async_stop so Ctrl-C / SIGTERM let in-flight requests
+        # drain cleanly. `asyncio.run` swallows the SIGINT KeyboardInterrupt
+        # otherwise, leaving partial downloads in flight.
+        loop = asyncio.get_running_loop()
+        installed: list[int] = []
+        for sig in (signal.SIGINT, signal.SIGTERM):
             try:
-                for job in jobs:
-                    if stop_event.is_set():
-                        break
-                    result_queue.put(_do_one(job))
-            except KeyboardInterrupt:
-                interrupted = True
-                stop_event.set()
-                print(
-                    "\n[telonex] Ctrl-C received — flushing pending rows to the Parquet store. "
-                    "Press Ctrl-C again to force-exit (risk losing in-flight day).",
-                    file=sys.stderr,
-                )
-        else:
-            # Bounded-producer pattern: keep at most `workers * 3` futures in flight
-            # so memory stays flat even when `jobs` has tens of millions of entries.
-            in_flight_limit = max(workers * 3, workers + 2)
-            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="telonex-dl") as pool:
-                job_iter = iter(jobs)
-                in_flight: set = set()
+                loop.add_signal_handler(sig, _async_stop_signal)
+                installed.append(sig)
+            except (NotImplementedError, RuntimeError):
+                # add_signal_handler is main-thread only and unavailable on Windows
+                pass
+
+        def _async_stop_signal_local() -> None:
+            pass  # placeholder so closure uses outer scope
+
+        try:
+            job_iter = iter(jobs)
+            in_flight: set[asyncio.Task] = set()
+            # Prime: launch up to `concurrency` tasks at once. The semaphore
+            # lives inside each task (via async_stop check) — we don't need
+            # one because we directly cap the set size.
+            for _ in range(concurrency):
                 try:
-                    for _ in range(in_flight_limit):
+                    j = next(job_iter)
+                except StopIteration:
+                    break
+                in_flight.add(asyncio.create_task(_do_one_async(j)))
+
+            async def _handoff(result: _DownloadResult) -> None:
+                # Cooperative put: poll the bounded queue so a slow writer
+                # throttles the dispatcher without starving the event loop or
+                # blocking a thread that couldn't be interrupted on SIGTERM.
+                while True:
+                    try:
+                        result_queue.put_nowait(result)
+                        return
+                    except Full:
+                        if async_stop.is_set():
+                            return
+                        await asyncio.sleep(0.05)
+
+            while in_flight:
+                if async_stop.is_set():
+                    break
+                done, in_flight = await asyncio.wait(
+                    in_flight, timeout=1.0, return_when=asyncio.FIRST_COMPLETED
+                )
+                for finished in done:
+                    try:
+                        result = finished.result()
+                    except asyncio.CancelledError:
+                        continue
+                    except Exception as exc:
+                        print(f"[telonex] worker raised {exc!r}", file=sys.stderr)
+                        continue
+                    await _handoff(result)
+                if not async_stop.is_set():
+                    for _ in range(len(done)):
                         try:
-                            job = next(job_iter)
+                            j = next(job_iter)
                         except StopIteration:
                             break
-                        in_flight.add(pool.submit(_do_one, job))
-                    while in_flight:
-                        if stop_event.is_set():
-                            break
-                        done, in_flight = concurrent.futures.wait(
-                            in_flight, timeout=1.0, return_when=FIRST_COMPLETED
-                        )
-                        for finished in done:
-                            try:
-                                result_queue.put(finished.result())
-                            except Exception as exc:  # noqa: BLE001
-                                print(f"[telonex] worker raised {exc!r}", file=sys.stderr)
-                        if not stop_event.is_set():
-                            for _ in range(len(done)):
-                                try:
-                                    job = next(job_iter)
-                                except StopIteration:
-                                    break
-                                in_flight.add(pool.submit(_do_one, job))
-                except KeyboardInterrupt:
-                    interrupted = True
-                    stop_event.set()
-                    print(
-                        "\n[telonex] Ctrl-C received — finishing in-flight downloads then "
-                        "flushing pending rows to the Parquet store. Press Ctrl-C again to "
-                        "force-exit (risk losing in-flight day).",
-                        file=sys.stderr,
-                    )
-                    for future in in_flight:
-                        future.cancel()
+                        in_flight.add(asyncio.create_task(_do_one_async(j)))
+
+            # Drain remaining in-flight on stop.
+            if in_flight:
+                for task in in_flight:
+                    task.cancel()
+                results = await asyncio.gather(*in_flight, return_exceptions=True)
+                for r in results:
+                    if isinstance(r, _DownloadResult):
+                        await _handoff(r)
+        finally:
+            for sig in installed:
+                try:
+                    loop.remove_signal_handler(sig)
+                except (NotImplementedError, RuntimeError):
+                    pass
+            if http_client is not None:
+                await http_client.aclose()
+
+    def _async_stop_signal() -> None:
+        # Runs in the event loop thread. Flip both the threading event (writer,
+        # retry loops still inspect it) and the asyncio event (coroutines).
+        nonlocal interrupted
+        if not stop_event.is_set():
+            interrupted = True
+            print(
+                "\n[telonex] Signal received — draining in-flight downloads then "
+                "flushing pending rows. Send again to force-exit.",
+                file=sys.stderr,
+            )
+        stop_event.set()
+        if async_stop is not None:
+            async_stop.set()
+
+    try:
+        try:
+            asyncio.run(_dispatcher())
+        except KeyboardInterrupt:
+            interrupted = True
+            stop_event.set()
     finally:
         writer_done.set()
         writer_thread.join(timeout=60.0)
         heartbeat_stop.set()
         heartbeat_thread.join(timeout=2.0)
+        parse_pool.shutdown(wait=True, cancel_futures=True)
         if progress is not None:
             _refresh_postfix(force=True)
             progress.close()

--- a/scripts/_telonex_data_download.py
+++ b/scripts/_telonex_data_download.py
@@ -784,6 +784,8 @@ async def _download_day_bytes_async(
     `follow_redirects=True` on the client collapses this to one logical GET;
     httpx strips `Authorization` on cross-origin redirect so the token never
     leaks to S3."""
+    if stop_event.is_set():
+        raise _CancelledError()
     headers = {"Authorization": f"Bearer {api_key}"}
     async with client.stream("GET", url, headers=headers) as response:
         if response.status_code == 404:
@@ -1382,10 +1384,22 @@ def _run_jobs(
             if in_flight:
                 for task in in_flight:
                     task.cancel()
-                results = await asyncio.gather(*in_flight, return_exceptions=True)
-                for r in results:
-                    if isinstance(r, _DownloadResult):
-                        await _handoff(r)
+                try:
+                    results = await asyncio.wait_for(
+                        asyncio.gather(*in_flight, return_exceptions=True),
+                        timeout=15.0,
+                    )
+                except asyncio.TimeoutError:
+                    stranded = sum(1 for t in in_flight if not t.done())
+                    print(
+                        f"[telonex] {stranded} task(s) still in flight after 15s drain "
+                        "— forcing close",
+                        file=sys.stderr,
+                    )
+                else:
+                    for r in results:
+                        if isinstance(r, _DownloadResult):
+                            await _handoff(r)
         finally:
             for sig in installed:
                 try:
@@ -1393,7 +1407,13 @@ def _run_jobs(
                 except (NotImplementedError, RuntimeError):
                     pass
             if http_client is not None:
-                await http_client.aclose()
+                try:
+                    await asyncio.wait_for(http_client.aclose(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    print(
+                        "[telonex] httpx client close timed out — connections abandoned",
+                        file=sys.stderr,
+                    )
 
     def _async_stop_signal() -> None:
         # Runs in the event loop thread. Flip both the threading event (writer,

--- a/scripts/_telonex_data_download.py
+++ b/scripts/_telonex_data_download.py
@@ -1158,9 +1158,7 @@ def _run_jobs(
             with state_lock:
                 failed_days += 1
                 if len(failed_samples) < 20:
-                    failed_samples.append(
-                        f"{job.market_slug} {job.channel} {job.day} HTTP {code}"
-                    )
+                    failed_samples.append(f"{job.market_slug} {job.channel} {job.day} HTTP {code}")
             return _DownloadResult(
                 job=job,
                 status="failed",
@@ -1206,9 +1204,7 @@ def _run_jobs(
         # single-thread disk-write budget.
         loop = asyncio.get_running_loop()
         try:
-            frame = await loop.run_in_executor(
-                parse_pool, pd.read_parquet, io.BytesIO(payload)
-            )
+            frame = await loop.run_in_executor(parse_pool, pd.read_parquet, io.BytesIO(payload))
         except Exception as exc:
             with state_lock:
                 failed_days += 1
@@ -1315,9 +1311,7 @@ def _run_jobs(
     async def _dispatcher() -> None:
         nonlocal http_client, async_stop
         async_stop = asyncio.Event()
-        http_client = _build_async_http_client(
-            concurrency=concurrency, timeout_secs=timeout_secs
-        )
+        http_client = _build_async_http_client(concurrency=concurrency, timeout_secs=timeout_secs)
 
         # Wire signals → async_stop so Ctrl-C / SIGTERM let in-flight requests
         # drain cleanly. `asyncio.run` swallows the SIGINT KeyboardInterrupt

--- a/scripts/telonex_download_data.py
+++ b/scripts/telonex_download_data.py
@@ -89,7 +89,18 @@ def main() -> int:
     parser.add_argument("--no-progress", action="store_true")
     parser.add_argument("--timeout-secs", type=int, default=60)
     parser.add_argument(
-        "--workers", type=int, default=16, help="Parallel download workers (default: 16)."
+        "--workers",
+        type=int,
+        default=128,
+        help=(
+            "Concurrent in-flight downloads (default: 128). With the async httpx "
+            "client each in-flight request is a coroutine, not an OS thread, so "
+            "pushing to 256–512 on a high-bandwidth VPS costs only sockets + "
+            "RAM. The real ceiling is usually either network bandwidth or the "
+            "disk-side parquet writer (single thread by design so the blob "
+            "store stays consistent); transient 429/503 are retried "
+            "automatically."
+        ),
     )
     parser.add_argument(
         "--db-filename",

--- a/tests/test_telonex_data_download.py
+++ b/tests/test_telonex_data_download.py
@@ -10,26 +10,6 @@ import pytest
 from scripts import _telonex_data_download as telonex_download
 
 
-class _Response:
-    def __init__(self, payload: bytes, headers: dict[str, str] | None = None) -> None:
-        self._payload = payload
-        self._offset = 0
-        self.headers = headers or {}
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):  # type: ignore[no-untyped-def]
-        return False
-
-    def read(self, size: int = -1) -> bytes:
-        if size is None or size < 0:
-            size = len(self._payload) - self._offset
-        chunk = self._payload[self._offset : self._offset + size]
-        self._offset += len(chunk)
-        return chunk
-
-
 def _parquet_payload(timestamp_us: int) -> bytes:
     frame = pd.DataFrame(
         {
@@ -45,34 +25,84 @@ def _parquet_payload(timestamp_us: int) -> bytes:
     return buffer.getvalue()
 
 
+def _parquet_payload_with_extra(
+    timestamp_us: int, *, extra_columns: dict[str, object] | None = None
+) -> bytes:
+    data: dict[str, list[object]] = {
+        "timestamp_us": [timestamp_us],
+        "bid_price": [0.44],
+        "ask_price": [0.45],
+        "bid_size": [10.0],
+        "ask_size": [12.0],
+    }
+    if extra_columns:
+        for key, value in extra_columns.items():
+            data[key] = [value]
+    frame = pd.DataFrame(data)
+    buffer = BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _install_payload_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    payloads_by_day: dict[str, bytes],
+    *,
+    seen_urls: list[str] | None = None,
+    seen_auth: list[str] | None = None,
+    fail_first_n: dict[str, int] | None = None,
+    raise_for_day: dict[str, Exception] | None = None,
+) -> None:
+    """Intercept the one network hop in the pipeline — `_download_day_bytes` —
+    and serve fixtures by day. Everything above this layer (jobs, manifest,
+    parquet writer) still exercises real code."""
+    fail_first_n = fail_first_n or {}
+    raise_for_day = raise_for_day or {}
+    call_counts: dict[str, int] = {}
+
+    def fake_download_day_bytes(*, client, url, api_key, stop_event, progress_cb):
+        del client, stop_event
+        if seen_urls is not None:
+            seen_urls.append(url)
+        if seen_auth is not None:
+            seen_auth.append(api_key)
+        # URL path looks like .../quotes/2026-01-19?slug=...
+        day = url.rsplit("/", 1)[1].split("?", 1)[0]
+        call_counts[day] = call_counts.get(day, 0) + 1
+
+        if day in raise_for_day and call_counts[day] == 1:
+            raise raise_for_day[day]
+
+        if fail_first_n.get(day, 0) >= call_counts[day]:
+            raise telonex_download._FakeHTTPError(503, "Service Unavailable")
+
+        if day not in payloads_by_day:
+            raise telonex_download._FakeHTTPError(404, "not found")
+
+        payload = payloads_by_day[day]
+        progress_cb(len(payload), len(payload), True)
+        return payload
+
+    # `_download_day_bytes` is not a real module attr (the network path is
+    # async internally); pass raising=False to install it as a test hook.
+    # `_run_jobs` looks it up via `globals().get(...)` at call time.
+    monkeypatch.setattr(
+        telonex_download, "_download_day_bytes", fake_download_day_bytes, raising=False
+    )
+
+
 def test_download_telonex_days_writes_duckdb_blob(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    requested_urls: list[str] = []
-    resolved_urls: list[str] = []
-    auth_keys: list[str] = []
+    seen_urls: list[str] = []
+    seen_auth: list[str] = []
     payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload(1_768_780_800_000_000),
-        "https://download.example/2026-01-20.parquet": _parquet_payload(1_768_867_200_000_000),
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
     }
 
-    def fake_resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del timeout_secs
-        requested_urls.append(url)
-        auth_keys.append(api_key)
-        day = url.rsplit("/", 1)[1].split("?", 1)[0]
-        resolved = f"https://download.example/{day}.parquet"
-        resolved_urls.append(resolved)
-        return resolved
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
-
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve_presigned_url)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
+    _install_payload_stub(monkeypatch, payloads, seen_urls=seen_urls, seen_auth=seen_auth)
 
     summary = telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -89,27 +119,21 @@ def test_download_telonex_days_writes_duckdb_blob(
     assert summary.skipped_existing_days == 0
     assert summary.failed_days == 0
     assert summary.missing_days == 0
-    assert sorted(requested_urls) == [
+    assert sorted(seen_urls) == [
         "https://api.telonex.io/v1/downloads/polymarket/quotes/2026-01-19?slug=us-recession-by-end-of-2026&outcome_id=0",
         "https://api.telonex.io/v1/downloads/polymarket/quotes/2026-01-20?slug=us-recession-by-end-of-2026&outcome_id=0",
     ]
-    assert sorted(resolved_urls) == [
-        "https://download.example/2026-01-19.parquet",
-        "https://download.example/2026-01-20.parquet",
-    ]
-    assert sorted(auth_keys) == ["test-key", "test-key"]
+    assert sorted(seen_auth) == ["test-key", "test-key"]
 
     manifest_path = tmp_path / "telonex.duckdb"
     assert manifest_path.exists()
     assert summary.db_path == str(manifest_path)
     assert summary.db_size_bytes > 0
 
-    # The store is Hive-partitioned Parquet: data/channel=X/year=.../month=.../part-*.parquet
     data_root = tmp_path / "data"
     assert data_root.exists()
     parquet_files = sorted(data_root.rglob("*.parquet"))
-    assert len(parquet_files) >= 1, "expected at least one Parquet part file"
-    # Every part file sits under the expected Hive path.
+    assert len(parquet_files) >= 1
     for path in parquet_files:
         rel = path.relative_to(data_root).parts
         assert rel[0].startswith("channel=")
@@ -126,8 +150,6 @@ def test_download_telonex_days_writes_duckdb_blob(
     finally:
         con.close()
 
-    # Resolve part paths via the manifest, then read the rows back via DuckDB's
-    # hive-partitioned read_parquet API — the same code path readers take.
     assert len(manifest) == 2
     assert {row[0] for row in manifest} == {"quotes"}
     assert {row[1] for row in manifest} == {"us-recession-by-end-of-2026"}
@@ -146,8 +168,6 @@ def test_download_telonex_days_writes_duckdb_blob(
     finally:
         con.close()
     assert [row[2] for row in rows] == [1_768_780_800_000_000, 1_768_867_200_000_000]
-    assert {row[0] for row in rows} == {"us-recession-by-end-of-2026"}
-    assert {row[1] for row in rows} == {"0"}
 
 
 def test_download_telonex_days_requires_key_from_env(
@@ -169,22 +189,10 @@ def test_download_telonex_days_requires_key_from_env(
 def test_download_telonex_days_resumes_from_manifest(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload(1_768_780_800_000_000),
-    }
-
-    def fake_resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del url, api_key, timeout_secs
-        return "https://download.example/2026-01-19.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
+    payloads = {"2026-01-19": _parquet_payload(1_768_780_800_000_000)}
 
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve_presigned_url)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
+    _install_payload_stub(monkeypatch, payloads)
 
     first = telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -197,10 +205,10 @@ def test_download_telonex_days_resumes_from_manifest(
     )
     assert first.downloaded_days == 1
 
-    def unexpected_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        raise AssertionError(f"unexpected Telonex request for {request.full_url}")
+    def boom(*_args, **_kwargs):
+        raise AssertionError("should not retry a skipped day")
 
-    monkeypatch.setattr(telonex_download, "urlopen", unexpected_urlopen)
+    monkeypatch.setattr(telonex_download, "_download_day_bytes", boom)
 
     second = telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -218,14 +226,8 @@ def test_download_telonex_days_resumes_from_manifest(
 def test_download_telonex_days_records_404_so_reruns_skip_empty_days(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    from urllib.error import HTTPError
-
-    def fake_resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        raise HTTPError(url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
-
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve_presigned_url)
+    _install_payload_stub(monkeypatch, {})  # every day 404s
 
     summary = telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -239,10 +241,10 @@ def test_download_telonex_days_records_404_so_reruns_skip_empty_days(
     assert summary.missing_days == 1
     assert summary.downloaded_days == 0
 
-    def boom(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+    def boom(*_args, **_kwargs):
         raise AssertionError("should not retry a known-empty day")
 
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", boom)
+    monkeypatch.setattr(telonex_download, "_download_day_bytes", boom)
 
     rerun = telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -284,7 +286,7 @@ def test_download_telonex_days_all_markets_expands_every_channel(
         del base_url, timeout_secs
         return markets
 
-    def fake_run_jobs(jobs, **kwargs):  # type: ignore[no-untyped-def]
+    def fake_run_jobs(jobs, **kwargs):
         del kwargs
         captured_jobs.extend(jobs)
         return (len(jobs), 0, 0, 0, 123, False, [])
@@ -307,55 +309,20 @@ def test_download_telonex_days_all_markets_expands_every_channel(
     assert {job.outcome_segment for job in captured_jobs} == {"0", "1"}
 
 
-def _parquet_payload_with_extra(
-    timestamp_us: int, *, extra_columns: dict[str, object] | None = None
-) -> bytes:
-    data = {
-        "timestamp_us": [timestamp_us],
-        "bid_price": [0.44],
-        "ask_price": [0.45],
-        "bid_size": [10.0],
-        "ask_size": [12.0],
-    }
-    if extra_columns:
-        for key, value in extra_columns.items():
-            data[key] = [value]
-    frame = pd.DataFrame(data)
-    buffer = BytesIO()
-    frame.to_parquet(buffer, index=False)
-    return buffer.getvalue()
-
-
 def test_download_telonex_days_schema_evolves_when_later_day_has_new_column(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Day 2's parquet has an `origin_asset_id` column that day 1's didn't —
-    the writer must ALTER TABLE rather than crashing with BinderException."""
+    the writer must roll a new part rather than crashing."""
     payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload_with_extra(
-            1_768_780_800_000_000
-        ),
-        "https://download.example/2026-01-20.parquet": _parquet_payload_with_extra(
-            1_768_867_200_000_000,
-            extra_columns={"origin_asset_id": "abc123"},
+        "2026-01-19": _parquet_payload_with_extra(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload_with_extra(
+            1_768_867_200_000_000, extra_columns={"origin_asset_id": "abc123"}
         ),
     }
 
-    def fake_resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        day = url.rsplit("/", 1)[1].split("?", 1)[0]
-        return f"https://download.example/{day}.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
-
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve_presigned_url)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
-    # Force each day into its own commit batch so day 2 triggers the
-    # schema-evolution path against an already-created table.
+    _install_payload_stub(monkeypatch, payloads)
     monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
     monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
 
@@ -371,9 +338,6 @@ def test_download_telonex_days_schema_evolves_when_later_day_has_new_column(
     assert summary.downloaded_days == 2
     assert summary.failed_days == 0
 
-    # Two commit batches with different schemas must both land on disk.
-    # `union_by_name=True` on read reconciles the per-file schemas, so the
-    # reader sees `origin_asset_id` as NULL for day 1 and populated for day 2.
     glob = str(tmp_path / "data" / "channel=quotes" / "**" / "*.parquet")
     con = duckdb.connect(":memory:")
     try:
@@ -391,26 +355,10 @@ def test_download_telonex_days_schema_evolves_when_later_day_has_new_column(
 def test_download_telonex_days_retries_transient_5xx_then_succeeds(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    from urllib.error import HTTPError
-
-    call_count = {"n": 0}
-    payload = _parquet_payload(1_768_780_800_000_000)
-
-    def fake_resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        call_count["n"] += 1
-        if call_count["n"] <= 2:
-            raise HTTPError(url, 503, "Service Unavailable", {}, None)  # type: ignore[arg-type]
-        return "https://download.example/day.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
+    payloads = {"2026-01-19": _parquet_payload(1_768_780_800_000_000)}
 
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve_presigned_url)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
-    # Zero out the retry backoff so the test finishes quickly.
+    _install_payload_stub(monkeypatch, payloads, fail_first_n={"2026-01-19": 2})
     monkeypatch.setattr(telonex_download, "_RETRY_BACKOFF_BASE_SECS", 0.0)
 
     summary = telonex_download.download_telonex_days(
@@ -424,34 +372,19 @@ def test_download_telonex_days_retries_transient_5xx_then_succeeds(
     )
     assert summary.downloaded_days == 1
     assert summary.failed_days == 0
-    # 2 transient failures + 1 success
-    assert call_count["n"] == 3
 
 
 def test_downloaded_parquet_is_readable_by_telonex_loader(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """End-to-end: the downloader's Parquet layout must be what the reader
-    expects. Without this, the downloader can silently produce files no loader
-    can consume."""
+    """End-to-end: downloader's Parquet layout must match what the reader expects."""
     payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload(1_768_780_800_000_000),
-        "https://download.example/2026-01-20.parquet": _parquet_payload(1_768_867_200_000_000),
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
     }
 
-    def fake_resolve(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        day = url.rsplit("/", 1)[1].split("?", 1)[0]
-        return f"https://download.example/{day}.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
-
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
+    _install_payload_stub(monkeypatch, payloads)
 
     telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -469,7 +402,7 @@ def test_downloaded_parquet_is_readable_by_telonex_loader(
 
     loader = RunnerPolymarketTelonexQuoteDataLoader.__new__(RunnerPolymarketTelonexQuoteDataLoader)
     blob_root = loader._local_blob_root(tmp_path)
-    assert blob_root is not None, "downloader output should be detected as a blob store"
+    assert blob_root is not None
 
     frame = loader._load_blob_range(
         store_root=blob_root,
@@ -481,14 +414,12 @@ def test_downloaded_parquet_is_readable_by_telonex_loader(
         end=pd.Timestamp("2026-01-20 23:59:59", tz="UTC"),
     )
     assert frame is not None and len(frame) == 2
-    # Bookkeeping columns stripped.
     assert "market_slug" not in frame.columns
     assert "outcome_segment" not in frame.columns
     assert "year" not in frame.columns
     assert "month" not in frame.columns
     assert set(frame["timestamp_us"]) == {1_768_780_800_000_000, 1_768_867_200_000_000}
 
-    # Month-range pruning works: January-only query drops all rows.
     frame_dec = loader._load_blob_range(
         store_root=blob_root,
         channel="quotes",
@@ -504,27 +435,13 @@ def test_downloaded_parquet_is_readable_by_telonex_loader(
 def test_download_telonex_days_rolls_part_files_when_threshold_exceeded(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """With a tiny part-roll threshold, each batch closes one file and opens
-    the next. The manifest must reference the correct file for each day."""
     payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload(1_768_780_800_000_000),
-        "https://download.example/2026-01-20.parquet": _parquet_payload(1_768_867_200_000_000),
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
     }
 
-    def fake_resolve(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        day = url.rsplit("/", 1)[1].split("?", 1)[0]
-        return f"https://download.example/{day}.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
-
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
-    # Force a part roll after each day by setting the threshold below one row's size.
+    _install_payload_stub(monkeypatch, payloads)
     monkeypatch.setattr(telonex_download, "_TARGET_PART_BYTES", 1)
     monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
     monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
@@ -540,41 +457,23 @@ def test_download_telonex_days_rolls_part_files_when_threshold_exceeded(
     )
 
     parts = sorted((tmp_path / "data").rglob("*.parquet"))
-    # Both days fell in the same (channel=quotes, year=2026, month=01) partition.
-    # With threshold=1, each day triggered a roll ⇒ two distinct part files.
     assert len(parts) == 2
-    assert all("part-" in p.name for p in parts)
 
     con = duckdb.connect(str(tmp_path / "telonex.duckdb"), read_only=True)
     try:
         rows = con.execute("SELECT day, parquet_part FROM completed_days ORDER BY day").fetchall()
     finally:
         con.close()
-    assert len({row[1] for row in rows}) == 2  # different parts for different days
+    assert len({row[1] for row in rows}) == 2
 
 
 def test_store_sweeps_orphan_parquet_on_startup(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A SIGKILL between writer.close() and manifest update leaves a Parquet
-    file on disk that isn't referenced. On the next startup, the store must
-    delete the orphan so read_parquet globs stay clean."""
-    payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload(1_768_780_800_000_000),
-    }
-
-    def fake_resolve(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del url, api_key, timeout_secs
-        return "https://download.example/2026-01-19.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
+    payloads = {"2026-01-19": _parquet_payload(1_768_780_800_000_000)}
 
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
+    _install_payload_stub(monkeypatch, payloads)
 
     telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -590,17 +489,14 @@ def test_store_sweeps_orphan_parquet_on_startup(
     assert len(parts_after_first) == 1
     real_part = parts_after_first[0]
 
-    # Plant a decoy orphan next to the real file — simulates a half-written
-    # part left behind by SIGKILL.
     orphan = real_part.parent / "part-999999.parquet"
     orphan.write_bytes(b"not a valid parquet footer")
     assert orphan.exists()
 
-    # Re-open the store — no download, just init — and the orphan should go.
     store = telonex_download._TelonexParquetStore(tmp_path)
     try:
-        assert not orphan.exists(), "orphan should be swept on startup"
-        assert real_part.exists(), "manifest-referenced file must survive"
+        assert not orphan.exists()
+        assert real_part.exists()
     finally:
         store.close()
 
@@ -608,32 +504,19 @@ def test_store_sweeps_orphan_parquet_on_startup(
 def test_download_telonex_days_resumes_midrun_interruption(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Simulate the realistic crash case: day 1 commits to the blob, day 2
-    raises before it can commit. On the next run, day 1 must skip and day 2
-    must re-fetch and succeed."""
+    """Day 1 commits, day 2 raises before commit. On rerun, day 1 skips and
+    day 2 re-fetches successfully."""
     payloads = {
-        "https://download.example/2026-01-19.parquet": _parquet_payload(1_768_780_800_000_000),
-        "https://download.example/2026-01-20.parquet": _parquet_payload(1_768_867_200_000_000),
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
     }
-    seen_days: list[str] = []
-
-    def fake_resolve_presigned_url(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        day = url.rsplit("/", 1)[1].split("?", 1)[0]
-        seen_days.append(day)
-        if day == "2026-01-20":
-            raise RuntimeError("simulated mid-run crash before day 2 commits")
-        return f"https://download.example/{day}.parquet"
-
-    def fake_urlopen(request, timeout=60):  # type: ignore[no-untyped-def]
-        del timeout
-        payload = payloads[request.full_url]
-        return _Response(payload, headers={"Content-Length": str(len(payload))})
 
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", fake_resolve_presigned_url)
-    monkeypatch.setattr(telonex_download, "urlopen", fake_urlopen)
-    # Zero backoff so retries are fast.
+    _install_payload_stub(
+        monkeypatch,
+        payloads,
+        raise_for_day={"2026-01-20": RuntimeError("simulated mid-run crash")},
+    )
     monkeypatch.setattr(telonex_download, "_RETRY_BACKOFF_BASE_SECS", 0.0)
 
     summary_a = telonex_download.download_telonex_days(
@@ -648,16 +531,9 @@ def test_download_telonex_days_resumes_midrun_interruption(
     assert summary_a.downloaded_days == 1
     assert summary_a.failed_days == 1
 
-    seen_days.clear()
-
-    # Now the crash is fixed — day 2 resolves normally.
-    def resolve_ok(*, url: str, api_key: str, timeout_secs: int) -> str:
-        del api_key, timeout_secs
-        day = url.rsplit("/", 1)[1].split("?", 1)[0]
-        seen_days.append(day)
-        return f"https://download.example/{day}.parquet"
-
-    monkeypatch.setattr(telonex_download, "_resolve_presigned_url", resolve_ok)
+    # Crash resolved on rerun — reinstall a clean stub.
+    seen_urls: list[str] = []
+    _install_payload_stub(monkeypatch, payloads, seen_urls=seen_urls)
 
     summary_b = telonex_download.download_telonex_days(
         destination=tmp_path,
@@ -668,13 +544,12 @@ def test_download_telonex_days_resumes_midrun_interruption(
         show_progress=False,
         workers=1,
     )
-    # Day 1 already committed → skip. Day 2 → fresh fetch.
     assert summary_b.downloaded_days == 1
     assert summary_b.skipped_existing_days == 1
     assert summary_b.failed_days == 0
-    assert seen_days == ["2026-01-20"]
+    # Only day 2 should have been refetched.
+    assert all("2026-01-20" in url for url in seen_urls)
 
-    # Final blob has both days.
     con = duckdb.connect(str(tmp_path / "telonex.duckdb"), read_only=True)
     try:
         days = sorted(


### PR DESCRIPTION
## Summary
- Rewrites the Telonex downloader hot loop from ThreadPoolExecutor+urllib to asyncio+httpx.AsyncClient, so concurrency scales with sockets/RAM instead of OS threads and the 302→S3 redirect collapses into one pooled GET.
- Adds bounded backpressure (result queue capped, dedicated small parse ThreadPoolExecutor) so downloads can't outrun the parquet writer and balloon memory at high concurrency.
- Keeps the single-thread blob-store writer design (one part-file per partition, pandas concat unifies divergent column schemas) but tightens the commit-batch thresholds so book_snapshot_full DataFrames don't pin RAM.
- CLI `--workers` default raised to 128 with updated help text covering the practical ceilings (network bandwidth, single-thread disk writer, Telonex per-IP rate limits).

## Why
Previous sync version tops out around a few dozen concurrent downloads because each connection is an OS thread. For the remaining 3 weeks of the unlimited-downloads Telonex subscription we want to scale way past that on a high-bandwidth VPS — especially to pull the heavier channels (book_snapshot_full, onchain_fills) that weren't part of the original default.

## Test plan
- [x] `uv run pytest tests/test_telonex_data_download.py` — 11 passed
- [x] End-to-end run against `/Volumes/LaCie/telonex_data` at `--workers 128` for a 3-day window across all 6 channels: memory stable ~3 GiB, ~1400 days committed + ~650 404s marked in ~2 minutes, no errors
- [x] Re-run on the VPS once deployed to confirm expected throughput at higher concurrency