### PR TITLE
[codex] fix Telonex API cache clearing safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: backtest install update test check clear-pmxt-cache clear-telonex-cache download-pmxt-raws download-telonex-data
 
 PMXT_CACHE_ROOT ?= $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/nautilus_trader/pmxt
+PMXT_LOCAL_DATA_ROOT ?= /Volumes/LaCie/pmxt_raws
+TELONEX_CACHE_ROOT ?= $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/nautilus_trader/telonex
 DESTINATION ?=
 PMXT_RAW_DOWNLOAD_FLAGS ?=
 TELONEX_DATA_DESTINATION ?= /Volumes/LaCie/telonex_data
@@ -20,14 +22,16 @@ check:
 test: check
 
 clear-pmxt-cache:
+	@python3 scripts/_cache_clear_guard.py --name PMXT_CACHE_ROOT --target "$(PMXT_CACHE_ROOT)" --unsafe "$(PMXT_LOCAL_DATA_ROOT)" --unsafe "$(TELONEX_DATA_DESTINATION)" --unsafe "$(DESTINATION)"
 	rm -rf "$(PMXT_CACHE_ROOT)"
 	mkdir -p "$(PMXT_CACHE_ROOT)"
 	du -sh "$(PMXT_CACHE_ROOT)"
 
 clear-telonex-cache:
-	rm -rf "$(TELONEX_DATA_DESTINATION)"
-	mkdir -p "$(TELONEX_DATA_DESTINATION)"
-	du -sh "$(TELONEX_DATA_DESTINATION)"
+	@python3 scripts/_cache_clear_guard.py --name TELONEX_CACHE_ROOT --target "$(TELONEX_CACHE_ROOT)" --unsafe "$(TELONEX_DATA_DESTINATION)" --unsafe "$(PMXT_LOCAL_DATA_ROOT)" --unsafe "$(DESTINATION)"
+	rm -rf "$(TELONEX_CACHE_ROOT)"
+	mkdir -p "$(TELONEX_CACHE_ROOT)"
+	du -sh "$(TELONEX_CACHE_ROOT)"
 
 download-pmxt-raws:
 	@if [ -z "$(DESTINATION)" ]; then echo "Set DESTINATION=/path"; exit 2; fi

--- a/docs/backtests.md
+++ b/docs/backtests.md
@@ -502,7 +502,7 @@ workflows:
 - `PMXT_RAW_ROOT`, `PMXT_REMOTE_BASE_URL`, `PMXT_CACHE_DIR`,
   `PMXT_DISABLE_CACHE`
 - `TELONEX_LOCAL_DIR`, `TELONEX_API_BASE_URL`, `TELONEX_API_KEY`,
-  `TELONEX_CHANNEL`
+  `TELONEX_CHANNEL`, `TELONEX_CACHE_ROOT`
 - `BACKTEST_ENABLE_TIMING=0`
 
 ## Data Vendor Notes
@@ -542,14 +542,20 @@ workflows:
 - Telonex source parsing accepts `local:` and `api:` only
 - `api:` reads `TELONEX_API_KEY` from the environment and constructs Telonex
   download URLs; never commit keys or put them in `DATA.sources`
+- API-day payloads are cached by default at
+  `~/.cache/nautilus_trader/telonex`; set `TELONEX_CACHE_ROOT=0` to disable or
+  `TELONEX_CACHE_ROOT=/path/to/cache` to move it
+- when the cache is enabled, the `Telonex source:` line includes `cache` before
+  the configured `local:` and `api:` entries
 - prefer `local:/Volumes/LaCie/telonex_data` for repeatable research once files
   have been downloaded with `scripts/telonex_download_data.py` or
   `make download-telonex-data`
 - the local downloader consolidates by default to
   `polymarket/<market_slug>/<outcome>/<channel>.parquet`
 - Telonex timing output is daily-file based: the `@timing_harness` progress bar
-  reports active `local:`/`api:` loads, byte progress when the API response
-  exposes a size, scan rows, and completed per-day lines
+  reports active `telonex local`, `telonex cache`, or `telonex api` loads,
+  byte progress when the API response exposes a size, scan rows, and completed
+  per-day lines
 
 For vendor-specific data-source behavior and timings, use:
 

--- a/docs/data-vendors.md
+++ b/docs/data-vendors.md
@@ -211,7 +211,9 @@ that field must be present and string-encoded exactly as expected.
 ## Telonex
 
 Telonex is a separate Polymarket quote-tick vendor path. It does not use PMXT
-hourly raw files or the PMXT filtered cache.
+hourly raw files or the PMXT filtered cache. Runner API downloads use a
+separate Telonex API-day cache at `~/.cache/nautilus_trader/telonex` by
+default.
 
 Telonex source syntax is also explicit:
 
@@ -224,6 +226,21 @@ The API path reads the key from `TELONEX_API_KEY`. Do not put API keys in
 `DATA.sources`, notebooks, docs, or committed files. Telonex free trials count
 each daily Parquet download, so warm local files first when you are experimenting
 and use `api:` only for intentional downloads.
+
+When a runner falls back to `api:`, the downloaded daily Parquet payload is
+written to the Telonex API-day cache before it is parsed. A second run for the
+same base URL, channel, market, outcome, and date reads that cache without
+asking Telonex for another presigned URL. Override the cache root with
+`TELONEX_CACHE_ROOT=/path/to/cache`, disable it with `TELONEX_CACHE_ROOT=0`, or
+clear only that cache with:
+
+```bash
+make clear-telonex-cache
+```
+
+Do not point `TELONEX_CACHE_ROOT` at a local mirror. The clear target refuses
+the configured local Telonex data destination, the PMXT raw mirror root, paths
+inside those stores, and parents containing those stores.
 
 Recommended local layout:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -214,8 +214,11 @@ after the run.
   the historical fallback)
 - PMXT `DATA.sources` entries are explicit and prefix-driven: `local:`,
   `archive:`
-- Telonex timing is daily-file based and reports active `local:`/`api:` loads
-  through the same `@timing_harness`
+- Telonex API-day cache is enabled by default at
+  `~/.cache/nautilus_trader/telonex`; `make clear-telonex-cache` clears only
+  that cache root and refuses configured local data stores
+- Telonex timing is daily-file based and reports active `telonex local`,
+  `telonex cache`, or `telonex api` loads through the same `@timing_harness`
 - normal Nautilus logs are still printed; the timing harness is additive
 
 ## Extension Architecture

--- a/docs/vendor-fetch-sources.md
+++ b/docs/vendor-fetch-sources.md
@@ -86,9 +86,19 @@ DATA = MarketDataConfig(
 
 The timing harness uses the same `BACKTEST_ENABLE_TIMING` switch for Telonex.
 Because the API source is daily, the progress bar says `Fetching days` instead
-of `Fetching hours`. Active status lines show `telonex local` or `telonex api`,
-byte progress for API downloads when the response exposes a content length,
-scan rows, matched quote rows, and a completed line for each date.
+of `Fetching hours`. Active status lines show the actual source class:
+`telonex local` for local mirrors, `telonex cache` for cached API-day payloads,
+or `telonex api` for network downloads. API downloads show byte progress when
+the response exposes a content length; every source reports scan rows, matched
+quote rows, and a completed line for each date.
+
+When `TELONEX_CACHE_ROOT` is enabled, the `Telonex source:` line includes the
+implicit cache layer before the configured `local:` and `api:` entries, for
+example:
+
+```text
+Telonex source: explicit priority (cache -> local /Volumes/LaCie/telonex_data -> api https://api.telonex.io (key set))
+```
 
 ## Timing Expectations By Source
 
@@ -98,7 +108,8 @@ scan rows, matched quote rows, and a completed line for each date.
 | Local raw PMXT archive | local disk bound | You mirrored raw PMXT hours locally and pointed `DATA.sources` at `local:/...`, or used `PMXT_RAW_ROOT` for a lower-level loader workflow |
 | Remote raw PMXT archive | network and file-size bound | Hour is missing from local cache and local raw mirror, so the client downloads the upstream raw parquet to a temp file and filters it locally |
 | Local Telonex daily Parquet | local disk bound | You warmed `/Volumes/LaCie/telonex_data` and listed `local:/Volumes/LaCie/telonex_data` before `api:` |
-| Telonex API daily Parquet | network and file-size bound | The local daily file is missing and the runner falls back to `api:` with `TELONEX_API_KEY` in the environment |
+| Telonex API-day cache | local disk bound | The same Telonex API day was downloaded earlier and cached under `TELONEX_CACHE_ROOT` |
+| Telonex API daily Parquet | network and file-size bound | The local daily file and API-day cache are missing, so the runner falls back to `api:` with `TELONEX_API_KEY` in the environment |
 | None | <1s | Hour does not exist yet |
 
 ## How To See This Output

--- a/prediction_market_extensions/backtesting/_timing_test.py
+++ b/prediction_market_extensions/backtesting/_timing_test.py
@@ -66,7 +66,7 @@ def _transfer_label(source: str) -> str:
         ("cache::", "cache"),
         ("local-raw::", "local raw"),
         ("remote-raw::", "r2 raw"),
-        ("telonex-blob::", "telonex blob"),
+        ("telonex-cache::", "telonex cache"),
         ("telonex-local::", "telonex local"),
         ("telonex-api::", "telonex api"),
     ):
@@ -634,7 +634,27 @@ def install_timing() -> None:
                 heartbeat_thread.start()
 
             try:
-                if dates:
+                has_api_cache = False
+                for date in dates:
+                    for entry in config.ordered_source_entries:
+                        if entry.kind != "api":
+                            continue
+                        assert entry.target is not None
+                        cache_path = self._api_cache_path(
+                            base_url=entry.target,
+                            channel=config.channel,
+                            date=date,
+                            market_slug=market_slug,
+                            token_index=token_index,
+                            outcome=outcome,
+                        )
+                        if cache_path is not None and cache_path.exists():
+                            has_api_cache = True
+                            break
+                    if has_api_cache:
+                        break
+
+                if dates and not has_api_cache:
                     for entry in config.ordered_source_entries:
                         if entry.kind != "local":
                             break
@@ -652,7 +672,7 @@ def install_timing() -> None:
                                 end=end,
                             )
                             if blob_frame is not None:
-                                source_label = f"telonex-blob::{blob_root}"
+                                source_label = f"telonex-local::{blob_root}"
                                 total_bytes = None
                                 started_at = time.perf_counter()
                                 with pbar_lock:
@@ -779,20 +799,108 @@ def install_timing() -> None:
                     day_total_bytes: int | None = None
                     frame = None
                     day_started_at = time.perf_counter()
+                    day_window = self._day_window(date, start=start, end=end)
+                    if day_window is None:
+                        return (date, local_records, day_source_label, 0.0)
+                    day_start, day_end = day_window
 
                     with pbar_lock:
                         _mark_hour_started(date)
                         _refresh_transfer_status()
 
                     for entry in config.ordered_source_entries:
+                        if entry.kind != "api":
+                            continue
+                        assert entry.target is not None
+                        cache_path = self._api_cache_path(
+                            base_url=entry.target,
+                            channel=config.channel,
+                            date=date,
+                            market_slug=market_slug,
+                            token_index=token_index,
+                            outcome=outcome,
+                        )
+                        if cache_path is None or not cache_path.exists():
+                            continue
+                        source_key = f"telonex-cache::{cache_path}"
+                        day_source_label = source_key
+                        try:
+                            day_total_bytes = cache_path.stat().st_size
+                        except OSError:
+                            day_total_bytes = None
+                        _start_transfer(date, source_key)
+                        try:
+                            frame = self._load_api_cache_day(
+                                base_url=entry.target,
+                                channel=config.channel,
+                                date=date,
+                                market_slug=market_slug,
+                                token_index=token_index,
+                                outcome=outcome,
+                            )
+                        finally:
+                            _finish_transfer(source_key)
+                        if frame is not None:
+                            break
+
+                    for entry in config.ordered_source_entries:
+                        if frame is not None:
+                            break
                         source_key: str | None = None
                         if entry.kind == "local":
                             assert entry.target is not None
                             root = Path(entry.target).expanduser()
+                            blob_root = self._local_blob_root(root)
+                            if blob_root is not None:
+                                source_key = f"telonex-local::{blob_root}"
+                                day_source_label = source_key
+                                _start_transfer(date, source_key)
+                                try:
+                                    frame = self._load_blob_range(
+                                        store_root=blob_root,
+                                        channel=config.channel,
+                                        market_slug=market_slug,
+                                        token_index=token_index,
+                                        outcome=outcome,
+                                        start=day_start,
+                                        end=day_end,
+                                    )
+                                finally:
+                                    _finish_transfer(source_key)
+                                if frame is not None:
+                                    break
                             local_path = self._local_path_for_day(
                                 root=root,
                                 channel=config.channel,
                                 date=date,
+                                market_slug=market_slug,
+                                token_index=token_index,
+                                outcome=outcome,
+                            )
+                            if local_path is not None:
+                                source_key = f"telonex-local::{local_path}"
+                                day_source_label = source_key
+                                try:
+                                    day_total_bytes = local_path.stat().st_size
+                                except OSError:
+                                    day_total_bytes = None
+                                _start_transfer(date, source_key)
+                                try:
+                                    frame = self._load_local_day(
+                                        root=root,
+                                        channel=config.channel,
+                                        date=date,
+                                        market_slug=market_slug,
+                                        token_index=token_index,
+                                        outcome=outcome,
+                                    )
+                                finally:
+                                    _finish_transfer(source_key)
+                                if frame is not None:
+                                    break
+                            local_path = self._local_consolidated_path(
+                                root=root,
+                                channel=config.channel,
                                 market_slug=market_slug,
                                 token_index=token_index,
                                 outcome=outcome,
@@ -807,10 +915,9 @@ def install_timing() -> None:
                                 day_total_bytes = None
                             _start_transfer(date, source_key)
                             try:
-                                frame = self._load_local_day(
+                                frame = self._load_local_range(
                                     root=root,
                                     channel=config.channel,
-                                    date=date,
                                     market_slug=market_slug,
                                     token_index=token_index,
                                     outcome=outcome,
@@ -827,7 +934,22 @@ def install_timing() -> None:
                                 token_index=token_index,
                                 outcome=outcome,
                             )
-                            source_key = f"telonex-api::{api_url}"
+                            cache_path = self._api_cache_path(
+                                base_url=entry.target,
+                                channel=config.channel,
+                                date=date,
+                                market_slug=market_slug,
+                                token_index=token_index,
+                                outcome=outcome,
+                            )
+                            if cache_path is not None and cache_path.exists():
+                                source_key = f"telonex-cache::{cache_path}"
+                                try:
+                                    day_total_bytes = cache_path.stat().st_size
+                                except OSError:
+                                    day_total_bytes = None
+                            else:
+                                source_key = f"telonex-api::{api_url}"
                             day_source_label = source_key
                             _start_transfer(date, source_key)
                             try:
@@ -842,13 +964,26 @@ def install_timing() -> None:
                                 )
                             finally:
                                 _finish_transfer(source_key)
+                            actual_source = getattr(self, "_telonex_last_api_source", None)
+                            if actual_source:
+                                day_source_label = actual_source
+                                if actual_source.startswith("telonex-cache::"):
+                                    actual_cache_path = Path(
+                                        actual_source.removeprefix("telonex-cache::")
+                                    )
+                                    try:
+                                        day_total_bytes = actual_cache_path.stat().st_size
+                                    except OSError:
+                                        day_total_bytes = None
                         if frame is not None:
                             break
 
                     if frame is not None:
                         row_count = len(frame)
                         _scan_progress(day_source_label, 1, row_count, 0, day_total_bytes, False)
-                        local_records = self._quote_ticks_from_frame(frame, start=start, end=end)
+                        local_records = self._quote_ticks_from_frame(
+                            frame, start=day_start, end=day_end
+                        )
                         _scan_progress(
                             day_source_label,
                             1,

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import warnings
+from hashlib import sha256
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -11,7 +12,7 @@ from datetime import UTC
 from io import BytesIO
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 import numpy as np
@@ -29,6 +30,7 @@ TELONEX_API_KEY_ENV = "TELONEX_API_KEY"
 TELONEX_API_BASE_URL_ENV = "TELONEX_API_BASE_URL"
 TELONEX_LOCAL_DIR_ENV = "TELONEX_LOCAL_DIR"
 TELONEX_CHANNEL_ENV = "TELONEX_CHANNEL"
+TELONEX_CACHE_ROOT_ENV = "TELONEX_CACHE_ROOT"
 
 _TELONEX_DEFAULT_API_BASE_URL = "https://api.telonex.io"
 _TELONEX_DEFAULT_CHANNEL = "quotes"
@@ -42,6 +44,7 @@ _TELONEX_SOURCE_LOCAL = "local"
 _TELONEX_SOURCE_API = "api"
 _TELONEX_BLOB_DB_FILENAME = "telonex.duckdb"
 _TELONEX_DATA_SUBDIR = "data"
+_TELONEX_CACHE_SUBDIR = "api-days"
 
 
 @dataclass(frozen=True)
@@ -84,6 +87,22 @@ def _env_value(name: str) -> str | None:
 
 def _resolve_channel() -> str:
     return (_env_value(TELONEX_CHANNEL_ENV) or _TELONEX_DEFAULT_CHANNEL).casefold()
+
+
+def _default_cache_root() -> Path:
+    configured = os.getenv("XDG_CACHE_HOME")
+    cache_home = Path(configured).expanduser() if configured else Path.home() / ".cache"
+    return cache_home / "nautilus_trader" / "telonex"
+
+
+def _resolve_api_cache_root() -> Path | None:
+    configured = os.getenv(TELONEX_CACHE_ROOT_ENV)
+    if configured is None:
+        return _default_cache_root()
+    value = configured.strip()
+    if value.casefold() in DISABLED_ENV_VALUES:
+        return None
+    return Path(value).expanduser()
 
 
 def _normalize_api_base_url(value: str | None) -> str:
@@ -170,7 +189,7 @@ def _default_telonex_sources_from_env() -> tuple[TelonexSourceEntry, ...]:
 
 
 def _source_summary(entries: Sequence[TelonexSourceEntry]) -> str:
-    parts: list[str] = []
+    parts: list[str] = ["cache"] if _resolve_api_cache_root() is not None else []
     for entry in entries:
         if entry.kind == _TELONEX_SOURCE_LOCAL:
             parts.append(f"local {entry.target}")
@@ -226,6 +245,10 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
         callback = getattr(self, "_telonex_download_progress_callback", None)
         if callback is not None:
             callback(url, downloaded_bytes, total_bytes, finished)
+
+    @classmethod
+    def _resolve_api_cache_root(cls) -> Path | None:
+        return _resolve_api_cache_root()
 
     def _config(self) -> TelonexLoaderConfig:
         config = _current_loader_config()
@@ -515,6 +538,101 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             f"?{urlencode(params)}"
         )
 
+    @classmethod
+    def _api_cache_path(
+        cls,
+        *,
+        base_url: str,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> Path | None:
+        cache_root = cls._resolve_api_cache_root()
+        if cache_root is None:
+            return None
+        normalized_base_url = base_url.rstrip("/")
+        base_url_key = sha256(normalized_base_url.encode("utf-8")).hexdigest()[:16]
+        outcome_segment = (
+            f"outcome={quote(outcome, safe='')}" if outcome else f"outcome_id={token_index}"
+        )
+        return (
+            cache_root
+            / _TELONEX_CACHE_SUBDIR
+            / base_url_key
+            / _TELONEX_EXCHANGE
+            / channel
+            / quote(market_slug, safe="")
+            / outcome_segment
+            / f"{date}.parquet"
+        )
+
+    def _load_api_cache_day(
+        self,
+        *,
+        base_url: str,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> pd.DataFrame | None:
+        cache_path = self._api_cache_path(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if cache_path is None or not cache_path.exists():
+            return None
+        frame = self._safe_read_parquet(cache_path)
+        if frame is not None:
+            return frame
+        try:
+            cache_path.unlink()
+        except OSError:
+            pass
+        return None
+
+    def _write_api_cache_day(
+        self,
+        *,
+        payload: bytes,
+        base_url: str,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> None:
+        cache_path = self._api_cache_path(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if cache_path is None:
+            return
+        tmp_path = cache_path.with_name(f"{cache_path.name}.tmp.{os.getpid()}")
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path.write_bytes(payload)
+            os.replace(tmp_path, cache_path)
+        except OSError as exc:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            warnings.warn(
+                f"Telonex: failed to write API cache {cache_path} ({exc})",
+                stacklevel=2,
+            )
+
     @staticmethod
     def _resolve_presigned_url(*, url: str, api_key: str) -> str:
         request = Request(
@@ -554,6 +672,29 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
         outcome: str | None,
         api_key: str | None = None,
     ) -> pd.DataFrame | None:
+        self._telonex_last_api_source = None
+        cached = self._load_api_cache_day(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if cached is not None:
+            cache_path = self._api_cache_path(
+                base_url=base_url,
+                channel=channel,
+                date=date,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+            )
+            self._telonex_last_api_source = (
+                f"telonex-cache::{cache_path}" if cache_path is not None else "telonex-cache"
+            )
+            return cached
+
         if api_key is None or not api_key.strip():
             api_key = _env_value(TELONEX_API_KEY_ENV)
         if api_key is None:
@@ -567,6 +708,7 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             token_index=token_index,
             outcome=outcome,
         )
+        self._telonex_last_api_source = f"telonex-api::{url}"
         try:
             presigned_url = self._resolve_presigned_url(url=url, api_key=api_key)
         except HTTPError as exc:
@@ -596,6 +738,15 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             if exc.code == 404:
                 return None
             raise
+        self._write_api_cache_day(
+            payload=payload,
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
         return pd.read_parquet(BytesIO(payload))
 
     @staticmethod
@@ -614,6 +765,19 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
         if value.tzinfo is None:
             return value.tz_localize(UTC)
         return value.tz_convert(UTC)
+
+    def _day_window(
+        self, date: str, *, start: pd.Timestamp, end: pd.Timestamp
+    ) -> tuple[pd.Timestamp, pd.Timestamp] | None:
+        day_start = pd.Timestamp(date, tz=UTC)
+        day_end = day_start + pd.Timedelta(days=1) - pd.Timedelta(nanoseconds=1)
+        start_utc = self._normalize_to_utc(start)
+        end_utc = self._normalize_to_utc(end)
+        clipped_start = start_utc if start_utc > day_start else day_start
+        clipped_end = end_utc if end_utc < day_end else day_end
+        if clipped_start > clipped_end:
+            return None
+        return clipped_start, clipped_end
 
     @staticmethod
     def _first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str:
@@ -731,6 +895,73 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             )
             return None
 
+    def _try_load_day_from_local(
+        self,
+        *,
+        entry: TelonexSourceEntry,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+        range_cache: dict[Path, pd.DataFrame | None],
+    ) -> pd.DataFrame | None:
+        assert entry.target is not None
+        root = Path(entry.target).expanduser()
+        blob_root = self._local_blob_root(root)
+        if blob_root is not None:
+            try:
+                blob_frame = self._load_blob_range(
+                    store_root=blob_root,
+                    channel=channel,
+                    market_slug=market_slug,
+                    token_index=token_index,
+                    outcome=outcome,
+                    start=start,
+                    end=end,
+                )
+            except Exception as exc:  # noqa: BLE001 — fall through to local layouts/API
+                warnings.warn(
+                    f"Telonex: local blob read failed at {blob_root} ({exc}); trying next source.",
+                    stacklevel=2,
+                )
+                blob_frame = None
+            if blob_frame is not None:
+                return blob_frame
+
+        try:
+            daily_frame = self._load_local_day(
+                root=root,
+                channel=channel,
+                date=date,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+            )
+        except Exception as exc:  # noqa: BLE001 — fall through to consolidated/API
+            warnings.warn(
+                f"Telonex: local daily read failed at {root} ({exc}); trying next source.",
+                stacklevel=2,
+            )
+            daily_frame = None
+        if daily_frame is not None:
+            return daily_frame
+
+        path = self._local_consolidated_path(
+            root=root,
+            channel=channel,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if path is None:
+            return None
+        if path not in range_cache:
+            range_cache[path] = self._safe_read_parquet(path)
+        return range_cache[path]
+
     def _try_load_day_from_entry(
         self,
         *,
@@ -782,26 +1013,20 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
     ) -> list[QuoteTick]:
         config = self._config()
         records: list[QuoteTick] = []
-        for entry in config.ordered_source_entries:
-            if entry.kind != _TELONEX_SOURCE_LOCAL:
-                continue
-            frame = self._try_load_range_from_local(
-                entry=entry,
-                channel=config.channel,
-                market_slug=market_slug,
-                token_index=token_index,
-                outcome=outcome,
-                start=start,
-                end=end,
-            )
-            if frame is not None:
-                return self._quote_ticks_from_frame(frame, start=start, end=end)
-
+        api_entries = [
+            entry for entry in config.ordered_source_entries if entry.kind == _TELONEX_SOURCE_API
+        ]
+        range_cache: dict[Path, pd.DataFrame | None] = {}
         for date in self._date_range(start, end):
+            day_window = self._day_window(date, start=start, end=end)
+            if day_window is None:
+                continue
+            day_start, day_end = day_window
             frame: pd.DataFrame | None = None
-            for entry in config.ordered_source_entries:
-                frame = self._try_load_day_from_entry(
-                    entry=entry,
+            for entry in api_entries:
+                assert entry.target is not None
+                frame = self._load_api_cache_day(
+                    base_url=entry.target,
                     channel=config.channel,
                     date=date,
                     market_slug=market_slug,
@@ -810,15 +1035,44 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
                 )
                 if frame is not None:
                     break
+            if frame is not None:
+                records.extend(self._quote_ticks_from_frame(frame, start=day_start, end=day_end))
+                continue
+
+            for entry in config.ordered_source_entries:
+                if entry.kind == _TELONEX_SOURCE_LOCAL:
+                    frame = self._try_load_day_from_local(
+                        entry=entry,
+                        channel=config.channel,
+                        date=date,
+                        market_slug=market_slug,
+                        token_index=token_index,
+                        outcome=outcome,
+                        start=day_start,
+                        end=day_end,
+                        range_cache=range_cache,
+                    )
+                else:
+                    frame = self._try_load_day_from_entry(
+                        entry=entry,
+                        channel=config.channel,
+                        date=date,
+                        market_slug=market_slug,
+                        token_index=token_index,
+                        outcome=outcome,
+                    )
+                if frame is not None:
+                    break
             if frame is None:
                 continue
-            records.extend(self._quote_ticks_from_frame(frame, start=start, end=end))
+            records.extend(self._quote_ticks_from_frame(frame, start=day_start, end=day_end))
         records.sort(key=lambda quote: quote.ts_event)
         return records
 
 
 __all__ = [
     "TELONEX_API_BASE_URL_ENV",
+    "TELONEX_CACHE_ROOT_ENV",
     "TELONEX_API_KEY_ENV",
     "TELONEX_CHANNEL_ENV",
     "TELONEX_LOCAL_DIR_ENV",

--- a/scripts/_cache_clear_guard.py
+++ b/scripts/_cache_clear_guard.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _resolved(path: str) -> Path | None:
+    cleaned = path.strip()
+    if not cleaned:
+        return None
+    return Path(cleaned).expanduser().resolve(strict=False)
+
+
+def _is_same_or_nested(a: Path, b: Path) -> bool:
+    return a == b or a in b.parents or b in a.parents
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Refuse unsafe cache clear roots.")
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--unsafe", action="append", default=[])
+    args = parser.parse_args()
+
+    target = _resolved(args.target)
+    home = Path.home().resolve(strict=False)
+    if target is None or target == Path(target.anchor) or target == home:
+        print(f"Refusing to clear unsafe {args.name}: {args.target}", file=sys.stderr)
+        return 2
+
+    for unsafe_raw in args.unsafe:
+        unsafe = _resolved(unsafe_raw)
+        if unsafe is None:
+            continue
+        if _is_same_or_nested(target, unsafe):
+            print(
+                f"Refusing to clear unsafe {args.name}: {args.target} "
+                f"(conflicts with local data store {unsafe_raw})",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_clear_telonex_cache_does_not_delete_local_data_destination() -> None:
+    result = subprocess.run(
+        [
+            "make",
+            "-n",
+            "clear-telonex-cache",
+            "TELONEX_DATA_DESTINATION=/tmp/local-telonex-data",
+            "TELONEX_CACHE_ROOT=/tmp/telonex-runner-cache",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert 'rm -rf "/tmp/local-telonex-data"' not in result.stdout
+    assert 'rm -rf "/tmp/telonex-runner-cache"' in result.stdout
+    assert "Telonex runner API downloads are not persisted" not in result.stdout
+    assert "Clearing Telonex cache root only" not in result.stdout
+
+
+def test_clear_telonex_cache_refuses_data_destination(tmp_path: Path) -> None:
+    data_root = tmp_path / "telonex-data"
+    data_root.mkdir()
+    marker = data_root / "marker.parquet"
+    marker.write_text("keep")
+
+    result = subprocess.run(
+        [
+            "make",
+            "clear-telonex-cache",
+            f"TELONEX_DATA_DESTINATION={data_root}",
+            f"TELONEX_CACHE_ROOT={data_root}",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Refusing to clear unsafe TELONEX_CACHE_ROOT" in result.stderr
+    assert marker.read_text() == "keep"
+
+
+def test_clear_telonex_cache_refuses_path_inside_data_destination(tmp_path: Path) -> None:
+    data_root = tmp_path / "telonex-data"
+    cache_root = data_root / "api-cache"
+    cache_root.mkdir(parents=True)
+    marker = cache_root / "marker.parquet"
+    marker.write_text("keep")
+
+    result = subprocess.run(
+        [
+            "make",
+            "clear-telonex-cache",
+            f"TELONEX_DATA_DESTINATION={data_root}",
+            f"TELONEX_CACHE_ROOT={cache_root}",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Refusing to clear unsafe TELONEX_CACHE_ROOT" in result.stderr
+    assert marker.read_text() == "keep"
+
+
+def test_clear_telonex_cache_refuses_parent_of_data_destination(tmp_path: Path) -> None:
+    data_root = tmp_path / "telonex-data"
+    data_root.mkdir()
+    marker = data_root / "marker.parquet"
+    marker.write_text("keep")
+
+    result = subprocess.run(
+        [
+            "make",
+            "clear-telonex-cache",
+            f"TELONEX_DATA_DESTINATION={data_root}",
+            f"TELONEX_CACHE_ROOT={tmp_path}",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Refusing to clear unsafe TELONEX_CACHE_ROOT" in result.stderr
+    assert marker.read_text() == "keep"
+
+
+def test_clear_pmxt_cache_refuses_local_data_root(tmp_path: Path) -> None:
+    data_root = tmp_path / "pmxt-raws"
+    data_root.mkdir()
+    marker = data_root / "polymarket_orderbook_2026-01-01T00.parquet"
+    marker.write_text("keep")
+
+    result = subprocess.run(
+        [
+            "make",
+            "clear-pmxt-cache",
+            f"PMXT_CACHE_ROOT={data_root}",
+            f"PMXT_LOCAL_DATA_ROOT={data_root}",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Refusing to clear unsafe PMXT_CACHE_ROOT" in result.stderr
+    assert marker.read_text() == "keep"
+
+
+def test_clear_pmxt_cache_refuses_path_inside_local_data_root(tmp_path: Path) -> None:
+    data_root = tmp_path / "pmxt-raws"
+    cache_root = data_root / "filtered-cache"
+    cache_root.mkdir(parents=True)
+    marker = cache_root / "polymarket_orderbook_2026-01-01T00.parquet"
+    marker.write_text("keep")
+
+    result = subprocess.run(
+        [
+            "make",
+            "clear-pmxt-cache",
+            f"PMXT_CACHE_ROOT={cache_root}",
+            f"PMXT_LOCAL_DATA_ROOT={data_root}",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Refusing to clear unsafe PMXT_CACHE_ROOT" in result.stderr
+    assert marker.read_text() == "keep"

--- a/tests/test_telonex_data_download.py
+++ b/tests/test_telonex_data_download.py
@@ -790,6 +790,87 @@ def test_downloaded_parquet_is_readable_by_telonex_loader(
     assert frame_dec is None
 
 
+def test_telonex_blob_reader_uses_requested_channel_only(tmp_path: Path) -> None:
+    store = telonex_download._TelonexParquetStore(tmp_path)
+    try:
+        store.ingest_batch(
+            [
+                telonex_download._DownloadResult(
+                    job=telonex_download._Job(
+                        market_slug="channel-test",
+                        outcome_segment="0",
+                        outcome_id=0,
+                        outcome=None,
+                        channel="quotes",
+                        day=date(2026, 1, 19),
+                    ),
+                    status="ok",
+                    table=telonex_download.pa.Table.from_pandas(
+                        pd.DataFrame(
+                            {
+                                "timestamp_us": [1_768_780_800_000_000],
+                                "bid_price": [0.44],
+                                "ask_price": [0.45],
+                                "bid_size": [10.0],
+                                "ask_size": [12.0],
+                            }
+                        ),
+                        preserve_index=False,
+                    ),
+                    payload=None,
+                    bytes_downloaded=100,
+                    error=None,
+                ),
+                telonex_download._DownloadResult(
+                    job=telonex_download._Job(
+                        market_slug="channel-test",
+                        outcome_segment="0",
+                        outcome_id=0,
+                        outcome=None,
+                        channel="trades",
+                        day=date(2026, 1, 19),
+                    ),
+                    status="ok",
+                    table=telonex_download.pa.Table.from_pandas(
+                        pd.DataFrame(
+                            {
+                                "timestamp_us": [1_768_780_900_000_000],
+                                "bid_price": [0.10],
+                                "ask_price": [0.90],
+                                "bid_size": [1.0],
+                                "ask_size": [1.0],
+                            }
+                        ),
+                        preserve_index=False,
+                    ),
+                    payload=None,
+                    bytes_downloaded=100,
+                    error=None,
+                ),
+            ]
+        )
+    finally:
+        store.close()
+
+    from prediction_market_extensions.backtesting.data_sources.telonex import (
+        RunnerPolymarketTelonexQuoteDataLoader,
+    )
+
+    loader = RunnerPolymarketTelonexQuoteDataLoader.__new__(RunnerPolymarketTelonexQuoteDataLoader)
+    frame = loader._load_blob_range(
+        store_root=tmp_path,
+        channel="quotes",
+        market_slug="channel-test",
+        token_index=0,
+        outcome=None,
+        start=pd.Timestamp("2026-01-19", tz="UTC"),
+        end=pd.Timestamp("2026-01-19 23:59:59", tz="UTC"),
+    )
+
+    assert frame is not None
+    assert list(frame["timestamp_us"]) == [1_768_780_800_000_000]
+
+
 def test_download_telonex_days_rolls_part_files_when_threshold_exceeded(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_telonex_data_source.py
+++ b/tests/test_telonex_data_source.py
@@ -1,16 +1,56 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import importlib
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
+import prediction_market_extensions.backtesting.data_sources.telonex as telonex_module
 from prediction_market_extensions.backtesting.data_sources.telonex import (
+    TELONEX_CACHE_ROOT_ENV,
     TELONEX_API_KEY_ENV,
     TELONEX_LOCAL_DIR_ENV,
     RunnerPolymarketTelonexQuoteDataLoader,
     configured_telonex_data_source,
     resolve_telonex_loader_config,
 )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _FakeHTTPResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._buffer = BytesIO(payload)
+        self.headers = {"Content-Length": str(len(payload))}
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buffer.read(size)
+
+
+def _quote_parquet_payload(timestamp_us: int) -> bytes:
+    buffer = BytesIO()
+    pd.DataFrame(
+        {
+            "timestamp_us": [timestamp_us],
+            "bid_price": [0.42],
+            "ask_price": [0.44],
+            "bid_size": [10.0],
+            "ask_size": [11.0],
+        }
+    ).to_parquet(buffer, index=False)
+    return buffer.getvalue()
 
 
 def test_configured_telonex_data_source_preserves_explicit_order(tmp_path) -> None:
@@ -22,7 +62,7 @@ def test_configured_telonex_data_source_preserves_explicit_order(tmp_path) -> No
     ) as selection:
         assert selection.mode == "auto"
         assert selection.summary == (
-            f"Telonex source: explicit priority (local {local_root} -> "
+            f"Telonex source: explicit priority (cache -> local {local_root} -> "
             "api https://api.example.test (key missing))"
         )
 
@@ -32,6 +72,22 @@ def test_configured_telonex_data_source_preserves_explicit_order(tmp_path) -> No
             ("local", str(local_root)),
             ("api", "https://api.example.test"),
         ]
+
+
+def test_configured_telonex_data_source_omits_disabled_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    local_root = tmp_path / "telonex"
+    local_root.mkdir()
+    monkeypatch.setenv(TELONEX_CACHE_ROOT_ENV, "0")
+
+    with configured_telonex_data_source(
+        sources=[f"local:{local_root}", "api:https://api.example.test"]
+    ) as selection:
+        assert selection.summary == (
+            f"Telonex source: explicit priority (local {local_root} -> "
+            "api https://api.example.test (key missing))"
+        )
 
 
 def test_configured_telonex_data_source_expands_env_in_api_key(monkeypatch, tmp_path) -> None:
@@ -80,6 +136,232 @@ def test_telonex_api_url_uses_slug_and_outcome_id_without_key() -> None:
         "https://api.telonex.io/v1/downloads/polymarket/quotes/2026-01-20"
         "?slug=will-the-us-strike-iran-next-433&outcome_id=1"
     )
+
+
+def test_telonex_runner_api_downloads_cache_then_clear(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cache_root = tmp_path / "telonex-cache"
+    monkeypatch.setenv(TELONEX_CACHE_ROOT_ENV, str(cache_root))
+    payload = _quote_parquet_payload(1_768_780_800_000_000)
+    resolve_calls: list[tuple[str, str]] = []
+    fetch_calls: list[str] = []
+
+    def fake_resolve_presigned_url(*, url: str, api_key: str) -> str:
+        resolve_calls.append((url, api_key))
+        return "https://presigned.example.test/day.parquet"
+
+    def fake_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+        fetch_calls.append(request.full_url)
+        return _FakeHTTPResponse(payload)
+
+    monkeypatch.setattr(
+        RunnerPolymarketTelonexQuoteDataLoader,
+        "_resolve_presigned_url",
+        staticmethod(fake_resolve_presigned_url),
+    )
+    monkeypatch.setattr(telonex_module, "urlopen", fake_urlopen)
+
+    loader = RunnerPolymarketTelonexQuoteDataLoader.__new__(RunnerPolymarketTelonexQuoteDataLoader)
+    load_kwargs = {
+        "base_url": "https://api.example.test",
+        "channel": "quotes",
+        "date": "2026-01-19",
+        "market_slug": "us-recession-by-end-of-2026",
+        "token_index": 0,
+        "outcome": None,
+    }
+
+    first = loader._load_api_day(**load_kwargs, api_key="test-key")
+
+    assert first is not None
+    assert len(first) == 1
+    assert len(resolve_calls) == 1
+    assert len(fetch_calls) == 1
+    cache_path = loader._api_cache_path(**load_kwargs)
+    assert cache_path is not None
+    assert cache_path.exists()
+    assert cache_path.is_relative_to(cache_root)
+    assert loader._telonex_last_api_source == (
+        "telonex-api::https://api.example.test/v1/downloads/polymarket/quotes/"
+        "2026-01-19?slug=us-recession-by-end-of-2026&outcome_id=0"
+    )
+
+    def fail_resolve_presigned_url(*, url: str, api_key: str) -> str:
+        raise AssertionError("cache hit should not request a presigned URL")
+
+    def fail_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+        raise AssertionError("cache hit should not download from Telonex")
+
+    monkeypatch.setattr(
+        RunnerPolymarketTelonexQuoteDataLoader,
+        "_resolve_presigned_url",
+        staticmethod(fail_resolve_presigned_url),
+    )
+    monkeypatch.setattr(telonex_module, "urlopen", fail_urlopen)
+
+    second = loader._load_api_day(**load_kwargs, api_key=None)
+
+    assert second is not None
+    pd.testing.assert_frame_equal(first, second)
+    assert loader._telonex_last_api_source == f"telonex-cache::{cache_path}"
+
+    result = subprocess.run(
+        [
+            "make",
+            "clear-telonex-cache",
+            f"TELONEX_CACHE_ROOT={cache_root}",
+            f"TELONEX_DATA_DESTINATION={tmp_path / 'telonex-data'}",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert 'rm -rf "' in result.stdout
+    assert str(cache_root) in result.stdout
+    assert cache_root.exists()
+    assert not cache_path.exists()
+
+    monkeypatch.setattr(
+        RunnerPolymarketTelonexQuoteDataLoader,
+        "_resolve_presigned_url",
+        staticmethod(fake_resolve_presigned_url),
+    )
+    monkeypatch.setattr(telonex_module, "urlopen", fake_urlopen)
+
+    third = loader._load_api_day(**load_kwargs, api_key="test-key")
+
+    assert third is not None
+    pd.testing.assert_frame_equal(first, third)
+    assert len(resolve_calls) == 2
+    assert len(fetch_calls) == 2
+    assert cache_path.exists()
+    assert loader._telonex_last_api_source == (
+        "telonex-api::https://api.example.test/v1/downloads/polymarket/quotes/"
+        "2026-01-19?slug=us-recession-by-end-of-2026&outcome_id=0"
+    )
+
+
+def test_telonex_load_quotes_uses_cache_before_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(telonex_module)
+    loader_cls = module.RunnerPolymarketTelonexQuoteDataLoader
+    loader = loader_cls.__new__(loader_cls)
+    config = module.TelonexLoaderConfig(
+        channel="quotes",
+        ordered_source_entries=(
+            module.TelonexSourceEntry(kind="local", target="/tmp/local"),
+            module.TelonexSourceEntry(
+                kind="api", target="https://api.example.test", api_key="test-key"
+            ),
+        ),
+    )
+    frame = pd.DataFrame(
+        {
+            "timestamp_us": [1_768_780_800_000_000],
+            "bid_price": [0.42],
+            "ask_price": [0.44],
+            "bid_size": [10.0],
+            "ask_size": [11.0],
+        }
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(loader, "_config", lambda: config)
+
+    def fake_cache(**kwargs: object) -> pd.DataFrame:
+        calls.append("cache")
+        return frame
+
+    def fail_local(**kwargs: object) -> None:
+        calls.append("local")
+        raise AssertionError("local should not be checked when cache has the day")
+
+    def fail_source(**kwargs: object) -> None:
+        calls.append("api")
+        raise AssertionError("api should not be checked when cache has the day")
+
+    monkeypatch.setattr(loader, "_load_api_cache_day", fake_cache)
+    monkeypatch.setattr(loader, "_try_load_day_from_local", fail_local)
+    monkeypatch.setattr(loader, "_try_load_day_from_entry", fail_source)
+    monkeypatch.setattr(
+        loader,
+        "_quote_ticks_from_frame",
+        lambda _frame, *, start, end: [SimpleNamespace(ts_event=1)],
+    )
+
+    records = loader.load_quotes(
+        pd.Timestamp("2026-01-19", tz="UTC"),
+        pd.Timestamp("2026-01-19 23:59:59", tz="UTC"),
+        market_slug="cache-test",
+        token_index=0,
+        outcome=None,
+    )
+
+    assert len(records) == 1
+    assert calls == ["cache"]
+
+
+def test_telonex_load_quotes_uses_local_before_api_after_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.reload(telonex_module)
+    loader_cls = module.RunnerPolymarketTelonexQuoteDataLoader
+    loader = loader_cls.__new__(loader_cls)
+    config = module.TelonexLoaderConfig(
+        channel="quotes",
+        ordered_source_entries=(
+            module.TelonexSourceEntry(kind="local", target="/tmp/local"),
+            module.TelonexSourceEntry(
+                kind="api", target="https://api.example.test", api_key="test-key"
+            ),
+        ),
+    )
+    frame = pd.DataFrame(
+        {
+            "timestamp_us": [1_768_780_800_000_000],
+            "bid_price": [0.42],
+            "ask_price": [0.44],
+            "bid_size": [10.0],
+            "ask_size": [11.0],
+        }
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(loader, "_config", lambda: config)
+
+    def fake_cache(**kwargs: object) -> None:
+        calls.append("cache")
+        return None
+
+    def fake_local(**kwargs: object) -> pd.DataFrame:
+        calls.append("local")
+        return frame
+
+    def fail_source(**kwargs: object) -> None:
+        calls.append("api")
+        raise AssertionError("api should not be checked when local has the day")
+
+    monkeypatch.setattr(loader, "_load_api_cache_day", fake_cache)
+    monkeypatch.setattr(loader, "_try_load_day_from_local", fake_local)
+    monkeypatch.setattr(loader, "_try_load_day_from_entry", fail_source)
+    monkeypatch.setattr(
+        loader,
+        "_quote_ticks_from_frame",
+        lambda _frame, *, start, end: [SimpleNamespace(ts_event=1)],
+    )
+
+    records = loader.load_quotes(
+        pd.Timestamp("2026-01-19", tz="UTC"),
+        pd.Timestamp("2026-01-19 23:59:59", tz="UTC"),
+        market_slug="local-test",
+        token_index=0,
+        outcome=None,
+    )
+
+    assert len(records) == 1
+    assert calls == ["cache", "local"]
 
 
 def test_telonex_local_range_matches_consolidated_download_script_layout(tmp_path) -> None:

--- a/tests/test_timing_test.py
+++ b/tests/test_timing_test.py
@@ -39,6 +39,11 @@ def test_transfer_label_identifies_r2_raw_urls() -> None:
 
 
 def test_transfer_label_identifies_telonex_sources() -> None:
+    cache_label = _transfer_label(
+        "telonex-cache::/Users/test/.cache/nautilus_trader/telonex/api-days/hash/"
+        "polymarket/quotes/slug/outcome_id=0/2026-03-01.parquet"
+    )
+    local_blob_label = _transfer_label("telonex-local::/Volumes/LaCie/telonex_data")
     local_label = _transfer_label(
         "telonex-local::/Volumes/LaCie/telonex_data/polymarket/quotes/slug/0/2026-03-01.parquet"
     )
@@ -46,6 +51,8 @@ def test_transfer_label_identifies_telonex_sources() -> None:
         "telonex-api::https://api.telonex.io/v1/downloads/polymarket/quotes/2026-03-01?slug=slug&outcome_id=0"
     )
 
+    assert cache_label == "telonex cache 2026-03-01.parquet"
+    assert local_blob_label == "telonex local telonex_data"
     assert local_label == "telonex local 2026-03-01.parquet"
     assert api_label == "telonex api 2026-03-01"
 


### PR DESCRIPTION
## Summary

- Adds a separate Telonex API-day cache under `TELONEX_CACHE_ROOT` (default `~/.cache/nautilus_trader/telonex`) for runner `api:` fallback downloads.
- Keeps source reporting accurate in timing output: `telonex local`, `telonex cache`, or `telonex api` based on the actual source used.
- Changes `make clear-telonex-cache` to clear only `TELONEX_CACHE_ROOT`, matching the PMXT cache-clearing model.
- Adds a path guard used by PMXT and Telonex cache-clear targets that refuses configured local data stores, paths inside them, and parent paths containing them before any `rm -rf` runs.
- Updates Telonex docs for the API-day cache, clear target, and timing source labels.

## Root Cause

`clear-telonex-cache` was wired to `TELONEX_DATA_DESTINATION`, which is the local Telonex mirror/download destination, not a runner API cache. That made the target capable of deleting a warmed local data store. The runner API path also parsed downloaded daily Parquet payloads from memory without persisting them, so there was no separate cache root for the target to clear.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` (`335 passed, 1 skipped`)
- `uv run mkdocs build --strict`
- Focused cache/guard tests cover API download -> cache hit without API -> clear cache -> API download again, plus refusal when cache roots equal, sit inside, or contain configured local data roots.

Real Telonex API smoke was attempted earlier, but `TELONEX_API_KEY` was not set in the shell where Codex ran.
