### PR TITLE
[codex] fix Telonex part file explosion

### DIFF
--- a/scripts/_telonex_data_download.py
+++ b/scripts/_telonex_data_download.py
@@ -36,7 +36,8 @@ _EXCHANGE = "polymarket"
 _DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 _MANIFEST_FILENAME = "telonex.duckdb"
 _DATA_SUBDIR = "data"
-_TARGET_PART_BYTES = 1 << 30  # 1 GiB uncompressed Arrow before rolling
+_TARGET_PART_BYTES = 64 << 30  # uncompressed Arrow safety cap before rolling
+_TARGET_PART_DISK_BYTES = 512 << 20  # compressed on-disk Parquet target before rolling
 _PARQUET_COMPRESSION = "zstd"
 _PARQUET_COMPRESSION_LEVEL = 3
 # Keep pending_for_commit bounded so book_snapshot_full Arrow tables don't pin
@@ -53,6 +54,11 @@ _FORCE_EXIT_SIGNAL_COUNT = 5
 _MARKETS_BATCH_ROWS = 100_000
 _HTTP_KEEPALIVE_EXPIRY_SECS = 30.0
 _DEFAULT_PARSE_WORKERS = min(8, max(1, os.cpu_count() or 2))
+_ORDER_BOOK_LEVEL_TYPE = pa.struct([pa.field("price", pa.string()), pa.field("size", pa.string())])
+_ORDER_BOOK_LEVELS_TYPE = pa.list_(pa.field("element", _ORDER_BOOK_LEVEL_TYPE))
+_ORDER_BOOK_SIDE_COLUMNS = frozenset({"bids", "asks"})
+_INT_TIMESTAMP_COLUMNS = frozenset({"timestamp_us", "block_timestamp_us"})
+_FLOAT_TIMESTAMP_COLUMNS = frozenset({"local_timestamp_us"})
 
 _CHANNEL_COLUMN_SUFFIX = {
     "trades": ("trades_from", "trades_to"),
@@ -227,7 +233,8 @@ class _CancelledError(Exception):
 class _OpenPart:
     """A Parquet part-file that's open for appending row groups.
 
-    Stays open across commit batches until it crosses `_TARGET_PART_BYTES`;
+    Stays open across commit batches until it crosses the compressed on-disk
+    part target or the uncompressed Arrow safety cap;
     only then do we close it and flush its manifest rows. Partial parts on
     crash are orphaned but never referenced from the manifest, so they're
     benign — the affected days re-download on the next run.
@@ -237,7 +244,108 @@ class _OpenPart:
     writer: pq.ParquetWriter
     schema: pa.Schema
     bytes_written: int
+    disk_bytes: int
     pending: list[tuple[_DownloadResult, int]]  # (result, row_count) waiting for manifest commit
+
+
+def _is_nullish_type(value_type: pa.DataType) -> bool:
+    if pa.types.is_null(value_type):
+        return True
+    if pa.types.is_list(value_type) or pa.types.is_large_list(value_type):
+        return _is_nullish_type(value_type.value_type)
+    return False
+
+
+def _normalize_telonex_table(table: pa.Table) -> pa.Table:
+    fields: list[pa.Field] = []
+    changed = False
+    for schema_field in table.schema:
+        target_type = schema_field.type
+        if schema_field.name in _ORDER_BOOK_SIDE_COLUMNS and _is_nullish_type(schema_field.type):
+            target_type = _ORDER_BOOK_LEVELS_TYPE
+        elif schema_field.name in _INT_TIMESTAMP_COLUMNS and pa.types.is_floating(
+            schema_field.type
+        ):
+            target_type = pa.int64()
+        elif schema_field.name in _FLOAT_TIMESTAMP_COLUMNS and pa.types.is_integer(
+            schema_field.type
+        ):
+            target_type = pa.float64()
+
+        if target_type.equals(schema_field.type):
+            fields.append(schema_field)
+            continue
+        fields.append(
+            pa.field(
+                schema_field.name,
+                target_type,
+                nullable=schema_field.nullable,
+                metadata=schema_field.metadata,
+            )
+        )
+        changed = True
+
+    if not changed:
+        return table
+
+    schema = pa.schema(fields, metadata=table.schema.metadata)
+    try:
+        return table.cast(schema, safe=True)
+    except (pa.ArrowInvalid, pa.ArrowTypeError):
+        return table
+
+
+def _merge_promotable_schema(base: pa.Schema, incoming: pa.Schema) -> pa.Schema | None:
+    """Merge schemas when differences are additive or null-only.
+
+    Parquet files cannot change schema after their writer is opened. This lets
+    the store learn a stable channel schema for future parts while avoiding
+    unsafe numeric/string coercions that could hide real data defects.
+    """
+    incoming_by_name = {field.name: field for field in incoming}
+    merged_fields: list[pa.Field] = []
+    for base_field in base:
+        incoming_field = incoming_by_name.pop(base_field.name, None)
+        if incoming_field is None:
+            merged_fields.append(base_field)
+            continue
+        if base_field.type.equals(incoming_field.type):
+            merged_fields.append(base_field)
+        elif _is_nullish_type(base_field.type):
+            merged_fields.append(incoming_field)
+        elif _is_nullish_type(incoming_field.type):
+            merged_fields.append(base_field)
+        else:
+            return None
+
+    merged_fields.extend(incoming_by_name.values())
+    return pa.schema(merged_fields, metadata=base.metadata or incoming.metadata)
+
+
+def _align_table_to_schema(table: pa.Table, schema: pa.Schema) -> pa.Table | None:
+    source_names = set(table.schema.names)
+    target_names = set(schema.names)
+    if source_names - target_names:
+        return None
+
+    arrays = []
+    for target_field in schema:
+        source_index = table.schema.get_field_index(target_field.name)
+        if source_index < 0:
+            arrays.append(pa.nulls(table.num_rows, type=target_field.type))
+            continue
+        source_field = table.schema.field(source_index)
+        if not source_field.type.equals(target_field.type) and not _is_nullish_type(
+            source_field.type
+        ):
+            return None
+        arrays.append(table.column(source_index))
+
+    aligned = pa.Table.from_arrays(arrays, schema=schema)
+    try:
+        return aligned.cast(schema, safe=True)
+    except (pa.ArrowInvalid, pa.ArrowTypeError):
+        return None
 
 
 class _TelonexParquetStore:
@@ -250,9 +358,10 @@ class _TelonexParquetStore:
           data/
             channel=<channel>/year=<y>/month=<mm>/part-NNNNNN.parquet
 
-    Writer rolls a new part file when the open part crosses `_TARGET_PART_BYTES`
-    or when the incoming batch's schema doesn't match the open writer's schema
-    (new columns appearing mid-stream). Readers query everything via
+    Writer rolls a new part file when the open part crosses the compressed
+    on-disk target or the uncompressed Arrow safety cap. It normalizes common
+    Telonex schema drift before writing, so empty order-book sides and optional
+    columns don't create one tiny file per batch. Readers query everything via
     `read_parquet('<root>/data/channel=X/**/*.parquet', hive_partitioning=1,
     union_by_name=True)` — DuckDB prunes on year/month for free.
     """
@@ -266,6 +375,8 @@ class _TelonexParquetStore:
         self._con = duckdb.connect(str(self._manifest_path))
         self._init_schema()
         self._writers: dict[tuple[str, int, int], _OpenPart] = {}
+        self._channel_schemas: dict[str, pa.Schema] = {}
+        self._closed = False
         # A previous run killed via SIGTERM/SIGKILL may have left half-written
         # Parquet files on disk — no footer, unreadable. Sweep them before any
         # new writes so the channel globs stay clean.
@@ -282,9 +393,13 @@ class _TelonexParquetStore:
     def close(self) -> None:
         """Flush all open writers and close the manifest. Idempotent."""
         with self._lock:
+            if self._closed:
+                return
             for key in list(self._writers.keys()):
                 self._flush_open_part_locked(key)
+            self._remove_orphan_parts()
             self._con.close()
+            self._closed = True
 
     def _init_schema(self) -> None:
         with self._lock:
@@ -401,6 +516,7 @@ class _TelonexParquetStore:
             writer=writer,
             schema=schema,
             bytes_written=0,
+            disk_bytes=0,
             pending=[],
         )
 
@@ -514,31 +630,58 @@ class _TelonexParquetStore:
         table: pa.Table,
         pending: list[tuple[_DownloadResult, int]],
     ) -> int:
-        """Write one Arrow table to a partition, rolling when schema changes.
+        """Write one Arrow table to a partition, rolling when needed.
 
         Caller holds the lock.
         """
+        table = _normalize_telonex_table(table)
+        channel = key[0]
+        channel_schema = self._channel_schemas.get(channel)
+        if channel_schema is None:
+            channel_schema = table.schema
+            self._channel_schemas[channel] = channel_schema
+        else:
+            merged_schema = _merge_promotable_schema(channel_schema, table.schema)
+            if merged_schema is not None:
+                channel_schema = merged_schema
+                self._channel_schemas[channel] = channel_schema
+                aligned = _align_table_to_schema(table, channel_schema)
+                if aligned is not None:
+                    table = aligned
 
         part = self._writers.get(key)
-        if part is not None and not part.schema.equals(table.schema):
-            # Schema changed mid-partition (new column, type promotion, etc.) —
-            # close the current part and start a new one. `union_by_name=True`
-            # on read lets the two files coexist.
-            self._flush_open_part_locked(key)
-            part = None
+        if part is not None:
+            aligned = _align_table_to_schema(table, part.schema)
+            if aligned is not None:
+                table = aligned
+            else:
+                # Parquet writers cannot change schema in-place. True additive
+                # schema evolution rolls once, then future rows align to the
+                # learned channel schema.
+                self._flush_open_part_locked(key)
+                part = None
 
         if part is None:
+            open_schema = self._channel_schemas.get(channel)
+            if open_schema is not None:
+                aligned = _align_table_to_schema(table, open_schema)
+                if aligned is not None:
+                    table = aligned
             part = self._open_part(key, table.schema)
             self._writers[key] = part
 
         total_rows = table.num_rows
         part.writer.write_table(table)
         part.bytes_written += table.nbytes
+        try:
+            part.disk_bytes = part.path.stat().st_size
+        except OSError:
+            part.disk_bytes = 0
         part.pending.extend(pending)
 
         del table
 
-        if part.bytes_written >= _TARGET_PART_BYTES:
+        if part.disk_bytes >= _TARGET_PART_DISK_BYTES or part.bytes_written >= _TARGET_PART_BYTES:
             self._flush_open_part_locked(key)
 
         return total_rows
@@ -723,17 +866,8 @@ def _fetch_markets_dataset(
     payload = b"".join(chunks)
     parquet = pq.ParquetFile(io.BytesIO(payload))
     total_rows = parquet.metadata.num_rows if parquet.metadata is not None else None
-    batches: list[pa.RecordBatch] = []
-    with tqdm(
-        total=total_rows,
-        desc="Loading Telonex markets",
-        unit="market",
-        dynamic_ncols=True,
-        disable=not show_progress,
-    ) as progress:
-        for batch in parquet.iter_batches(batch_size=_MARKETS_BATCH_ROWS):
-            batches.append(batch)
-            progress.update(batch.num_rows)
+    del total_rows
+    batches = list(parquet.iter_batches(batch_size=_MARKETS_BATCH_ROWS))
     table = pa.Table.from_batches(batches, schema=parquet.schema_arrow)
     return table.to_pandas()
 
@@ -788,9 +922,6 @@ def _iter_jobs_from_catalog(
     Drops unused columns upfront so the 5+ GiB catalog shrinks before
     the reusable iterable holds a reference to the slim frame.
     """
-    if show_progress:
-        print("[telonex] Planning Telonex jobs from catalog...", file=sys.stderr)
-
     # Collect only the columns we need: slug, status, and per-channel date bounds.
     needed_cols: list[str] = ["slug"]
     if status_filter is not None:
@@ -813,20 +944,9 @@ def _iter_jobs_from_catalog(
     # upfront so the per-row loop does zero datetime parsing (the main bottleneck).
     window_start_ts = pd.Timestamp(window_start, tz=UTC) if window_start is not None else None
     window_end_ts = pd.Timestamp(window_end, tz=UTC) if window_end is not None else None
-    channel_progress = (
-        tqdm(
-            channels,
-            desc="Planning Telonex channels",
-            unit="channel",
-            dynamic_ncols=True,
-        )
-        if show_progress
-        else channels
-    )
-    for ch in channel_progress:
+    del show_progress
+    for ch in channels:
         from_col, to_col = _CHANNEL_COLUMN_SUFFIX[ch]
-        if show_progress:
-            channel_progress.set_postfix_str(ch, refresh=False)
         for col in (from_col, to_col):
             if col in frame.columns:
                 frame[col] = pd.to_datetime(
@@ -855,19 +975,7 @@ def _iter_jobs_from_catalog(
         raise ValueError("Telonex markets catalog is missing required 'slug' column.")
 
     total_jobs = 0
-    count_progress = (
-        tqdm(
-            channel_col_idxs,
-            desc="Counting Telonex day jobs",
-            unit="channel",
-            dynamic_ncols=True,
-        )
-        if show_progress
-        else channel_col_idxs
-    )
-    for ch, _from_idx, _to_idx in count_progress:
-        if show_progress:
-            count_progress.set_postfix_str(ch, refresh=False)
+    for ch, _from_idx, _to_idx in channel_col_idxs:
         from_col, to_col = _CHANNEL_COLUMN_SUFFIX[ch]
         valid = frame[from_col].notna() & frame[to_col].notna() & (frame[from_col] <= frame[to_col])
         if not valid.any():
@@ -883,12 +991,6 @@ def _iter_jobs_from_catalog(
         markets_considered=len(frame),
         total_jobs=total_jobs,
     )
-    if show_progress:
-        print(
-            f"[telonex] Planned {plan.total_jobs:,} day job(s) across "
-            f"{plan.markets_considered:,} market(s).",
-            file=sys.stderr,
-        )
     return plan
 
 
@@ -1858,8 +1960,6 @@ def download_telonex_days(
             markets = _fetch_markets_dataset(
                 base_url, timeout_secs=max(30, timeout_secs), show_progress=show_progress
             )
-            if show_progress:
-                print(f"Loaded {len(markets):,} markets", file=sys.stderr)
             slug_filter = set(market_slugs) if market_slugs else None
             outcomes = outcomes_for_all or [0, 1]
             catalog_jobs = _iter_jobs_from_catalog(
@@ -1938,7 +2038,8 @@ def download_telonex_days(
             print(
                 f"[telonex] Channels={channels} workers={workers} "
                 f"retries={_DEFAULT_MAX_RETRIES} timeout={timeout_secs}s "
-                f"part-roll-at={_format_bytes(_TARGET_PART_BYTES)}.",
+                f"part-roll-at={_format_bytes(_TARGET_PART_DISK_BYTES)} on disk "
+                f"or {_format_bytes(_TARGET_PART_BYTES)} Arrow.",
                 file=sys.stderr,
             )
 

--- a/tests/test_telonex_data_download.py
+++ b/tests/test_telonex_data_download.py
@@ -59,6 +59,56 @@ def _parquet_payload_with_local_timestamp(value: int | float) -> bytes:
     return buffer.getvalue()
 
 
+def _book_snapshot_payload(
+    timestamp_us: int,
+    *,
+    bids_type: str = "levels",
+    asks_type: str = "levels",
+) -> bytes:
+    levels_type = telonex_download.pa.list_(
+        telonex_download.pa.field(
+            "element",
+            telonex_download.pa.struct(
+                [
+                    telonex_download.pa.field("price", telonex_download.pa.string()),
+                    telonex_download.pa.field("size", telonex_download.pa.string()),
+                ]
+            ),
+        )
+    )
+
+    def side(kind: str):
+        if kind == "null":
+            return telonex_download.pa.array(
+                [[]], type=telonex_download.pa.list_(telonex_download.pa.null())
+            )
+        return telonex_download.pa.array(
+            [[{"price": "0.44", "size": "10"}]],
+            type=levels_type,
+        )
+
+    table = telonex_download.pa.table(
+        {
+            "timestamp_us": telonex_download.pa.array(
+                [timestamp_us], type=telonex_download.pa.int64()
+            ),
+            "local_timestamp_us": telonex_download.pa.array(
+                [float(timestamp_us)], type=telonex_download.pa.float64()
+            ),
+            "exchange": ["polymarket"],
+            "market_id": ["m1"],
+            "slug": ["book-market"],
+            "asset_id": ["asset-0"],
+            "outcome": ["Yes"],
+            "bids": side(bids_type),
+            "asks": side(asks_type),
+        }
+    )
+    buffer = BytesIO()
+    telonex_download.pq.write_table(table, buffer)
+    return buffer.getvalue()
+
+
 def _install_payload_stub(
     monkeypatch: pytest.MonkeyPatch,
     payloads_by_day: dict[str, bytes],
@@ -484,12 +534,12 @@ def test_download_telonex_days_schema_evolves_when_later_day_has_new_column(
     assert rows == [(None,), ("abc123",)]
 
 
-def test_download_telonex_days_rolls_when_arrow_types_conflict(
+def test_download_telonex_days_normalizes_local_timestamps_to_float(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     payloads = {
         "2026-01-19": _parquet_payload_with_local_timestamp(1_768_780_800_000_000),
-        "2026-01-20": _parquet_payload_with_local_timestamp(1_768_867_200_000_000.0),
+        "2026-01-20": _parquet_payload_with_local_timestamp(1_768_867_200_000_000.75),
     }
 
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
@@ -519,7 +569,84 @@ def test_download_telonex_days_rolls_when_arrow_types_conflict(
         con.close()
 
     assert len(manifest) == 2
-    assert manifest[0][1] != manifest[1][1]
+    assert manifest[0][1] == manifest[1][1]
+
+    part = tmp_path / manifest[0][1]
+    schema = telonex_download.pq.ParquetFile(part).schema_arrow
+    assert schema.field("local_timestamp_us").type == telonex_download.pa.float64()
+
+
+def test_download_telonex_days_keeps_empty_book_sides_in_one_part(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _book_snapshot_payload(1_768_780_800_000_000),
+        "2026-01-20": _book_snapshot_payload(1_768_867_200_000_000, bids_type="null"),
+        "2026-01-21": _book_snapshot_payload(1_768_953_600_000_000, asks_type="null"),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    summary = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["book-market"],
+        outcome_id=0,
+        channel="book_snapshot_full",
+        start_date="2026-01-19",
+        end_date="2026-01-21",
+        show_progress=False,
+        workers=1,
+    )
+
+    assert summary.downloaded_days == 3
+    assert summary.failed_days == 0
+    parts = sorted((tmp_path / "data").rglob("*.parquet"))
+    assert len(parts) == 1
+    schema = telonex_download.pq.ParquetFile(parts[0]).schema_arrow
+    assert schema.field("bids").type.equals(telonex_download._ORDER_BOOK_LEVELS_TYPE)
+    assert schema.field("asks").type.equals(telonex_download._ORDER_BOOK_LEVELS_TYPE)
+
+
+def test_download_telonex_days_reuses_promoted_optional_column_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _parquet_payload_with_extra(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload_with_extra(
+            1_768_867_200_000_000, extra_columns={"origin_asset_id": "abc123"}
+        ),
+        "2026-01-21": _parquet_payload_with_extra(1_768_953_600_000_000),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    summary = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["optional-column-market"],
+        outcome_id=0,
+        start_date="2026-01-19",
+        end_date="2026-01-21",
+        show_progress=False,
+        workers=1,
+    )
+
+    assert summary.downloaded_days == 3
+    assert summary.failed_days == 0
+
+    con = duckdb.connect(str(tmp_path / "telonex.duckdb"), read_only=True)
+    try:
+        rows = con.execute("SELECT day, parquet_part FROM completed_days ORDER BY day").fetchall()
+    finally:
+        con.close()
+
+    assert len({row[1] for row in rows}) == 2
+    assert rows[1][1] == rows[2][1]
 
 
 def test_download_telonex_days_retries_transient_5xx_then_succeeds(
@@ -732,6 +859,75 @@ def test_download_telonex_progress_format_includes_bar_percent_and_eta(
     assert all("{remaining}" in fmt for fmt in download_bar_formats)
 
 
+def test_all_markets_progress_only_uses_fetch_and_download_bars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    markets = pd.DataFrame(
+        {
+            "slug": ["market-one"],
+            "quotes_from": ["2026-01-19"],
+            "quotes_to": ["2026-01-19"],
+        }
+    )
+    progress_descs: list[str] = []
+
+    class FakeTqdm:
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            del args
+            desc = kwargs.get("desc")
+            if desc is not None:
+                progress_descs.append(str(desc))
+            self.n = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # type: ignore[no-untyped-def]
+            del exc_type, exc, tb
+            return False
+
+        def update(self, value: int) -> None:
+            self.n += value
+
+        def set_postfix_str(self, value: str, refresh: bool = False) -> None:
+            del value, refresh
+
+        def refresh(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    def fake_fetch_markets_dataset(
+        base_url: str, timeout_secs: int, *, show_progress: bool = False
+    ) -> pd.DataFrame:
+        del base_url, timeout_secs
+        if show_progress:
+            telonex_download.tqdm(total=10, desc="Fetching Telonex markets").close()
+        return markets
+
+    def fake_run_jobs(jobs, **kwargs):
+        assert kwargs["show_progress"] is True
+        list(jobs)
+        telonex_download.tqdm(total=1, desc="Downloading Telonex days").close()
+        return (1, 0, 0, 0, 100, False, [])
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    monkeypatch.setattr(telonex_download, "tqdm", FakeTqdm)
+    monkeypatch.setattr(telonex_download, "_fetch_markets_dataset", fake_fetch_markets_dataset)
+    monkeypatch.setattr(telonex_download, "_run_jobs", fake_run_jobs)
+
+    summary = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        all_markets=True,
+        channels=["quotes"],
+        show_progress=True,
+    )
+
+    assert summary.downloaded_days == 1
+    assert progress_descs == ["Fetching Telonex markets", "Downloading Telonex days"]
+
+
 def test_downloaded_parquet_is_readable_by_telonex_loader(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -906,6 +1102,35 @@ def test_download_telonex_days_rolls_part_files_when_threshold_exceeded(
     assert len({row[1] for row in rows}) == 2
 
 
+def test_download_telonex_days_rolls_part_files_when_disk_threshold_exceeded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_BYTES", 1 << 40)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_DISK_BYTES", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["disk-roll-test"],
+        outcome_id=0,
+        start_date="2026-01-19",
+        end_date="2026-01-20",
+        show_progress=False,
+        workers=1,
+    )
+
+    parts = sorted((tmp_path / "data").rglob("*.parquet"))
+    assert len(parts) == 2
+
+
 def test_store_sweeps_orphan_parquet_on_startup(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -938,6 +1163,22 @@ def test_store_sweeps_orphan_parquet_on_startup(
         assert real_part.exists()
     finally:
         store.close()
+
+
+def test_store_sweeps_orphan_parquet_on_close(tmp_path: Path) -> None:
+    store = telonex_download._TelonexParquetStore(tmp_path)
+    orphan_dir = tmp_path / "data" / "channel=book_snapshot_full" / "year=2026" / "month=01"
+    orphan_dir.mkdir(parents=True, exist_ok=True)
+    orphan = orphan_dir / "part-999999.parquet"
+    telonex_download.pq.write_table(
+        telonex_download.pa.table({"timestamp_us": [1_768_780_800_000_000]}),
+        orphan,
+    )
+    assert orphan.exists()
+
+    store.close()
+
+    assert not orphan.exists()
 
 
 def test_download_telonex_days_resumes_midrun_interruption(


### PR DESCRIPTION
## Summary

- Set Telonex part rolling to a 512 MiB compressed on-disk target, with a 64 GiB uncompressed Arrow safety cap.
- Normalize common Telonex schema drift before writing: empty `bids`/`asks` order-book sides become `list<struct<price,size>>`, `timestamp_us`/`block_timestamp_us` are canonical `int64`, `local_timestamp_us` is canonical `float64`, and missing optional columns are filled once a channel schema has learned them.
- Sweep unreferenced readable Parquet parts on graceful close after open writers flush, so interrupted/rolled-away files do not remain in channel globs.
- Remove the non-download progress bars for loading markets, planning channels, and counting jobs while preserving the fetching-markets and downloading-days bars.

## Root Cause

`book_snapshot_full` compresses extremely well, so the old 1 GiB Arrow-only roll threshold produced tiny compressed files. My first pass fixed that part, but missed the live-data schema churn: `local_timestamp_us` can contain fractional microseconds, so safe-casting it to `int64` failed and the writer kept alternating between integer and double schemas. Parquet writers cannot change schema in-place, so that alternation still forced tiny part rolls.

The fix preserves fractional `local_timestamp_us` values as `float64`, keeps true integral timestamp columns as `int64`, and only rolls parts for size or genuinely incompatible writer state.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` (`344 passed, 1 skipped`)
- `uv run pytest tests/test_telonex_data_download.py -q` (`25 passed`)
- Live 10+ minute clean run using the exact command from the issue against `/Volumes/LaCie/telonex_data`: `21,754` downloaded, `7,992` missing, `0` failed, `3.06 GiB` fetched, `2.3 GiB` store, `63` total Parquet files; `book_snapshot_full` was `11` files for about `2.04 GiB`.
- Final clean Ctrl-C run after the close-sweep patch: `4,465` downloaded, `1,532` missing, `0` failed; all Parquet files readable, `0` unreferenced files, `book_snapshot_full` had `7` files and `1` schema.