### PR TITLE
[codex] fix telonex l2 execution realism

### DIFF
--- a/backtests/kalshi_trade_tick_breakout.py
+++ b/backtests/kalshi_trade_tick_breakout.py
@@ -27,6 +27,10 @@ from prediction_market_extensions.backtesting._experiments import (
     build_replay_experiment,
     run_experiment,
 )
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
@@ -80,6 +84,16 @@ STRATEGY_CONFIGS = [
     }
 ]
 
+EXECUTION = ExecutionModelConfig(
+    queue_position=False,
+    latency_model=StaticLatencyConfig(
+        base_latency_ms=75.0,
+        insert_latency_ms=10.0,
+        update_latency_ms=5.0,
+        cancel_latency_ms=5.0,
+    ),
+)
+
 REPORT = MarketReportConfig(
     count_key="trades",
     count_label="Trades",
@@ -97,6 +111,7 @@ EXPERIMENT = build_replay_experiment(
     probability_window=60,
     min_trades=200,
     min_price_range=0.03,
+    execution=EXECUTION,
     report=REPORT,
     empty_message="No Kalshi breakout sims met the trade-tick requirements.",
     emit_html=True,

--- a/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/kalshi_trade_tick_independent_multi_replay_runner.py
@@ -22,6 +22,10 @@ from prediction_market_extensions.backtesting._experiments import (
     build_replay_experiment,
     run_experiment,
 )
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
@@ -103,6 +107,16 @@ STRATEGY_CONFIGS = [
     }
 ]
 
+EXECUTION = ExecutionModelConfig(
+    queue_position=False,
+    latency_model=StaticLatencyConfig(
+        base_latency_ms=75.0,
+        insert_latency_ms=10.0,
+        update_latency_ms=5.0,
+        cancel_latency_ms=5.0,
+    ),
+)
+
 REPORT = MarketReportConfig(
     count_key="trades",
     count_label="Trades",
@@ -123,6 +137,7 @@ EXPERIMENT = build_replay_experiment(
     probability_window=60,
     min_trades=200,
     min_price_range=0.03,
+    execution=EXECUTION,
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,

--- a/backtests/kalshi_trade_tick_joint_portfolio_runner.py
+++ b/backtests/kalshi_trade_tick_joint_portfolio_runner.py
@@ -22,6 +22,10 @@ from prediction_market_extensions.backtesting._experiments import (
     build_replay_experiment,
     run_experiment,
 )
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
@@ -101,6 +105,16 @@ STRATEGY_CONFIGS = [
     }
 ]
 
+EXECUTION = ExecutionModelConfig(
+    queue_position=False,
+    latency_model=StaticLatencyConfig(
+        base_latency_ms=75.0,
+        insert_latency_ms=10.0,
+        update_latency_ms=5.0,
+        cancel_latency_ms=5.0,
+    ),
+)
+
 REPORT = MarketReportConfig(
     count_key="trades",
     count_label="Trades",
@@ -121,6 +135,7 @@ EXPERIMENT = build_replay_experiment(
     probability_window=60,
     min_trades=200,
     min_price_range=0.03,
+    execution=EXECUTION,
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,

--- a/backtests/polymarket_telonex_quote_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_telonex_quote_tick_joint_portfolio_runner.py
@@ -133,7 +133,7 @@ STRATEGY_CONFIGS = [
 ]
 
 EXECUTION = ExecutionModelConfig(
-    queue_position=False,
+    queue_position=True,
     latency_model=StaticLatencyConfig(
         base_latency_ms=75.0,
         insert_latency_ms=10.0,

--- a/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
+++ b/backtests/polymarket_trade_tick_independent_multi_replay_runner.py
@@ -22,6 +22,10 @@ from prediction_market_extensions.backtesting._experiments import (
     build_replay_experiment,
     run_experiment,
 )
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
@@ -127,6 +131,16 @@ STRATEGY_CONFIGS = [
     }
 ]
 
+EXECUTION = ExecutionModelConfig(
+    queue_position=False,
+    latency_model=StaticLatencyConfig(
+        base_latency_ms=75.0,
+        insert_latency_ms=10.0,
+        update_latency_ms=5.0,
+        cancel_latency_ms=5.0,
+    ),
+)
+
 REPORT = MarketReportConfig(
     count_key="trades",
     count_label="Trades",
@@ -148,6 +162,7 @@ EXPERIMENT = build_replay_experiment(
     probability_window=80,
     min_trades=25,
     min_price_range=0.01,
+    execution=EXECUTION,
     report=REPORT,
     empty_message="No fixed Polymarket basket sims met the trade-tick requirements.",
     partial_message="Completed {completed} of {total} fixed basket sims.",

--- a/backtests/polymarket_trade_tick_joint_portfolio_runner.py
+++ b/backtests/polymarket_trade_tick_joint_portfolio_runner.py
@@ -22,6 +22,10 @@ from prediction_market_extensions.backtesting._experiments import (
     build_replay_experiment,
     run_experiment,
 )
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
@@ -128,6 +132,16 @@ STRATEGY_CONFIGS = [
     }
 ]
 
+EXECUTION = ExecutionModelConfig(
+    queue_position=False,
+    latency_model=StaticLatencyConfig(
+        base_latency_ms=75.0,
+        insert_latency_ms=10.0,
+        update_latency_ms=5.0,
+        cancel_latency_ms=5.0,
+    ),
+)
+
 REPORT = MarketReportConfig(
     count_key="trades",
     count_label="Trades",
@@ -149,6 +163,7 @@ EXPERIMENT = build_replay_experiment(
     probability_window=80,
     min_trades=25,
     min_price_range=0.01,
+    execution=EXECUTION,
     report=REPORT,
     empty_message=EMPTY_MESSAGE,
     partial_message=PARTIAL_MESSAGE,

--- a/backtests/polymarket_trade_tick_vwap_reversion.py
+++ b/backtests/polymarket_trade_tick_vwap_reversion.py
@@ -24,6 +24,10 @@ from prediction_market_extensions.backtesting._experiments import (
     build_replay_experiment,
     run_experiment,
 )
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._prediction_market_backtest import MarketReportConfig
 from prediction_market_extensions.backtesting._prediction_market_runner import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import TradeReplay
@@ -83,6 +87,16 @@ STRATEGY_CONFIGS = [
     }
 ]
 
+EXECUTION = ExecutionModelConfig(
+    queue_position=False,
+    latency_model=StaticLatencyConfig(
+        base_latency_ms=75.0,
+        insert_latency_ms=10.0,
+        update_latency_ms=5.0,
+        cancel_latency_ms=5.0,
+    ),
+)
+
 REPORT = MarketReportConfig(
     count_key="trades",
     count_label="Trades",
@@ -100,6 +114,7 @@ EXPERIMENT = build_replay_experiment(
     probability_window=30,
     min_trades=300,
     min_price_range=0.005,
+    execution=EXECUTION,
     report=REPORT,
     empty_message="No Polymarket VWAP-reversion sims met the trade-tick requirements.",
     emit_html=True,

--- a/docs/backtests.md
+++ b/docs/backtests.md
@@ -538,7 +538,9 @@ workflows:
 
 ### Telonex
 
-- `telonex` is a Polymarket quote-tick vendor backed by Telonex Parquet files
+- `telonex` is a Polymarket quote-tick runner surface backed by Telonex
+  Parquet files; the adapter reads `book_snapshot_full` and replays L2
+  `OrderBookDeltas` plus derived quotes
 - Telonex source parsing accepts `local:` and `api:` only
 - `api:` reads `TELONEX_API_KEY` from the environment and constructs Telonex
   download URLs; never commit keys or put them in `DATA.sources`

--- a/docs/data-vendors.md
+++ b/docs/data-vendors.md
@@ -210,10 +210,13 @@ that field must be present and string-encoded exactly as expected.
 
 ## Telonex
 
-Telonex is a separate Polymarket quote-tick vendor path. It does not use PMXT
-hourly raw files or the PMXT filtered cache. Runner API downloads use a
-separate Telonex API-day cache at `~/.cache/nautilus_trader/telonex` by
-default.
+Telonex is a separate Polymarket vendor path. The public runner surface still
+uses `data_type=quote_tick`, but the Telonex adapter pins the
+`book_snapshot_full` channel, converts full-depth book snapshots into L2
+`OrderBookDeltas`, and emits derived `QuoteTick`s for strategies and reports.
+It does not use PMXT hourly raw files or the PMXT filtered cache. Runner API
+downloads use a separate Telonex API-day cache at
+`~/.cache/nautilus_trader/telonex` by default.
 
 Telonex source syntax is also explicit:
 

--- a/docs/execution-modeling.md
+++ b/docs/execution-modeling.md
@@ -29,19 +29,23 @@ the raw venue data are:
 - PMXT-backed Polymarket L2 backtests do not use the synthetic one-tick taker
   fill model; they replay historical `OrderBookDeltas` with `book_type=L2_MBP`
   and `liquidity_consumption=True`
+- Telonex-backed Polymarket quote backtests request the `book_snapshot_full`
+  channel, convert full-depth snapshots into L2 `OrderBookDeltas` plus derived
+  `QuoteTick`s, and run with `book_type=L2_MBP`
 
 ## Passive Orders And Queue Position
 
-- public runners can now opt into Nautilus `queue_position=True`
-- the public PMXT quote-tick runners in this repo now enable that heuristic by
-  default, and the public trade-tick late-favorite passive runner now does too
+- public PMXT and Telonex quote-tick runners enable Nautilus
+  `queue_position=True` by default because they replay L2 book data
+- public Kalshi and Polymarket trade-tick runners keep `queue_position=False`
+  because trade prints do not provide book depth to queue against
 - this is still a heuristic, not true venue queue reconstruction
-- Kalshi and Polymarket trade-tick replay can use trade prints to move queue
-  ahead estimates on passive limit orders
-- PMXT quote-tick replay can also enable queue tracking, but that path replays
-  L2 book updates and quotes rather than historical trade ticks, so fills still
-  depend more heavily on book-level clears and price moves than on true trade
-  consumption
+- Kalshi and Polymarket trade-tick replay still uses the static latency model,
+  but queue-position simulation is intentionally disabled for those runners
+- PMXT and Telonex quote-tick replay can also enable queue tracking, but those
+  paths replay MBP book updates and quotes rather than MBO queue events, so
+  fills still depend more heavily on book-level size changes and price moves
+  than on true venue priority reconstruction
 - public MBP data does not expose hidden liquidity, exact priority inside a
   level, or venue-specific matching quirks
 
@@ -49,8 +53,8 @@ the raw venue data are:
 
 - public runners can now attach a static Nautilus latency model through the
   runner config
-- the public PMXT quote-tick runners in this repo now ship with a static
-  latency model enabled by default
+- the public PMXT, Telonex, Kalshi trade-tick, and Polymarket trade-tick
+  runners in this repo now ship with a static latency model enabled by default
 - the current repo-layer surface is a static millisecond model with separate
   base, insert, update, and cancel delays
 - this helps test whether a market-making or quote-chasing strategy only works
@@ -64,11 +68,12 @@ the raw venue data are:
   `loaded_end`, `coverage_ratio`, and `requested_coverage_ratio`
 - Kalshi public backtests here are trade-tick replay only
 - Polymarket PMXT-backed backtests are full L2 order-book replay
-- Polymarket Telonex-backed backtests are quote-tick replay only
+- Polymarket Telonex-backed backtests use full-depth Telonex book snapshots
+  when available
 - taker-heavy strategies that harvest tiny price changes can look much worse
   once fees and one-tick slippage are turned on
-- PMXT L2 helps with taker modeling, but robust maker realism still needs L3
-  or MBO-style data
+- PMXT and Telonex L2 help with taker and passive-book modeling, but robust
+  maker realism still needs L3 or MBO-style data
 
 ## Vendor L2 Behavior
 
@@ -84,14 +89,15 @@ the raw venue data are:
 
 ### Telonex
 
-- Telonex support is quote-tick only in this repo
+- Telonex support uses the `quote_tick` runner surface, but the adapter pins
+  the `book_snapshot_full` channel and replays L2 book data alongside derived
+  quotes
 - `local:` reads already-downloaded Telonex Parquet files, while `api:` uses
   the Telonex download endpoint with `TELONEX_API_KEY` from the environment
-- because Telonex quote ticks do not carry full order-book depth here, the
-  adapter uses the quote-tick execution profile rather than PMXT's L2 passive
-  book profile
-- use PMXT when a strategy depends on L2 replay behavior; use Telonex for
-  quote-tick strategies where the daily Parquet source is the desired input
+- Telonex quote-tick runners use a passive L2 book execution profile with
+  `queue_position=True`, `liquidity_consumption=True`, and static latency
+- use Telonex when the full-depth daily Parquet/API source is the desired
+  Polymarket input; use PMXT when you specifically want the PMXT hourly archive
 
 For concrete timings and source tiers, see [Vendor Fetch Sources And
 Timing](vendor-fetch-sources.md).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -137,12 +137,14 @@ Downloading raw hours (2/3 done, 1 active):  67%|██████████�
 The counts, hour labels, source label, and byte totals vary with the current
 archive and the window you are mirroring.
 
-To mirror a small Telonex quote-tick window locally, run:
+To mirror a small Telonex runner window locally, include the full-depth book
+channel:
 
 ```bash
 TELONEX_API_KEY=... make download-telonex-data TELONEX_DOWNLOAD_FLAGS='\
   --market-slug us-recession-by-end-of-2026 \
   --outcome-id 0 \
+  --channels quotes book_snapshot_full \
   --start-date 2026-01-19 \
   --end-date 2026-02-01'
 ```

--- a/docs/vendor-fetch-sources.md
+++ b/docs/vendor-fetch-sources.md
@@ -67,10 +67,11 @@ printed in the same terminal session:
 
 ## Telonex
 
-Telonex quote-tick runners can read consolidated local Parquet files from
+Telonex quote-tick runners read the `book_snapshot_full` channel as L2 book
+data from consolidated local Parquet files at
 `polymarket/<market>/<outcome>/<channel>.parquet`, or fetch missing daily files
-from `api:` when the local mirror is not present. Use local files first when you
-have warmed them:
+from `api:` when the local mirror is not present. Use local files first when
+you have warmed them:
 
 ```python
 DATA = MarketDataConfig(
@@ -90,7 +91,13 @@ of `Fetching hours`. Active status lines show the actual source class:
 `telonex local` for local mirrors, `telonex cache` for cached API-day payloads,
 or `telonex api` for network downloads. API downloads show byte progress when
 the response exposes a content length; every source reports scan rows, matched
-quote rows, and a completed line for each date.
+book/quote rows, and a completed line for each date.
+
+If a local Telonex blob partition contains a Parquet part that is not readable
+yet, for example because a downloader is actively writing the mirror, the runner
+rejects that local blob slice and tries the next source instead of silently
+replaying partial L2 books. With the public source priority, that means API-day
+cache first, then local, then `api:`.
 
 When `TELONEX_CACHE_ROOT` is enabled, the `Telonex source:` line includes the
 implicit cache layer before the configured `local:` and `api:` entries, for
@@ -109,7 +116,7 @@ Telonex source: explicit priority (cache -> local /Volumes/LaCie/telonex_data ->
 | Remote raw PMXT archive | network and file-size bound | Hour is missing from local cache and local raw mirror, so the client downloads the upstream raw parquet to a temp file and filters it locally |
 | Local Telonex daily Parquet | local disk bound | You warmed `/Volumes/LaCie/telonex_data` and listed `local:/Volumes/LaCie/telonex_data` before `api:` |
 | Telonex API-day cache | local disk bound | The same Telonex API day was downloaded earlier and cached under `TELONEX_CACHE_ROOT` |
-| Telonex API daily Parquet | network and file-size bound | The local daily file and API-day cache are missing, so the runner falls back to `api:` with `TELONEX_API_KEY` in the environment |
+| Telonex API daily Parquet | network and file-size bound | The local daily file is missing or a not-yet-readable local blob partition was rejected, and the API-day cache is missing, so the runner falls back to `api:` with `TELONEX_API_KEY` in the environment |
 | None | <1s | Hour does not exist yet |
 
 ## How To See This Output

--- a/prediction_market_extensions/adapters/prediction_market/research.py
+++ b/prediction_market_extensions/adapters/prediction_market/research.py
@@ -986,7 +986,7 @@ def save_aggregate_backtest_report(
 
     final_equity = float(aggregate_equity.iloc[-1])
     equity_values = pd.Series([snapshot.total_equity for snapshot in equity_curve], dtype=float)
-    running_peak = equity_values.cummax().replace(0.0, pd.NA)
+    running_peak = equity_values.cummax().mask(lambda values: values == 0.0)
     drawdowns = ((equity_values - running_peak) / running_peak).fillna(0.0)
     max_drawdown = float(drawdowns.min()) if not drawdowns.empty else 0.0
     metrics = {
@@ -1219,7 +1219,7 @@ def save_joint_portfolio_backtest_report(
     ]
 
     equity_values = pd.Series([snapshot.total_equity for snapshot in equity_curve], dtype=float)
-    running_peak = equity_values.cummax().replace(0.0, pd.NA)
+    running_peak = equity_values.cummax().mask(lambda values: values == 0.0)
     drawdowns = ((equity_values - running_peak) / running_peak).fillna(0.0)
     max_drawdown = float(drawdowns.min()) if not drawdowns.empty else 0.0
     metrics = {

--- a/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
+++ b/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
@@ -50,6 +50,7 @@ from prediction_market_extensions.backtesting.data_sources.telonex import (
     RunnerPolymarketTelonexQuoteDataLoader as PolymarketTelonexQuoteDataLoader,
 )
 from prediction_market_extensions.backtesting.data_sources.telonex import (
+    TELONEX_FULL_BOOK_CHANNEL,
     configured_telonex_data_source,
 )
 
@@ -533,13 +534,19 @@ class PolymarketTelonexQuoteReplayAdapter(_BaseReplayAdapter):
         super().__init__(
             _key=ReplayAdapterKey("polymarket", "telonex", "quote_tick"),
             _replay_spec_type=QuoteReplay,
-            _configure_sources_fn=configured_telonex_data_source,
+            _configure_sources_fn=lambda *, sources: configured_telonex_data_source(
+                sources=sources,
+                channel=TELONEX_FULL_BOOK_CHANNEL,
+            ),
             _engine_profile=ReplayEngineProfile(
                 venue=POLYMARKET_VENUE,
                 oms_type=OmsType.NETTING,
                 account_type=AccountType.CASH,
                 base_currency=USDC_POS,
                 fee_model_factory=PolymarketFeeModel,
+                fill_model_mode="passive_book",
+                book_type=BookType.L2_MBP,
+                liquidity_consumption=True,
             ),
             _single_market_required_fields=("market_slug",),
             _single_market_forwarded_fields=(
@@ -601,7 +608,7 @@ class PolymarketTelonexQuoteReplayAdapter(_BaseReplayAdapter):
                 replay.market_slug, token_index=replay.token_index
             )
             records = tuple(
-                loader.load_quotes(
+                loader.load_order_book_and_quotes(
                     start,
                     end,
                     market_slug=replay.market_slug,
@@ -610,20 +617,27 @@ class PolymarketTelonexQuoteReplayAdapter(_BaseReplayAdapter):
                 )
             )
         except Exception as exc:
-            print(f"Skip {replay.market_slug}: unable to load Telonex quotes ({exc})")
+            print(f"Skip {replay.market_slug}: unable to load Telonex L2 book data ({exc})")
             return None
 
         if not records:
-            print(f"Skip {replay.market_slug}: no Telonex quotes returned")
+            print(f"Skip {replay.market_slug}: no Telonex L2 book data returned")
             return None
 
-        prices_tuple = tuple(
-            (float(record.bid_price) + float(record.ask_price)) / 2.0 for record in records
-        )
+        quote_tick_type = _resolve_backtest_compat_symbol("QuoteTick", QuoteTick)
+        prices: list[float] = []
+        quote_count = 0
+        for record in records:
+            if not isinstance(record, quote_tick_type):
+                continue
+            quote_count += 1
+            prices.append((float(record.bid_price) + float(record.ask_price)) / 2.0)
+
+        prices_tuple = tuple(prices)
         if not _validate_replay_window(
             market_label=replay.market_slug,
             count_label="quotes",
-            count=len(records),
+            count=quote_count,
             min_record_count=request.min_record_count,
             prices=prices_tuple,
             min_price_range=request.min_price_range,
@@ -634,7 +648,7 @@ class PolymarketTelonexQuoteReplayAdapter(_BaseReplayAdapter):
             replay=replay,
             instrument=loader.instrument,
             records=records,
-            count=len(records),
+            count=quote_count,
             count_key="quotes",
             market_key="slug",
             market_id=replay.market_slug,

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -17,7 +17,18 @@ from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 import numpy as np
 import pandas as pd
+import pyarrow.parquet as pq
+from nautilus_trader.adapters.polymarket.schemas.book import (
+    PolymarketBookLevel,
+    PolymarketBookSnapshot,
+)
+from nautilus_trader.model.data import BookOrder
+from nautilus_trader.model.data import OrderBookDelta
+from nautilus_trader.model.data import OrderBookDeltas
 from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.enums import BookAction
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import RecordFlag
 
 from prediction_market_extensions.adapters.polymarket.loaders import PolymarketDataLoader
 from prediction_market_extensions.backtesting.data_sources._common import (
@@ -34,6 +45,7 @@ TELONEX_CACHE_ROOT_ENV = "TELONEX_CACHE_ROOT"
 
 _TELONEX_DEFAULT_API_BASE_URL = "https://api.telonex.io"
 _TELONEX_DEFAULT_CHANNEL = "quotes"
+TELONEX_FULL_BOOK_CHANNEL = "book_snapshot_full"
 _TELONEX_EXCHANGE = "polymarket"
 _TELONEX_HTTP_TIMEOUT_SECS = 60
 _TELONEX_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
@@ -85,8 +97,8 @@ def _env_value(name: str) -> str | None:
     return stripped
 
 
-def _resolve_channel() -> str:
-    return (_env_value(TELONEX_CHANNEL_ENV) or _TELONEX_DEFAULT_CHANNEL).casefold()
+def _resolve_channel(channel: str | None = None) -> str:
+    return (channel or _env_value(TELONEX_CHANNEL_ENV) or _TELONEX_DEFAULT_CHANNEL).casefold()
 
 
 def _default_cache_root() -> Path:
@@ -200,9 +212,9 @@ def _source_summary(entries: Sequence[TelonexSourceEntry]) -> str:
 
 
 def resolve_telonex_loader_config(
-    *, sources: Sequence[str] | None = None
+    *, sources: Sequence[str] | None = None, channel: str | None = None
 ) -> tuple[TelonexDataSourceSelection, TelonexLoaderConfig]:
-    if sources is None:
+    if sources is None and channel is None:
         current_config = _current_loader_config()
         if current_config is not None:
             return (
@@ -215,7 +227,7 @@ def resolve_telonex_loader_config(
     entries = _classify_telonex_sources(sources) if sources else _default_telonex_sources_from_env()
     return (
         TelonexDataSourceSelection(mode="auto", summary=_source_summary(entries)),
-        TelonexLoaderConfig(channel=_resolve_channel(), ordered_source_entries=entries),
+        TelonexLoaderConfig(channel=_resolve_channel(channel), ordered_source_entries=entries),
     )
 
 
@@ -228,9 +240,9 @@ def resolve_telonex_data_source_selection(
 
 @contextmanager
 def configured_telonex_data_source(
-    *, sources: Sequence[str] | None = None
+    *, sources: Sequence[str] | None = None, channel: str | None = None
 ) -> Iterator[TelonexDataSourceSelection]:
-    selection, config = resolve_telonex_loader_config(sources=sources)
+    selection, config = resolve_telonex_loader_config(sources=sources, channel=channel)
     token = _CURRENT_TELONEX_LOADER_CONFIG.set(config)
     try:
         yield selection
@@ -239,6 +251,18 @@ def configured_telonex_data_source(
 
 
 class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        self._ensure_blob_scan_caches()
+
+    def _ensure_blob_scan_caches(self) -> None:
+        if not hasattr(self, "_telonex_readable_blob_parts"):
+            self._telonex_readable_blob_parts: dict[Path, tuple[tuple[str, ...], bool]] = {}
+        if not hasattr(self, "_telonex_unreadable_blob_parts_warned"):
+            self._telonex_unreadable_blob_parts_warned: set[Path] = set()
+        if not hasattr(self, "_telonex_incomplete_blob_partitions_warned"):
+            self._telonex_incomplete_blob_partitions_warned: set[Path] = set()
+
     def _download_progress(
         self, url: str, downloaded_bytes: int, total_bytes: int | None, finished: bool
     ) -> None:
@@ -295,6 +319,69 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             segments.insert(0, outcome)
         return tuple(segments)
 
+    @staticmethod
+    def _month_partition_dirs(
+        *, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp
+    ) -> tuple[Path, ...]:
+        cursor = start.floor("D").replace(day=1)
+        final = end.floor("D").replace(day=1)
+        dirs: list[Path] = []
+        while cursor <= final:
+            dirs.append(channel_dir / f"year={cursor.year}" / f"month={cursor.month:02d}")
+            cursor += pd.DateOffset(months=1)
+        return tuple(dirs)
+
+    def _readable_blob_part_paths(
+        self, *, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp
+    ) -> tuple[list[str], bool]:
+        self._ensure_blob_scan_caches()
+        paths: list[str] = []
+        incomplete = False
+        for partition_dir in self._month_partition_dirs(
+            channel_dir=channel_dir,
+            start=start,
+            end=end,
+        ):
+            if partition_dir not in self._telonex_readable_blob_parts:
+                self._telonex_readable_blob_parts[partition_dir] = (
+                    self._scan_readable_blob_part_paths(partition_dir)
+                )
+            partition_paths, partition_incomplete = self._telonex_readable_blob_parts[partition_dir]
+            if partition_incomplete:
+                incomplete = True
+                if partition_dir not in self._telonex_incomplete_blob_partitions_warned:
+                    warnings.warn(
+                        "Telonex: local blob partition "
+                        f"{partition_dir} has unreadable part files; trying next "
+                        "source to avoid partial local data.",
+                        stacklevel=2,
+                    )
+                    self._telonex_incomplete_blob_partitions_warned.add(partition_dir)
+            paths.extend(partition_paths)
+        return paths, incomplete
+
+    def _scan_readable_blob_part_paths(self, partition_dir: Path) -> tuple[tuple[str, ...], bool]:
+        if not partition_dir.exists():
+            return (), False
+
+        paths: list[str] = []
+        incomplete = False
+        for path in sorted(partition_dir.glob("*.parquet")):
+            try:
+                pq.read_metadata(path)
+            except (OSError, ValueError, RuntimeError):
+                incomplete = True
+                if path not in self._telonex_unreadable_blob_parts_warned:
+                    warnings.warn(
+                        f"Telonex: parquet part is not readable yet: {path}; "
+                        "trying next source instead of using partial local data.",
+                        stacklevel=2,
+                    )
+                    self._telonex_unreadable_blob_parts_warned.add(path)
+                continue
+            paths.append(str(path))
+        return tuple(paths), incomplete
+
     def _load_blob_range(
         self,
         *,
@@ -319,8 +406,14 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
         # Glob every part file under this channel, regardless of year/month
         # partition depth. Empty-but-existing channel dirs yield no matches,
         # in which case DuckDB will raise — guard with a cheap pre-check.
-        part_glob = str(channel_dir / "**" / "*.parquet")
-        if not any(channel_dir.rglob("*.parquet")):
+        part_paths, incomplete_parts = self._readable_blob_part_paths(
+            channel_dir=channel_dir,
+            start=self._normalize_to_utc(start),
+            end=self._normalize_to_utc(end),
+        )
+        if incomplete_parts:
+            return None
+        if not part_paths:
             return None
 
         segments = self._outcome_segment_candidates(token_index=token_index, outcome=outcome)
@@ -339,7 +432,7 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             "AND CAST(year AS INTEGER) * 100 + CAST(month AS INTEGER) "
             "BETWEEN ? AND ?"
         )
-        params: list[object] = [part_glob, market_slug, *segments, start_ym, end_ym]
+        params: list[object] = [part_paths, market_slug, *segments, start_ym, end_ym]
 
         con = duckdb.connect(":memory:")
         try:
@@ -847,6 +940,206 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
             for bp, ap, bs, sz, ns in zip(bid_px, ask_px, bid_sz, ask_sz, ns_arr, strict=True)
         ]
 
+    @staticmethod
+    def _book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]:
+        if value is None:
+            return ()
+
+        levels: list[tuple[float, str, str]] = []
+        try:
+            iterator = list(value)  # type: ignore[arg-type]
+        except TypeError:
+            return ()
+
+        for raw_level in iterator:
+            if raw_level is None:
+                continue
+            if isinstance(raw_level, dict):
+                raw_price = raw_level.get("price")
+                raw_size = raw_level.get("size")
+            else:
+                raw_price = getattr(raw_level, "price", None)
+                raw_size = getattr(raw_level, "size", None)
+            if raw_price is None or raw_size is None:
+                continue
+            price = float(raw_price)
+            size = float(raw_size)
+            if size <= 0:
+                continue
+            levels.append((price, str(raw_price), str(raw_size)))
+
+        # Nautilus' Polymarket parser takes bids[-1] and asks[-1] as the touch.
+        # Telonex stores bids best-first and asks best-first, so normalize the
+        # ordering before parsing snapshots or deriving quotes.
+        reverse = side == "ask"
+        levels.sort(key=lambda item: item[0], reverse=reverse)
+        return tuple(PolymarketBookLevel(price=price, size=size) for _px, price, size in levels)
+
+    @staticmethod
+    def _book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]:
+        return {str(level.price): str(level.size) for level in levels}
+
+    def _snapshot_to_deltas(
+        self,
+        *,
+        bids: Sequence[PolymarketBookLevel],
+        asks: Sequence[PolymarketBookLevel],
+        ts_event: int,
+    ) -> OrderBookDeltas | None:
+        snapshot = PolymarketBookSnapshot(
+            market=str(getattr(self, "condition_id", "") or ""),
+            asset_id=str(getattr(self, "token_id", "") or ""),
+            bids=list(bids),
+            asks=list(asks),
+            timestamp=str(ts_event / 1_000_000),
+        )
+        return snapshot.parse_to_snapshot(instrument=self.instrument, ts_init=ts_event)
+
+    def _diff_to_deltas(
+        self,
+        *,
+        previous_bids: dict[str, str],
+        previous_asks: dict[str, str],
+        current_bids: dict[str, str],
+        current_asks: dict[str, str],
+        ts_event: int,
+    ) -> OrderBookDeltas | None:
+        changes: list[tuple[OrderSide, str, str]] = []
+
+        for price in sorted(previous_bids.keys() | current_bids.keys(), key=float):
+            size = current_bids.get(price)
+            if size == previous_bids.get(price):
+                continue
+            changes.append((OrderSide.BUY, price, size or "0"))
+
+        for price in sorted(previous_asks.keys() | current_asks.keys(), key=float, reverse=True):
+            size = current_asks.get(price)
+            if size == previous_asks.get(price):
+                continue
+            changes.append((OrderSide.SELL, price, size or "0"))
+
+        if not changes:
+            return None
+
+        deltas: list[OrderBookDelta] = []
+        instrument = self.instrument
+        for idx, (side, price, size) in enumerate(changes):
+            qty = instrument.make_qty(float(size))
+            order = BookOrder(
+                side=side,
+                price=instrument.make_price(float(price)),
+                size=qty,
+                order_id=0,
+            )
+            deltas.append(
+                OrderBookDelta(
+                    instrument_id=instrument.id,
+                    action=BookAction.UPDATE if qty > 0 else BookAction.DELETE,
+                    order=order,
+                    flags=RecordFlag.F_LAST if idx == len(changes) - 1 else 0,
+                    sequence=0,
+                    ts_event=ts_event,
+                    ts_init=ts_event,
+                )
+            )
+        return OrderBookDeltas(instrument.id, deltas)
+
+    def _quote_from_levels(
+        self,
+        *,
+        bids: Sequence[PolymarketBookLevel],
+        asks: Sequence[PolymarketBookLevel],
+        ts_event: int,
+    ) -> QuoteTick | None:
+        snapshot = PolymarketBookSnapshot(
+            market=str(getattr(self, "condition_id", "") or ""),
+            asset_id=str(getattr(self, "token_id", "") or ""),
+            bids=list(bids),
+            asks=list(asks),
+            timestamp=str(ts_event / 1_000_000),
+        )
+        return snapshot.parse_to_quote(instrument=self.instrument, ts_init=ts_event + 1)
+
+    def _book_events_from_frame(
+        self,
+        frame: pd.DataFrame,
+        *,
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+        include_order_book: bool = True,
+        include_quotes: bool = True,
+    ) -> list[OrderBookDeltas | QuoteTick]:
+        if frame.empty:
+            return []
+
+        timestamp_column = self._first_present_column(
+            frame, ("timestamp_us", "timestamp_ms", "timestamp", "time"), label="book snapshot"
+        )
+        bids_column = self._first_present_column(frame, ("bids",), label="book snapshot")
+        asks_column = self._first_present_column(frame, ("asks",), label="book snapshot")
+
+        start_ns = int(self._normalize_to_utc(start).value)
+        end_ns = int(self._normalize_to_utc(end).value)
+        ts_ns = self._column_to_ns(frame[timestamp_column], timestamp_column)
+        mask = ts_ns <= end_ns
+        if not mask.any():
+            return []
+
+        bids_values = frame[bids_column].to_numpy()[mask]
+        asks_values = frame[asks_column].to_numpy()[mask]
+        ns_arr = ts_ns[mask]
+        order = np.argsort(ns_arr, kind="stable")
+
+        events: list[OrderBookDeltas | QuoteTick] = []
+        previous_bids: dict[str, str] | None = None
+        previous_asks: dict[str, str] | None = None
+        emitted_snapshot = False
+
+        for idx in order:
+            ts_event = int(ns_arr[idx])
+            bids = self._book_levels_from_value(bids_values[idx], side="bid")
+            asks = self._book_levels_from_value(asks_values[idx], side="ask")
+            current_bids = self._book_side_map(bids)
+            current_asks = self._book_side_map(asks)
+
+            if ts_event < start_ns:
+                previous_bids = current_bids
+                previous_asks = current_asks
+                continue
+
+            deltas: OrderBookDeltas | None
+            if not emitted_snapshot:
+                deltas = self._snapshot_to_deltas(bids=bids, asks=asks, ts_event=ts_event)
+                emitted_snapshot = deltas is not None
+            else:
+                assert previous_bids is not None
+                assert previous_asks is not None
+                deltas = self._diff_to_deltas(
+                    previous_bids=previous_bids,
+                    previous_asks=previous_asks,
+                    current_bids=current_bids,
+                    current_asks=current_asks,
+                    ts_event=ts_event,
+                )
+
+            if deltas is not None and include_order_book:
+                events.append(deltas)
+            if include_quotes:
+                quote = self._quote_from_levels(bids=bids, asks=asks, ts_event=ts_event)
+                if quote is not None:
+                    events.append(quote)
+
+            previous_bids = current_bids
+            previous_asks = current_asks
+
+        events.sort(
+            key=lambda record: (
+                int(record.ts_event),
+                0 if isinstance(record, OrderBookDeltas) else 1,
+            )
+        )
+        return events
+
     def _try_load_range_from_local(
         self,
         *,
@@ -1069,12 +1362,104 @@ class RunnerPolymarketTelonexQuoteDataLoader(PolymarketDataLoader):
         records.sort(key=lambda quote: quote.ts_event)
         return records
 
+    def load_order_book_and_quotes(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+        *,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+        include_order_book: bool = True,
+        include_quotes: bool = True,
+    ) -> list[OrderBookDeltas | QuoteTick]:
+        config = self._config()
+        records: list[OrderBookDeltas | QuoteTick] = []
+        api_entries = [
+            entry for entry in config.ordered_source_entries if entry.kind == _TELONEX_SOURCE_API
+        ]
+        range_cache: dict[Path, pd.DataFrame | None] = {}
+        for date in self._date_range(start, end):
+            day_window = self._day_window(date, start=start, end=end)
+            if day_window is None:
+                continue
+            day_start, day_end = day_window
+            frame: pd.DataFrame | None = None
+            for entry in api_entries:
+                assert entry.target is not None
+                frame = self._load_api_cache_day(
+                    base_url=entry.target,
+                    channel=config.channel,
+                    date=date,
+                    market_slug=market_slug,
+                    token_index=token_index,
+                    outcome=outcome,
+                )
+                if frame is not None:
+                    break
+            if frame is not None:
+                records.extend(
+                    self._book_events_from_frame(
+                        frame,
+                        start=day_start,
+                        end=day_end,
+                        include_order_book=include_order_book,
+                        include_quotes=include_quotes,
+                    )
+                )
+                continue
+
+            for entry in config.ordered_source_entries:
+                if entry.kind == _TELONEX_SOURCE_LOCAL:
+                    frame = self._try_load_day_from_local(
+                        entry=entry,
+                        channel=config.channel,
+                        date=date,
+                        market_slug=market_slug,
+                        token_index=token_index,
+                        outcome=outcome,
+                        start=day_start,
+                        end=day_end,
+                        range_cache=range_cache,
+                    )
+                else:
+                    frame = self._try_load_day_from_entry(
+                        entry=entry,
+                        channel=config.channel,
+                        date=date,
+                        market_slug=market_slug,
+                        token_index=token_index,
+                        outcome=outcome,
+                    )
+                if frame is not None:
+                    break
+            if frame is None:
+                continue
+            records.extend(
+                self._book_events_from_frame(
+                    frame,
+                    start=day_start,
+                    end=day_end,
+                    include_order_book=include_order_book,
+                    include_quotes=include_quotes,
+                )
+            )
+        records.sort(
+            key=lambda record: (
+                int(record.ts_event),
+                0 if isinstance(record, OrderBookDeltas) else 1,
+                int(record.ts_init),
+            )
+        )
+        return records
+
 
 __all__ = [
     "TELONEX_API_BASE_URL_ENV",
     "TELONEX_CACHE_ROOT_ENV",
     "TELONEX_API_KEY_ENV",
     "TELONEX_CHANNEL_ENV",
+    "TELONEX_FULL_BOOK_CHANNEL",
     "TELONEX_LOCAL_DIR_ENV",
     "RunnerPolymarketTelonexQuoteDataLoader",
     "TelonexDataSourceSelection",

--- a/scripts/_telonex_data_download.py
+++ b/scripts/_telonex_data_download.py
@@ -36,7 +36,8 @@ _EXCHANGE = "polymarket"
 _DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 _MANIFEST_FILENAME = "telonex.duckdb"
 _DATA_SUBDIR = "data"
-_TARGET_PART_BYTES = 1 << 30  # 1 GiB uncompressed Arrow before rolling
+_TARGET_PART_BYTES = 64 << 30  # uncompressed Arrow safety cap before rolling
+_TARGET_PART_DISK_BYTES = 512 << 20  # compressed on-disk Parquet target before rolling
 _PARQUET_COMPRESSION = "zstd"
 _PARQUET_COMPRESSION_LEVEL = 3
 # Keep pending_for_commit bounded so book_snapshot_full Arrow tables don't pin
@@ -53,6 +54,11 @@ _FORCE_EXIT_SIGNAL_COUNT = 5
 _MARKETS_BATCH_ROWS = 100_000
 _HTTP_KEEPALIVE_EXPIRY_SECS = 30.0
 _DEFAULT_PARSE_WORKERS = min(8, max(1, os.cpu_count() or 2))
+_ORDER_BOOK_LEVEL_TYPE = pa.struct([pa.field("price", pa.string()), pa.field("size", pa.string())])
+_ORDER_BOOK_LEVELS_TYPE = pa.list_(pa.field("element", _ORDER_BOOK_LEVEL_TYPE))
+_ORDER_BOOK_SIDE_COLUMNS = frozenset({"bids", "asks"})
+_INT_TIMESTAMP_COLUMNS = frozenset({"timestamp_us", "block_timestamp_us"})
+_FLOAT_TIMESTAMP_COLUMNS = frozenset({"local_timestamp_us"})
 
 _CHANNEL_COLUMN_SUFFIX = {
     "trades": ("trades_from", "trades_to"),
@@ -227,7 +233,8 @@ class _CancelledError(Exception):
 class _OpenPart:
     """A Parquet part-file that's open for appending row groups.
 
-    Stays open across commit batches until it crosses `_TARGET_PART_BYTES`;
+    Stays open across commit batches until it crosses the compressed on-disk
+    part target or the uncompressed Arrow safety cap;
     only then do we close it and flush its manifest rows. Partial parts on
     crash are orphaned but never referenced from the manifest, so they're
     benign — the affected days re-download on the next run.
@@ -237,7 +244,108 @@ class _OpenPart:
     writer: pq.ParquetWriter
     schema: pa.Schema
     bytes_written: int
+    disk_bytes: int
     pending: list[tuple[_DownloadResult, int]]  # (result, row_count) waiting for manifest commit
+
+
+def _is_nullish_type(value_type: pa.DataType) -> bool:
+    if pa.types.is_null(value_type):
+        return True
+    if pa.types.is_list(value_type) or pa.types.is_large_list(value_type):
+        return _is_nullish_type(value_type.value_type)
+    return False
+
+
+def _normalize_telonex_table(table: pa.Table) -> pa.Table:
+    fields: list[pa.Field] = []
+    changed = False
+    for schema_field in table.schema:
+        target_type = schema_field.type
+        if schema_field.name in _ORDER_BOOK_SIDE_COLUMNS and _is_nullish_type(schema_field.type):
+            target_type = _ORDER_BOOK_LEVELS_TYPE
+        elif schema_field.name in _INT_TIMESTAMP_COLUMNS and pa.types.is_floating(
+            schema_field.type
+        ):
+            target_type = pa.int64()
+        elif schema_field.name in _FLOAT_TIMESTAMP_COLUMNS and pa.types.is_integer(
+            schema_field.type
+        ):
+            target_type = pa.float64()
+
+        if target_type.equals(schema_field.type):
+            fields.append(schema_field)
+            continue
+        fields.append(
+            pa.field(
+                schema_field.name,
+                target_type,
+                nullable=schema_field.nullable,
+                metadata=schema_field.metadata,
+            )
+        )
+        changed = True
+
+    if not changed:
+        return table
+
+    schema = pa.schema(fields, metadata=table.schema.metadata)
+    try:
+        return table.cast(schema, safe=True)
+    except (pa.ArrowInvalid, pa.ArrowTypeError):
+        return table
+
+
+def _merge_promotable_schema(base: pa.Schema, incoming: pa.Schema) -> pa.Schema | None:
+    """Merge schemas when differences are additive or null-only.
+
+    Parquet files cannot change schema after their writer is opened. This lets
+    the store learn a stable channel schema for future parts while avoiding
+    unsafe numeric/string coercions that could hide real data defects.
+    """
+    incoming_by_name = {field.name: field for field in incoming}
+    merged_fields: list[pa.Field] = []
+    for base_field in base:
+        incoming_field = incoming_by_name.pop(base_field.name, None)
+        if incoming_field is None:
+            merged_fields.append(base_field)
+            continue
+        if base_field.type.equals(incoming_field.type):
+            merged_fields.append(base_field)
+        elif _is_nullish_type(base_field.type):
+            merged_fields.append(incoming_field)
+        elif _is_nullish_type(incoming_field.type):
+            merged_fields.append(base_field)
+        else:
+            return None
+
+    merged_fields.extend(incoming_by_name.values())
+    return pa.schema(merged_fields, metadata=base.metadata or incoming.metadata)
+
+
+def _align_table_to_schema(table: pa.Table, schema: pa.Schema) -> pa.Table | None:
+    source_names = set(table.schema.names)
+    target_names = set(schema.names)
+    if source_names - target_names:
+        return None
+
+    arrays = []
+    for target_field in schema:
+        source_index = table.schema.get_field_index(target_field.name)
+        if source_index < 0:
+            arrays.append(pa.nulls(table.num_rows, type=target_field.type))
+            continue
+        source_field = table.schema.field(source_index)
+        if not source_field.type.equals(target_field.type) and not _is_nullish_type(
+            source_field.type
+        ):
+            return None
+        arrays.append(table.column(source_index))
+
+    aligned = pa.Table.from_arrays(arrays, schema=schema)
+    try:
+        return aligned.cast(schema, safe=True)
+    except (pa.ArrowInvalid, pa.ArrowTypeError):
+        return None
 
 
 class _TelonexParquetStore:
@@ -250,9 +358,10 @@ class _TelonexParquetStore:
           data/
             channel=<channel>/year=<y>/month=<mm>/part-NNNNNN.parquet
 
-    Writer rolls a new part file when the open part crosses `_TARGET_PART_BYTES`
-    or when the incoming batch's schema doesn't match the open writer's schema
-    (new columns appearing mid-stream). Readers query everything via
+    Writer rolls a new part file when the open part crosses the compressed
+    on-disk target or the uncompressed Arrow safety cap. It normalizes common
+    Telonex schema drift before writing, so empty order-book sides and optional
+    columns don't create one tiny file per batch. Readers query everything via
     `read_parquet('<root>/data/channel=X/**/*.parquet', hive_partitioning=1,
     union_by_name=True)` — DuckDB prunes on year/month for free.
     """
@@ -266,6 +375,8 @@ class _TelonexParquetStore:
         self._con = duckdb.connect(str(self._manifest_path))
         self._init_schema()
         self._writers: dict[tuple[str, int, int], _OpenPart] = {}
+        self._channel_schemas: dict[str, pa.Schema] = {}
+        self._closed = False
         # A previous run killed via SIGTERM/SIGKILL may have left half-written
         # Parquet files on disk — no footer, unreadable. Sweep them before any
         # new writes so the channel globs stay clean.
@@ -282,9 +393,13 @@ class _TelonexParquetStore:
     def close(self) -> None:
         """Flush all open writers and close the manifest. Idempotent."""
         with self._lock:
+            if self._closed:
+                return
             for key in list(self._writers.keys()):
                 self._flush_open_part_locked(key)
+            self._remove_orphan_parts()
             self._con.close()
+            self._closed = True
 
     def _init_schema(self) -> None:
         with self._lock:
@@ -401,6 +516,7 @@ class _TelonexParquetStore:
             writer=writer,
             schema=schema,
             bytes_written=0,
+            disk_bytes=0,
             pending=[],
         )
 
@@ -514,31 +630,58 @@ class _TelonexParquetStore:
         table: pa.Table,
         pending: list[tuple[_DownloadResult, int]],
     ) -> int:
-        """Write one Arrow table to a partition, rolling when schema changes.
+        """Write one Arrow table to a partition, rolling when needed.
 
         Caller holds the lock.
         """
+        table = _normalize_telonex_table(table)
+        channel = key[0]
+        channel_schema = self._channel_schemas.get(channel)
+        if channel_schema is None:
+            channel_schema = table.schema
+            self._channel_schemas[channel] = channel_schema
+        else:
+            merged_schema = _merge_promotable_schema(channel_schema, table.schema)
+            if merged_schema is not None:
+                channel_schema = merged_schema
+                self._channel_schemas[channel] = channel_schema
+                aligned = _align_table_to_schema(table, channel_schema)
+                if aligned is not None:
+                    table = aligned
 
         part = self._writers.get(key)
-        if part is not None and not part.schema.equals(table.schema):
-            # Schema changed mid-partition (new column, type promotion, etc.) —
-            # close the current part and start a new one. `union_by_name=True`
-            # on read lets the two files coexist.
-            self._flush_open_part_locked(key)
-            part = None
+        if part is not None:
+            aligned = _align_table_to_schema(table, part.schema)
+            if aligned is not None:
+                table = aligned
+            else:
+                # Parquet writers cannot change schema in-place. True additive
+                # schema evolution rolls once, then future rows align to the
+                # learned channel schema.
+                self._flush_open_part_locked(key)
+                part = None
 
         if part is None:
+            open_schema = self._channel_schemas.get(channel)
+            if open_schema is not None:
+                aligned = _align_table_to_schema(table, open_schema)
+                if aligned is not None:
+                    table = aligned
             part = self._open_part(key, table.schema)
             self._writers[key] = part
 
         total_rows = table.num_rows
         part.writer.write_table(table)
         part.bytes_written += table.nbytes
+        try:
+            part.disk_bytes = part.path.stat().st_size
+        except OSError:
+            part.disk_bytes = 0
         part.pending.extend(pending)
 
         del table
 
-        if part.bytes_written >= _TARGET_PART_BYTES:
+        if part.disk_bytes >= _TARGET_PART_DISK_BYTES or part.bytes_written >= _TARGET_PART_BYTES:
             self._flush_open_part_locked(key)
 
         return total_rows
@@ -723,17 +866,8 @@ def _fetch_markets_dataset(
     payload = b"".join(chunks)
     parquet = pq.ParquetFile(io.BytesIO(payload))
     total_rows = parquet.metadata.num_rows if parquet.metadata is not None else None
-    batches: list[pa.RecordBatch] = []
-    with tqdm(
-        total=total_rows,
-        desc="Loading Telonex markets",
-        unit="market",
-        dynamic_ncols=True,
-        disable=not show_progress,
-    ) as progress:
-        for batch in parquet.iter_batches(batch_size=_MARKETS_BATCH_ROWS):
-            batches.append(batch)
-            progress.update(batch.num_rows)
+    del total_rows
+    batches = list(parquet.iter_batches(batch_size=_MARKETS_BATCH_ROWS))
     table = pa.Table.from_batches(batches, schema=parquet.schema_arrow)
     return table.to_pandas()
 
@@ -788,9 +922,6 @@ def _iter_jobs_from_catalog(
     Drops unused columns upfront so the 5+ GiB catalog shrinks before
     the reusable iterable holds a reference to the slim frame.
     """
-    if show_progress:
-        print("[telonex] Planning Telonex jobs from catalog...", file=sys.stderr)
-
     # Collect only the columns we need: slug, status, and per-channel date bounds.
     needed_cols: list[str] = ["slug"]
     if status_filter is not None:
@@ -813,20 +944,9 @@ def _iter_jobs_from_catalog(
     # upfront so the per-row loop does zero datetime parsing (the main bottleneck).
     window_start_ts = pd.Timestamp(window_start, tz=UTC) if window_start is not None else None
     window_end_ts = pd.Timestamp(window_end, tz=UTC) if window_end is not None else None
-    channel_progress = (
-        tqdm(
-            channels,
-            desc="Planning Telonex channels",
-            unit="channel",
-            dynamic_ncols=True,
-        )
-        if show_progress
-        else channels
-    )
-    for ch in channel_progress:
+    del show_progress
+    for ch in channels:
         from_col, to_col = _CHANNEL_COLUMN_SUFFIX[ch]
-        if show_progress:
-            channel_progress.set_postfix_str(ch, refresh=False)
         for col in (from_col, to_col):
             if col in frame.columns:
                 frame[col] = pd.to_datetime(
@@ -855,19 +975,7 @@ def _iter_jobs_from_catalog(
         raise ValueError("Telonex markets catalog is missing required 'slug' column.")
 
     total_jobs = 0
-    count_progress = (
-        tqdm(
-            channel_col_idxs,
-            desc="Counting Telonex day jobs",
-            unit="channel",
-            dynamic_ncols=True,
-        )
-        if show_progress
-        else channel_col_idxs
-    )
-    for ch, _from_idx, _to_idx in count_progress:
-        if show_progress:
-            count_progress.set_postfix_str(ch, refresh=False)
+    for ch, _from_idx, _to_idx in channel_col_idxs:
         from_col, to_col = _CHANNEL_COLUMN_SUFFIX[ch]
         valid = frame[from_col].notna() & frame[to_col].notna() & (frame[from_col] <= frame[to_col])
         if not valid.any():
@@ -883,12 +991,6 @@ def _iter_jobs_from_catalog(
         markets_considered=len(frame),
         total_jobs=total_jobs,
     )
-    if show_progress:
-        print(
-            f"[telonex] Planned {plan.total_jobs:,} day job(s) across "
-            f"{plan.markets_considered:,} market(s).",
-            file=sys.stderr,
-        )
     return plan
 
 
@@ -1858,8 +1960,6 @@ def download_telonex_days(
             markets = _fetch_markets_dataset(
                 base_url, timeout_secs=max(30, timeout_secs), show_progress=show_progress
             )
-            if show_progress:
-                print(f"Loaded {len(markets):,} markets", file=sys.stderr)
             slug_filter = set(market_slugs) if market_slugs else None
             outcomes = outcomes_for_all or [0, 1]
             catalog_jobs = _iter_jobs_from_catalog(
@@ -1938,7 +2038,8 @@ def download_telonex_days(
             print(
                 f"[telonex] Channels={channels} workers={workers} "
                 f"retries={_DEFAULT_MAX_RETRIES} timeout={timeout_secs}s "
-                f"part-roll-at={_format_bytes(_TARGET_PART_BYTES)}.",
+                f"part-roll-at={_format_bytes(_TARGET_PART_DISK_BYTES)} on disk "
+                f"or {_format_bytes(_TARGET_PART_BYTES)} Arrow.",
                 file=sys.stderr,
             )
 

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -173,6 +173,35 @@ def test_public_runner_modules_expose_metadata_contract(
     assert callable(globals_dict.get("run"))
 
 
+@pytest.mark.parametrize("relative_path", EXPECTED_PUBLIC_SCRIPT_RUNNER_PATHS)
+def test_public_script_runners_attach_explicit_execution_model(
+    monkeypatch: pytest.MonkeyPatch, relative_path: Path
+) -> None:
+    monkeypatch.setenv("TELONEX_API_KEY", "test-telonex-key")
+    script_path = REPO_ROOT / relative_path
+    normalized_sys_path = [entry for entry in sys.path if Path(entry or ".").resolve() != REPO_ROOT]
+    monkeypatch.setattr(sys, "path", [str(script_path.parent), *normalized_sys_path])
+
+    globals_dict = runpy.run_path(str(script_path), run_name="__script_test__")
+
+    execution = globals_dict.get("EXECUTION")
+    assert execution is not None
+    assert execution.latency_model is not None
+
+    parameter_search = globals_dict.get(
+        "PARAMETER_SEARCH", globals_dict.get("OPTIMIZER", globals_dict.get("OPTIMIZATION"))
+    )
+    experiment = globals_dict["EXPERIMENT"]
+    target = parameter_search if parameter_search is not None else experiment
+    assert target.execution is execution
+
+    data = globals_dict["DATA"]
+    if data.data_type == "quote_tick":
+        assert execution.queue_position is True
+    else:
+        assert execution.queue_position is False
+
+
 @pytest.mark.parametrize("relative_path", PUBLIC_NOTEBOOK_RUNNER_PATHS)
 def test_public_notebook_runners_expose_metadata_contract(relative_path: Path) -> None:
     from prediction_market_extensions.backtesting._notebook_runner import load_notebook_metadata

--- a/tests/test_public_runner_validation.py
+++ b/tests/test_public_runner_validation.py
@@ -68,7 +68,7 @@ def test_public_kalshi_runner_reconciles_fills_fees_and_taker_slippage() -> None
 
     # Kalshi trade ticks expose 4-decimal prices, but taker execution must be
     # modeled with the real one-cent order tick.
-    assert [event["price"] for event in fill_events] == [0.51, 0.54, 0.60, 0.59]
+    assert [event["price"] for event in fill_events] == [0.56, 0.59, 0.61, 0.50]
     assert [event["commission"] for event in fill_events] == [0.02, 0.02, 0.02, 0.02]
 
 
@@ -83,9 +83,8 @@ def test_public_polymarket_trade_runner_reconciles_size_clipping_and_slippage() 
     result = _run_validation_case("polymarket-trade")
 
     fill_events = result["fill_events"]
-    assert result["fills"] == len(fill_events) == 4
+    assert result["fills"] == len(fill_events) == 2
     assert result["terminated_early"] is False
     assert result["pnl"] == pytest.approx(_ledger_realized_pnl(fill_events))
-    assert [event["price"] for event in fill_events] == [0.51, 0.49, 0.52, 0.49]
+    assert [event["price"] for event in fill_events] == [0.51, 0.50]
     assert fill_events[0]["quantity"] == 97.0
-    assert fill_events[2]["quantity"] == pytest.approx(95.1182)

--- a/tests/test_telonex_backtests.py
+++ b/tests/test_telonex_backtests.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 
 import pytest
+from nautilus_trader.model.enums import BookType
 from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
 from prediction_market_extensions.backtesting._strategy_configs import build_strategies_from_configs
+from prediction_market_extensions.backtesting.data_sources.registry import resolve_replay_adapter
 from strategies import QuoteTickDeepValueHoldConfig, QuoteTickDeepValueHoldStrategy
 
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
@@ -73,7 +76,7 @@ def test_telonex_joint_portfolio_runner_uses_local_first_sources(
     assert module.DATA.vendor == "telonex"
     assert module.DATA.sources == EXPECTED_TELONEX_SOURCES
     assert len(module.REPLAYS) == 5
-    assert module.EXECUTION.queue_position is False
+    assert module.EXECUTION.queue_position is True
     assert module.DETAIL_PLOT_PANELS == EXPECTED_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.REPORT.summary_report is True
@@ -82,3 +85,30 @@ def test_telonex_joint_portfolio_runner_uses_local_first_sources(
     assert module.EXPERIMENT.return_summary_series is True
     assert module.EXPERIMENT.multi_replay_mode == "joint_portfolio"
     assert captured["experiment"] is module.EXPERIMENT
+
+
+def test_telonex_quote_adapter_uses_passive_l2_execution_profile() -> None:
+    adapter = resolve_replay_adapter(
+        platform="polymarket", data_type="quote_tick", vendor="telonex"
+    )
+    profile = adapter.engine_profile
+
+    assert profile.fill_model_mode == "passive_book"
+    assert profile.book_type == BookType.L2_MBP
+    assert profile.liquidity_consumption is True
+
+
+def test_telonex_quote_adapter_requests_full_depth_book_channel(tmp_path: Path) -> None:
+    adapter = resolve_replay_adapter(
+        platform="polymarket", data_type="quote_tick", vendor="telonex"
+    )
+
+    with adapter.configure_sources(sources=(f"local:{tmp_path}",)):
+        from prediction_market_extensions.backtesting.data_sources.telonex import (
+            TELONEX_FULL_BOOK_CHANNEL,
+            resolve_telonex_loader_config,
+        )
+
+        _selection, config = resolve_telonex_loader_config()
+
+    assert config.channel == TELONEX_FULL_BOOK_CHANNEL

--- a/tests/test_telonex_data_download.py
+++ b/tests/test_telonex_data_download.py
@@ -59,6 +59,56 @@ def _parquet_payload_with_local_timestamp(value: int | float) -> bytes:
     return buffer.getvalue()
 
 
+def _book_snapshot_payload(
+    timestamp_us: int,
+    *,
+    bids_type: str = "levels",
+    asks_type: str = "levels",
+) -> bytes:
+    levels_type = telonex_download.pa.list_(
+        telonex_download.pa.field(
+            "element",
+            telonex_download.pa.struct(
+                [
+                    telonex_download.pa.field("price", telonex_download.pa.string()),
+                    telonex_download.pa.field("size", telonex_download.pa.string()),
+                ]
+            ),
+        )
+    )
+
+    def side(kind: str):
+        if kind == "null":
+            return telonex_download.pa.array(
+                [[]], type=telonex_download.pa.list_(telonex_download.pa.null())
+            )
+        return telonex_download.pa.array(
+            [[{"price": "0.44", "size": "10"}]],
+            type=levels_type,
+        )
+
+    table = telonex_download.pa.table(
+        {
+            "timestamp_us": telonex_download.pa.array(
+                [timestamp_us], type=telonex_download.pa.int64()
+            ),
+            "local_timestamp_us": telonex_download.pa.array(
+                [float(timestamp_us)], type=telonex_download.pa.float64()
+            ),
+            "exchange": ["polymarket"],
+            "market_id": ["m1"],
+            "slug": ["book-market"],
+            "asset_id": ["asset-0"],
+            "outcome": ["Yes"],
+            "bids": side(bids_type),
+            "asks": side(asks_type),
+        }
+    )
+    buffer = BytesIO()
+    telonex_download.pq.write_table(table, buffer)
+    return buffer.getvalue()
+
+
 def _install_payload_stub(
     monkeypatch: pytest.MonkeyPatch,
     payloads_by_day: dict[str, bytes],
@@ -484,12 +534,12 @@ def test_download_telonex_days_schema_evolves_when_later_day_has_new_column(
     assert rows == [(None,), ("abc123",)]
 
 
-def test_download_telonex_days_rolls_when_arrow_types_conflict(
+def test_download_telonex_days_normalizes_local_timestamps_to_float(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     payloads = {
         "2026-01-19": _parquet_payload_with_local_timestamp(1_768_780_800_000_000),
-        "2026-01-20": _parquet_payload_with_local_timestamp(1_768_867_200_000_000.0),
+        "2026-01-20": _parquet_payload_with_local_timestamp(1_768_867_200_000_000.75),
     }
 
     monkeypatch.setenv("TELONEX_API_KEY", "test-key")
@@ -519,7 +569,84 @@ def test_download_telonex_days_rolls_when_arrow_types_conflict(
         con.close()
 
     assert len(manifest) == 2
-    assert manifest[0][1] != manifest[1][1]
+    assert manifest[0][1] == manifest[1][1]
+
+    part = tmp_path / manifest[0][1]
+    schema = telonex_download.pq.ParquetFile(part).schema_arrow
+    assert schema.field("local_timestamp_us").type == telonex_download.pa.float64()
+
+
+def test_download_telonex_days_keeps_empty_book_sides_in_one_part(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _book_snapshot_payload(1_768_780_800_000_000),
+        "2026-01-20": _book_snapshot_payload(1_768_867_200_000_000, bids_type="null"),
+        "2026-01-21": _book_snapshot_payload(1_768_953_600_000_000, asks_type="null"),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    summary = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["book-market"],
+        outcome_id=0,
+        channel="book_snapshot_full",
+        start_date="2026-01-19",
+        end_date="2026-01-21",
+        show_progress=False,
+        workers=1,
+    )
+
+    assert summary.downloaded_days == 3
+    assert summary.failed_days == 0
+    parts = sorted((tmp_path / "data").rglob("*.parquet"))
+    assert len(parts) == 1
+    schema = telonex_download.pq.ParquetFile(parts[0]).schema_arrow
+    assert schema.field("bids").type.equals(telonex_download._ORDER_BOOK_LEVELS_TYPE)
+    assert schema.field("asks").type.equals(telonex_download._ORDER_BOOK_LEVELS_TYPE)
+
+
+def test_download_telonex_days_reuses_promoted_optional_column_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _parquet_payload_with_extra(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload_with_extra(
+            1_768_867_200_000_000, extra_columns={"origin_asset_id": "abc123"}
+        ),
+        "2026-01-21": _parquet_payload_with_extra(1_768_953_600_000_000),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    summary = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["optional-column-market"],
+        outcome_id=0,
+        start_date="2026-01-19",
+        end_date="2026-01-21",
+        show_progress=False,
+        workers=1,
+    )
+
+    assert summary.downloaded_days == 3
+    assert summary.failed_days == 0
+
+    con = duckdb.connect(str(tmp_path / "telonex.duckdb"), read_only=True)
+    try:
+        rows = con.execute("SELECT day, parquet_part FROM completed_days ORDER BY day").fetchall()
+    finally:
+        con.close()
+
+    assert len({row[1] for row in rows}) == 2
+    assert rows[1][1] == rows[2][1]
 
 
 def test_download_telonex_days_retries_transient_5xx_then_succeeds(
@@ -732,6 +859,75 @@ def test_download_telonex_progress_format_includes_bar_percent_and_eta(
     assert all("{remaining}" in fmt for fmt in download_bar_formats)
 
 
+def test_all_markets_progress_only_uses_fetch_and_download_bars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    markets = pd.DataFrame(
+        {
+            "slug": ["market-one"],
+            "quotes_from": ["2026-01-19"],
+            "quotes_to": ["2026-01-19"],
+        }
+    )
+    progress_descs: list[str] = []
+
+    class FakeTqdm:
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            del args
+            desc = kwargs.get("desc")
+            if desc is not None:
+                progress_descs.append(str(desc))
+            self.n = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # type: ignore[no-untyped-def]
+            del exc_type, exc, tb
+            return False
+
+        def update(self, value: int) -> None:
+            self.n += value
+
+        def set_postfix_str(self, value: str, refresh: bool = False) -> None:
+            del value, refresh
+
+        def refresh(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    def fake_fetch_markets_dataset(
+        base_url: str, timeout_secs: int, *, show_progress: bool = False
+    ) -> pd.DataFrame:
+        del base_url, timeout_secs
+        if show_progress:
+            telonex_download.tqdm(total=10, desc="Fetching Telonex markets").close()
+        return markets
+
+    def fake_run_jobs(jobs, **kwargs):
+        assert kwargs["show_progress"] is True
+        list(jobs)
+        telonex_download.tqdm(total=1, desc="Downloading Telonex days").close()
+        return (1, 0, 0, 0, 100, False, [])
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    monkeypatch.setattr(telonex_download, "tqdm", FakeTqdm)
+    monkeypatch.setattr(telonex_download, "_fetch_markets_dataset", fake_fetch_markets_dataset)
+    monkeypatch.setattr(telonex_download, "_run_jobs", fake_run_jobs)
+
+    summary = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        all_markets=True,
+        channels=["quotes"],
+        show_progress=True,
+    )
+
+    assert summary.downloaded_days == 1
+    assert progress_descs == ["Fetching Telonex markets", "Downloading Telonex days"]
+
+
 def test_downloaded_parquet_is_readable_by_telonex_loader(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -906,6 +1102,35 @@ def test_download_telonex_days_rolls_part_files_when_threshold_exceeded(
     assert len({row[1] for row in rows}) == 2
 
 
+def test_download_telonex_days_rolls_part_files_when_disk_threshold_exceeded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_BYTES", 1 << 40)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_DISK_BYTES", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["disk-roll-test"],
+        outcome_id=0,
+        start_date="2026-01-19",
+        end_date="2026-01-20",
+        show_progress=False,
+        workers=1,
+    )
+
+    parts = sorted((tmp_path / "data").rglob("*.parquet"))
+    assert len(parts) == 2
+
+
 def test_store_sweeps_orphan_parquet_on_startup(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -938,6 +1163,22 @@ def test_store_sweeps_orphan_parquet_on_startup(
         assert real_part.exists()
     finally:
         store.close()
+
+
+def test_store_sweeps_orphan_parquet_on_close(tmp_path: Path) -> None:
+    store = telonex_download._TelonexParquetStore(tmp_path)
+    orphan_dir = tmp_path / "data" / "channel=book_snapshot_full" / "year=2026" / "month=01"
+    orphan_dir.mkdir(parents=True, exist_ok=True)
+    orphan = orphan_dir / "part-999999.parquet"
+    telonex_download.pq.write_table(
+        telonex_download.pa.table({"timestamp_us": [1_768_780_800_000_000]}),
+        orphan,
+    )
+    assert orphan.exists()
+
+    store.close()
+
+    assert not orphan.exists()
 
 
 def test_download_telonex_days_resumes_midrun_interruption(

--- a/tests/test_telonex_data_source.py
+++ b/tests/test_telonex_data_source.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from nautilus_trader.adapters.polymarket.common.parsing import parse_polymarket_instrument
+from nautilus_trader.model.data import OrderBookDeltas, QuoteTick
 
 import prediction_market_extensions.backtesting.data_sources.telonex as telonex_module
 from prediction_market_extensions.backtesting.data_sources.telonex import (
@@ -22,6 +24,28 @@ from prediction_market_extensions.backtesting.data_sources.telonex import (
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_polymarket_loader() -> RunnerPolymarketTelonexQuoteDataLoader:
+    instrument = parse_polymarket_instrument(
+        market_info={
+            "condition_id": "0x" + "1" * 64,
+            "question": "Synthetic Telonex market",
+            "minimum_tick_size": "0.01",
+            "minimum_order_size": "1",
+            "end_date_iso": "2026-12-31T00:00:00Z",
+            "maker_base_fee": "0",
+            "taker_base_fee": "0",
+        },
+        token_id="2" * 64,
+        outcome="Yes",
+        ts_init=0,
+    )
+    loader = RunnerPolymarketTelonexQuoteDataLoader.__new__(RunnerPolymarketTelonexQuoteDataLoader)
+    loader._instrument = instrument
+    loader._token_id = "2" * 64
+    loader._condition_id = "0x" + "1" * 64
+    return loader
 
 
 class _FakeHTTPResponse:
@@ -72,6 +96,18 @@ def test_configured_telonex_data_source_preserves_explicit_order(tmp_path) -> No
             ("local", str(local_root)),
             ("api", "https://api.example.test"),
         ]
+
+
+def test_configured_telonex_data_source_can_pin_full_book_channel(tmp_path) -> None:
+    local_root = tmp_path / "telonex"
+    local_root.mkdir()
+
+    with configured_telonex_data_source(
+        sources=[f"local:{local_root}"], channel="book_snapshot_full"
+    ):
+        _selection, config = resolve_telonex_loader_config()
+
+    assert config.channel == "book_snapshot_full"
 
 
 def test_configured_telonex_data_source_omits_disabled_cache(
@@ -362,6 +398,159 @@ def test_telonex_load_quotes_uses_local_before_api_after_cache_miss(
 
     assert len(records) == 1
     assert calls == ["cache", "local"]
+
+
+def test_telonex_full_book_snapshots_replay_l2_deltas_and_quotes() -> None:
+    loader = _make_polymarket_loader()
+    frame = pd.DataFrame(
+        {
+            "timestamp_us": [1_768_780_800_000_000, 1_768_780_800_100_000],
+            "bids": [
+                [{"price": "0.34", "size": "10"}, {"price": "0.33", "size": "20"}],
+                [{"price": "0.34", "size": "7"}, {"price": "0.32", "size": "5"}],
+            ],
+            "asks": [
+                [{"price": "0.39", "size": "11"}, {"price": "0.40", "size": "22"}],
+                [{"price": "0.38", "size": "12"}, {"price": "0.40", "size": "22"}],
+            ],
+        }
+    )
+
+    records = loader._book_events_from_frame(
+        frame,
+        start=pd.Timestamp("2026-01-19T00:00:00Z"),
+        end=pd.Timestamp("2026-01-20T00:00:00Z"),
+    )
+
+    assert [type(record) for record in records] == [
+        OrderBookDeltas,
+        QuoteTick,
+        OrderBookDeltas,
+        QuoteTick,
+    ]
+    quotes = [record for record in records if isinstance(record, QuoteTick)]
+    assert [(float(quote.bid_price), float(quote.ask_price)) for quote in quotes] == [
+        (0.34, 0.39),
+        (0.34, 0.38),
+    ]
+
+
+def test_telonex_full_book_loader_uses_cache_before_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(telonex_module)
+    loader_cls = module.RunnerPolymarketTelonexQuoteDataLoader
+    loader = loader_cls.__new__(loader_cls)
+    config = module.TelonexLoaderConfig(
+        channel="book_snapshot_full",
+        ordered_source_entries=(
+            module.TelonexSourceEntry(kind="local", target="/tmp/local"),
+            module.TelonexSourceEntry(
+                kind="api", target="https://api.example.test", api_key="test-key"
+            ),
+        ),
+    )
+    frame = pd.DataFrame(
+        {
+            "timestamp_us": [1_768_780_800_000_000],
+            "bids": [[{"price": "0.34", "size": "10"}]],
+            "asks": [[{"price": "0.39", "size": "11"}]],
+        }
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(loader, "_config", lambda: config)
+
+    def fake_cache(**kwargs: object) -> pd.DataFrame:
+        calls.append("cache")
+        return frame
+
+    def fail_local(**kwargs: object) -> None:
+        calls.append("local")
+        raise AssertionError("local should not be checked when cache has the day")
+
+    def fail_source(**kwargs: object) -> None:
+        calls.append("api")
+        raise AssertionError("api should not be checked when cache has the day")
+
+    monkeypatch.setattr(loader, "_load_api_cache_day", fake_cache)
+    monkeypatch.setattr(loader, "_try_load_day_from_local", fail_local)
+    monkeypatch.setattr(loader, "_try_load_day_from_entry", fail_source)
+    monkeypatch.setattr(
+        loader,
+        "_book_events_from_frame",
+        lambda _frame, *, start, end, include_order_book, include_quotes: [
+            SimpleNamespace(ts_event=1, ts_init=1)
+        ],
+    )
+
+    records = loader.load_order_book_and_quotes(
+        pd.Timestamp("2026-01-19", tz="UTC"),
+        pd.Timestamp("2026-01-19 23:59:59", tz="UTC"),
+        market_slug="cache-test",
+        token_index=0,
+        outcome=None,
+    )
+
+    assert len(records) == 1
+    assert calls == ["cache"]
+
+
+def test_telonex_full_book_loader_falls_back_to_api_when_blob_partition_is_incomplete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = importlib.reload(telonex_module)
+    loader_cls = module.RunnerPolymarketTelonexQuoteDataLoader
+    loader = loader_cls.__new__(loader_cls)
+    local_root = tmp_path / "telonex"
+    partition_dir = local_root / "data" / "channel=book_snapshot_full" / "year=2026" / "month=01"
+    partition_dir.mkdir(parents=True)
+    (local_root / "telonex.duckdb").write_bytes(b"not-used")
+    (partition_dir / "part-000001.parquet").write_bytes(b"incomplete")
+
+    config = module.TelonexLoaderConfig(
+        channel="book_snapshot_full",
+        ordered_source_entries=(
+            module.TelonexSourceEntry(kind="local", target=str(local_root)),
+            module.TelonexSourceEntry(
+                kind="api", target="https://api.example.test", api_key="test-key"
+            ),
+        ),
+    )
+    api_frame = pd.DataFrame(
+        {
+            "timestamp_us": [1_768_780_800_000_000],
+            "bids": [[{"price": "0.34", "size": "10"}]],
+            "asks": [[{"price": "0.39", "size": "11"}]],
+        }
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(loader, "_config", lambda: config)
+    monkeypatch.setattr(loader, "_load_api_cache_day", lambda **kwargs: None)
+
+    def fake_api_day(**kwargs: object) -> pd.DataFrame:
+        calls.append("api")
+        return api_frame
+
+    monkeypatch.setattr(loader, "_load_api_day", fake_api_day)
+    monkeypatch.setattr(
+        loader,
+        "_book_events_from_frame",
+        lambda _frame, *, start, end, include_order_book, include_quotes: [
+            SimpleNamespace(ts_event=1, ts_init=1)
+        ],
+    )
+
+    with pytest.warns(UserWarning, match="trying next source"):
+        records = loader.load_order_book_and_quotes(
+            pd.Timestamp("2026-01-19", tz="UTC"),
+            pd.Timestamp("2026-01-19 23:59:59", tz="UTC"),
+            market_slug="fallback-test",
+            token_index=0,
+            outcome=None,
+        )
+
+    assert len(records) == 1
+    assert calls == ["api"]
 
 
 def test_telonex_local_range_matches_consolidated_download_script_layout(tmp_path) -> None:

--- a/tests/test_trade_tick_runner_contract.py
+++ b/tests/test_trade_tick_runner_contract.py
@@ -57,6 +57,12 @@ EXPECTED_POLYMARKET_TRADE_SOURCES = (
     "trades:https://data-api.polymarket.com",
     "clob:https://clob.polymarket.com",
 )
+EXPECTED_TRADE_TICK_LATENCY = {
+    "base_latency_ms": 75.0,
+    "insert_latency_ms": 10.0,
+    "update_latency_ms": 5.0,
+    "cancel_latency_ms": 5.0,
+}
 
 BACKTESTS_ROOT = Path(__file__).resolve().parents[1] / "backtests"
 
@@ -142,10 +148,22 @@ def _import_runner(runner_path: Path):
     return importlib.import_module(f"backtests.{runner_path.stem}")
 
 
+def _assert_trade_tick_execution(module) -> None:
+    assert module.EXECUTION.queue_position is False
+    assert {
+        "base_latency_ms": module.EXECUTION.latency_model.base_latency_ms,
+        "insert_latency_ms": module.EXECUTION.latency_model.insert_latency_ms,
+        "update_latency_ms": module.EXECUTION.latency_model.update_latency_ms,
+        "cancel_latency_ms": module.EXECUTION.latency_model.cancel_latency_ms,
+    } == EXPECTED_TRADE_TICK_LATENCY
+    assert module.EXPERIMENT.execution == module.EXECUTION
+
+
 def test_kalshi_trade_tick_single_runner_uses_expected_runtime_contract() -> None:
     module = _import_runner(KALSHI_SINGLE_RUNNER)
 
     assert module.DATA.sources == EXPECTED_KALSHI_TRADE_SOURCES
+    _assert_trade_tick_execution(module)
     assert module.DETAIL_PLOT_PANELS == EXPECTED_KALSHI_DETAIL_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_EMIT_HTML
     assert module.EXPERIMENT.chart_output_path == EXPECTED_CHART_OUTPUT_PATH
@@ -158,6 +176,7 @@ def test_kalshi_trade_tick_independent_runner_uses_expected_runtime_contract() -
     module = _import_runner(KALSHI_INDEPENDENT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_KALSHI_TRADE_SOURCES
+    _assert_trade_tick_execution(module)
     assert module.DETAIL_PLOT_PANELS == EXPECTED_KALSHI_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_MULTI_RUNNER_EMIT_HTML
@@ -175,6 +194,7 @@ def test_kalshi_trade_tick_joint_runner_uses_expected_runtime_contract() -> None
     module = _import_runner(KALSHI_JOINT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_KALSHI_TRADE_SOURCES
+    _assert_trade_tick_execution(module)
     assert module.DETAIL_PLOT_PANELS == EXPECTED_KALSHI_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.return_summary_series is True
@@ -186,6 +206,7 @@ def test_polymarket_trade_tick_single_runner_uses_expected_runtime_contract() ->
     module = _import_runner(POLYMARKET_SINGLE_RUNNER)
 
     assert module.DATA.sources == EXPECTED_POLYMARKET_TRADE_SOURCES
+    _assert_trade_tick_execution(module)
     assert module.DETAIL_PLOT_PANELS == EXPECTED_POLYMARKET_DETAIL_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_EMIT_HTML
     assert module.EXPERIMENT.chart_output_path == EXPECTED_CHART_OUTPUT_PATH
@@ -197,6 +218,7 @@ def test_polymarket_trade_tick_independent_runner_uses_fixed_replay_windows() ->
     module = _import_runner(POLYMARKET_INDEPENDENT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_POLYMARKET_TRADE_SOURCES
+    _assert_trade_tick_execution(module)
     assert module.DETAIL_PLOT_PANELS == EXPECTED_POLYMARKET_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.emit_html is EXPECTED_MULTI_RUNNER_EMIT_HTML
@@ -215,6 +237,7 @@ def test_polymarket_trade_tick_joint_runner_uses_fixed_replay_windows() -> None:
     module = _import_runner(POLYMARKET_JOINT_RUNNER)
 
     assert module.DATA.sources == EXPECTED_POLYMARKET_TRADE_SOURCES
+    _assert_trade_tick_execution(module)
     assert module.DETAIL_PLOT_PANELS == EXPECTED_POLYMARKET_DETAIL_PLOT_PANELS
     assert module.SUMMARY_PLOT_PANELS == EXPECTED_SUMMARY_PLOT_PANELS
     assert module.EXPERIMENT.return_summary_series is True


### PR DESCRIPTION
## Summary

- Replay Telonex Polymarket data from the `book_snapshot_full` channel as L2 MBP order-book deltas, with derived quote ticks for strategy subscriptions.
- Make Telonex local blob reads fail over to the next configured source when a monthly partition contains an unreadable/in-progress part file, instead of replaying partial local data.
- Add explicit static latency execution configs to all public trade-tick runners, while keeping queue position disabled there because trade ticks have no book depth.
- Keep queue position enabled for PMXT/Telonex quote/L2 runners, update runner contract tests, and document the execution/data-source behavior.
- Remove a pandas FutureWarning in drawdown reporting during normal runner output.

## Validation

Completed before this commit:

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` (`362 passed, 1 skipped`)
- `uv run mkdocs build --strict`
- Focused Telonex/execution runner contract tests.
- Representative direct runners for Kalshi trade ticks, Polymarket trade ticks, PMXT quote ticks, and a compact Telonex L2 replay smoke.

Still running locally after push:

- `uv run python scripts/run_all_backtests.py --stop-on-failure`

The long sweep is currently filling PMXT raw cache from R2 for `backtests/polymarket_quote_tick_independent_25_replay_runner.py`; I will update this PR once it completes.
