### PR TITLE
[codex] fix telonex downloader resume memory

### DIFF
--- a/docs/data-vendors.md
+++ b/docs/data-vendors.md
@@ -301,10 +301,12 @@ downloading `book_snapshot_5` and `book_snapshot_25` alongside
 
 The default `--workers 128` is the in-flight coroutine ceiling in the shared
 async `httpx` pool. The downloader decodes day Parquet payloads directly into
-Arrow tables and writes consolidated ~1 GiB blob parts; it does not create
-millions of tiny day files. On a fast host, benchmark `--workers 64`, `128`,
-and `256` before scaling up because high concurrency can hit socket/file
-descriptor pressure or outrun the single consolidated Parquet writer.
+Arrow tables and writes consolidated blob parts that roll around 512 MiB on
+disk, 64 GiB of Arrow data, or 10,000 pending manifest days; it does not create
+millions of tiny day files or keep one huge manifest batch in RAM until
+shutdown. On a fast host, benchmark `--workers 64`, `128`, and `256` before
+scaling up because high concurrency can hit socket/file descriptor pressure or
+outrun the single consolidated Parquet writer.
 `--parse-workers` controls the bounded Arrow decode pool (default:
 `min(8, cpu_count)`, also configurable with `TELONEX_PARSE_WORKERS`). Transient
 `408/425/429/5xx` responses retry with exponential backoff. Hit `Ctrl-C` once

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -168,8 +168,10 @@ The default destination is `/Volumes/LaCie/telonex_data`, matching the
 `local:/Volumes/LaCie/telonex_data` source in the public Telonex runner.
 The downloader uses a shared async `httpx` pool with `--workers 128`
 in-flight coroutines by default. The hot path decodes day Parquet payloads
-directly into Arrow tables and writes them into consolidated ~1 GiB blob
-parts; it does not create millions of tiny day files. On a fast host, benchmark
+directly into Arrow tables and writes them into consolidated blob parts that
+roll around 512 MiB on disk, 64 GiB of Arrow data, or 10,000 pending manifest
+days; it does not create millions of tiny day files or keep one huge manifest
+batch in RAM until shutdown. On a fast host, benchmark
 `--workers 64`, `128`, and `256` before scaling up; higher worker counts can
 hit socket/file-descriptor pressure or outrun the single consolidated Parquet
 writer. `--parse-workers` controls the bounded Arrow decode pool (default:

--- a/scripts/_telonex_data_download.py
+++ b/scripts/_telonex_data_download.py
@@ -38,6 +38,7 @@ _MANIFEST_FILENAME = "telonex.duckdb"
 _DATA_SUBDIR = "data"
 _TARGET_PART_BYTES = 64 << 30  # uncompressed Arrow safety cap before rolling
 _TARGET_PART_DISK_BYTES = 512 << 20  # compressed on-disk Parquet target before rolling
+_TARGET_PART_PENDING_DAYS = 10_000  # manifest rows held by one open part before rolling
 _PARQUET_COMPRESSION = "zstd"
 _PARQUET_COMPRESSION_LEVEL = 3
 # Keep pending_for_commit bounded so book_snapshot_full Arrow tables don't pin
@@ -681,7 +682,11 @@ class _TelonexParquetStore:
 
         del table
 
-        if part.disk_bytes >= _TARGET_PART_DISK_BYTES or part.bytes_written >= _TARGET_PART_BYTES:
+        if (
+            part.disk_bytes >= _TARGET_PART_DISK_BYTES
+            or part.bytes_written >= _TARGET_PART_BYTES
+            or len(part.pending) >= _TARGET_PART_PENDING_DAYS
+        ):
             self._flush_open_part_locked(key)
 
         return total_rows
@@ -2023,8 +2028,22 @@ def download_telonex_days(
         if show_progress:
             existing_store_size = store.size_bytes()
             completed_before = sum(len(store.completed_keys(ch)) for ch in channels)
-            empty_before = sum(len(store.empty_keys(ch)) for ch in channels)
-            remaining_text = f"remaining={remaining_jobs:,}. " if remaining_jobs is not None else ""
+            empty_before = sum(
+                len(store.empty_keys(ch, recheck_after_days=recheck_empty_after_days))
+                for ch in channels
+            )
+            if all_markets and planned_jobs is not None:
+                # Exact all-market pruning is lazy so startup doesn't materialize
+                # tens of millions of jobs. This estimate is accurate for the
+                # normal full-catalog resume path and avoids printing the
+                # unpruned total as "remaining".
+                skipped_before = min(planned_jobs, completed_before + empty_before)
+                remaining_jobs = max(0, planned_jobs - skipped_before)
+                remaining_text = f"estimated_remaining_after_resume={remaining_jobs:,}. "
+            else:
+                remaining_text = (
+                    f"remaining={remaining_jobs:,}. " if remaining_jobs is not None else ""
+                )
             print(
                 f"[telonex] Resume summary: manifest={db_path} "
                 f"data={store.data_root} total={_format_bytes(existing_store_size)}, "
@@ -2039,7 +2058,8 @@ def download_telonex_days(
                 f"[telonex] Channels={channels} workers={workers} "
                 f"retries={_DEFAULT_MAX_RETRIES} timeout={timeout_secs}s "
                 f"part-roll-at={_format_bytes(_TARGET_PART_DISK_BYTES)} on disk "
-                f"or {_format_bytes(_TARGET_PART_BYTES)} Arrow.",
+                f"or {_format_bytes(_TARGET_PART_BYTES)} Arrow "
+                f"or {_TARGET_PART_PENDING_DAYS:,} pending days.",
                 file=sys.stderr,
             )
 

--- a/tests/test_telonex_data_download.py
+++ b/tests/test_telonex_data_download.py
@@ -928,6 +928,61 @@ def test_all_markets_progress_only_uses_fetch_and_download_bars(
     assert progress_descs == ["Fetching Telonex markets", "Downloading Telonex days"]
 
 
+def test_all_markets_resume_progress_total_excludes_manifest_hits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {"2026-01-19": _parquet_payload(1_768_780_800_000_000)}
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+
+    first = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["already-downloaded"],
+        outcome_id=0,
+        start_date="2026-01-19",
+        end_date="2026-01-19",
+        show_progress=False,
+        workers=1,
+    )
+    assert first.downloaded_days == 1
+
+    markets = pd.DataFrame(
+        {
+            "slug": ["already-downloaded"],
+            "quotes_from": ["2026-01-19"],
+            "quotes_to": ["2026-01-19"],
+        }
+    )
+    captured_total_jobs: list[int | None] = []
+
+    def fake_fetch_markets_dataset(
+        base_url: str, timeout_secs: int, *, show_progress: bool = False
+    ) -> pd.DataFrame:
+        del base_url, timeout_secs, show_progress
+        return markets
+
+    def fake_run_jobs(jobs, **kwargs):
+        captured_total_jobs.append(kwargs["total_jobs"])
+        kept_jobs = list(jobs)
+        assert len(kept_jobs) == 1
+        assert kept_jobs[0].outcome_id == 1
+        return (0, 0, 0, 0, 0, False, [])
+
+    monkeypatch.setattr(telonex_download, "_fetch_markets_dataset", fake_fetch_markets_dataset)
+    monkeypatch.setattr(telonex_download, "_run_jobs", fake_run_jobs)
+
+    second = telonex_download.download_telonex_days(
+        destination=tmp_path,
+        all_markets=True,
+        channels=["quotes"],
+        show_progress=True,
+        workers=1,
+    )
+
+    assert second.skipped_existing_days == 1
+    assert captured_total_jobs == [1]
+
+
 def test_downloaded_parquet_is_readable_by_telonex_loader(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1129,6 +1184,45 @@ def test_download_telonex_days_rolls_part_files_when_disk_threshold_exceeded(
 
     parts = sorted((tmp_path / "data").rglob("*.parquet"))
     assert len(parts) == 2
+
+
+def test_download_telonex_days_rolls_part_files_when_pending_manifest_rows_exceeded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payloads = {
+        "2026-01-19": _parquet_payload(1_768_780_800_000_000),
+        "2026-01-20": _parquet_payload(1_768_867_200_000_000),
+        "2026-01-21": _parquet_payload(1_768_953_600_000_000),
+    }
+
+    monkeypatch.setenv("TELONEX_API_KEY", "test-key")
+    _install_payload_stub(monkeypatch, payloads)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_BYTES", 1 << 40)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_DISK_BYTES", 1 << 40)
+    monkeypatch.setattr(telonex_download, "_TARGET_PART_PENDING_DAYS", 2)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_ROWS", 1)
+    monkeypatch.setattr(telonex_download, "_DEFAULT_COMMIT_BATCH_SECS", 0.0)
+
+    telonex_download.download_telonex_days(
+        destination=tmp_path,
+        market_slugs=["pending-roll-test"],
+        outcome_id=0,
+        start_date="2026-01-19",
+        end_date="2026-01-21",
+        show_progress=False,
+        workers=1,
+    )
+
+    parts = sorted((tmp_path / "data").rglob("*.parquet"))
+    assert len(parts) == 2
+
+    con = duckdb.connect(str(tmp_path / "telonex.duckdb"), read_only=True)
+    try:
+        rows = con.execute("SELECT day, parquet_part FROM completed_days ORDER BY day").fetchall()
+    finally:
+        con.close()
+    assert len(rows) == 3
+    assert len({row[1] for row in rows}) == 2
 
 
 def test_store_sweeps_orphan_parquet_on_startup(


### PR DESCRIPTION
## Summary
- Roll Telonex consolidated Parquet parts by pending manifest-day count as well as byte thresholds, so long all-market downloads do not hold millions of pending manifest rows in RAM until shutdown.
- Make all-market resume progress subtract selected-channel manifest hits instead of displaying the unpruned catalog total as remaining.
- Update downloader docs and add focused coverage for pending-row rollover and resume progress totals.

## Validation
- `uv run pytest tests/test_telonex_data_download.py -q`
- `uv run ruff check scripts/_telonex_data_download.py tests/test_telonex_data_download.py`
- `uv run ruff format --check scripts/_telonex_data_download.py tests/test_telonex_data_download.py`
- `uv run mkdocs build --strict`

Note: the full local `scripts/run_all_backtests.py --stop-on-failure` sweep is still running separately and was not interrupted.
