### PR TITLE
[codex] Add BTC strategy runners and settlement report fixes

### DIFF
--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-04-27T04:38:25+00:00
-Modules: 100 | Classes: 148 | Functions/methods: 1134
+Generated: 2026-04-27T15:00:39+00:00
+Modules: 103 | Classes: 152 | Functions/methods: 1194
 
 ## Backtesting Data Flow
 
@@ -42,6 +42,20 @@ flowchart TD
 ### `backtests/polymarket_book_joint_portfolio_runner.py`
 - Imports: `__future__, decimal`
 - Function L18: `run() -> None`
+
+### `backtests/polymarket_btc_5m_late_favorite_taker_hold.py`
+- Imports: `__future__, datetime, decimal`
+- Function L26: `_utc_iso(value: datetime) -> str`
+- Function L30: `_btc_5m_windows() -> tuple[tuple[str, datetime, datetime], ...]`
+- Function L42: `_btc_5m_replays() -> Any`
+- Function L65: `run() -> None`
+
+### `backtests/polymarket_btc_5m_pair_arbitrage.py`
+- Imports: `__future__, datetime, decimal`
+- Function L24: `_utc_iso(value: datetime) -> str`
+- Function L28: `_btc_5m_windows() -> tuple[tuple[str, str, str], ...]`
+- Function L40: `_btc_5m_replays() -> Any`
+- Function L56: `run() -> None`
 
 ### `backtests/polymarket_telonex_book_joint_portfolio_runner.py`
 - Imports: `__future__, decimal`
@@ -486,39 +500,40 @@ flowchart TD
 - Function L238: `_to_legacy_datetime(timestamp: pd.Timestamp) -> datetime`
 - Function L242: `_series_to_iso_pairs(series: pd.Series) -> list[tuple[str, float]]`
 - Function L249: `_align_series_to_timeline(series: pd.Series, timeline: pd.DatetimeIndex, *, before: float, after: float) -> pd.Series`
-- Function L261: `_parse_float_like(value, default: float = 0.0) -> float`
-- Function L281: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
-- Function L358: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
-- Function L401: `_aggregate_brier_frames(results: Sequence[dict[str, Any]]) -> dict[str, pd.DataFrame]`
-- Function L429: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
-- Function L451: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
-- Function L455: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
-- Function L461: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
-- Function L468: `_yes_price_fill_marker_budget(max_points: int) -> int`
-- Function L474: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
-- Function L485: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
-- Function L532: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
-- Function L546: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
-- Function L567: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
-- Function L612: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
-- Function L627: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = True, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L1_MBP, liquidity_consumption: bool = False, queue_position: bool = False, latency_model: Any | None = None) -> dict[str, Any]`
-- Function L781: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
-- Function L835: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1080: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1318: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
-- Function L1381: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
-- Function L1399: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
-- Function L1425: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
-- Function L1443: `_summary_returns_from_pairs(pairs: object) -> dict[int, float]`
-- Function L1464: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
-- Function L1481: `_summary_total_return_pct(pairs: object) -> float | None`
-- Function L1497: `_safe_stat(func, returns: dict[int, float]) -> float | None`
-- Function L1505: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
-- Function L1510: `_coerce_float(value: object) -> float | None`
-- Function L1518: `_format_summary_float(value: object, decimals: int) -> str`
-- Function L1525: `_format_summary_pct(value: object) -> str`
-- Function L1532: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
-- Function L1595: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
+- Function L261: `_extend_active_range(active_ranges: dict[str, tuple[pd.Timestamp, pd.Timestamp]], label: str, start: pd.Timestamp, end: pd.Timestamp) -> None`
+- Function L274: `_parse_float_like(value, default: float = 0.0) -> float`
+- Function L294: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
+- Function L371: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
+- Function L414: `_aggregate_brier_frames(results: Sequence[dict[str, Any]]) -> dict[str, pd.DataFrame]`
+- Function L442: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
+- Function L464: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
+- Function L468: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
+- Function L474: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
+- Function L481: `_yes_price_fill_marker_budget(max_points: int) -> int`
+- Function L487: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
+- Function L498: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
+- Function L545: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
+- Function L559: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
+- Function L580: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
+- Function L625: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
+- Function L640: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = True, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L1_MBP, liquidity_consumption: bool = False, queue_position: bool = False, latency_model: Any | None = None) -> dict[str, Any]`
+- Function L793: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
+- Function L847: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1093: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1335: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
+- Function L1398: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
+- Function L1416: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
+- Function L1442: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
+- Function L1460: `_summary_returns_from_pairs(pairs: object) -> dict[int, float]`
+- Function L1481: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
+- Function L1498: `_summary_total_return_pct(pairs: object) -> float | None`
+- Function L1514: `_safe_stat(func, returns: dict[int, float]) -> float | None`
+- Function L1522: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
+- Function L1527: `_coerce_float(value: object) -> float | None`
+- Function L1535: `_format_summary_float(value: object, decimals: int) -> str`
+- Function L1542: `_format_summary_pct(value: object) -> str`
+- Function L1549: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
+- Function L1612: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
 
 ### `prediction_market_extensions/analysis/__init__.py`
 - Imports: none
@@ -606,52 +621,54 @@ flowchart TD
 - Function L317: `_build_portfolio_snapshots(models_module, account_report: pd.DataFrame, fills: list[Any]) -> list[Any]`
 - Function L343: `_build_dense_timeline(fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]]) -> pd.DatetimeIndex`
 - Function L353: `_dense_cash_series(sparse_snapshots: list[Any], dense_dt: pd.DatetimeIndex, initial_cash: float) -> np.ndarray`
-- Function L370: `_replay_fill_position_deltas(fills: list[Any], dense_dts: np.ndarray) -> tuple[dict[str, np.ndarray], dict[str, float]]`
-- Function L394: `_aligned_market_prices(market_id: str, market_prices: Mapping[str, Sequence[tuple[datetime, float]]], dense_dts: np.ndarray, n_bars: int, fallback_price: float) -> tuple[np.ndarray, np.datetime64 | None]`
-- Function L421: `_apply_resolution_cutoffs(pos_qty: dict[str, np.ndarray], pos_changes: Mapping[str, np.ndarray], market_last_ts: Mapping[str, np.datetime64 | None], dense_dts: np.ndarray) -> None`
-- Function L443: `_mark_to_market(pos_qty: Mapping[str, np.ndarray], price_on_bar: Mapping[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray]`
-- Function L463: `_build_dense_portfolio_snapshots(models_module, sparse_snapshots: list[Any], fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> list[Any]`
-- Function L532: `_normalize_market_prices(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
-- Function L563: `_market_prices_from_fills(fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
-- Function L572: `_merge_market_price_sources(primary: Mapping[str, Sequence[tuple[Any, float]]] | None, secondary: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
-- Function L596: `_market_prices_with_fill_points(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None, fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
-- Function L607: `_build_metrics(snapshots: list[Any], initial_cash: float) -> dict[str, float]`
-- Function L625: `_platform_enum(models_module, platform: str) -> Any`
-- Function L632: `_mark_panel_figure(fig, panel_id: str) -> Any`
-- Function L640: `_brier_unavailable_reason(*, user_probabilities: pd.Series | None, market_probabilities: pd.Series | None, outcomes: pd.Series | None) -> str | None`
-- Function L659: `_build_brier_placeholder_panel(message: str) -> Any`
-- Function L700: `_style_panel_legend(fig) -> None`
-- Function L712: `_build_brier_timeseries_panel(brier_frame: pd.DataFrame, *, panel_id: str, axis_label: str, legend_label: str, line_color: str = '#2ca0f0') -> Any | None`
-- Function L813: `_build_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
-- Function L822: `_build_total_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
-- Function L832: `_iter_layout_nodes(node) -> Any`
-- Function L844: `_iter_figures(layout) -> Any`
-- Function L850: `_field_name(spec) -> str | None`
-- Function L861: `_filter_tool_container(container, tools_to_remove: set[Any]) -> None`
-- Function L895: `_remove_tools_from_layout(layout, tools_to_remove: set[Any]) -> None`
-- Function L904: `_remove_hover_tools(fig, *, layout: Any | None = None) -> set[Any]`
-- Function L916: `_format_period_label(start, end) -> str`
-- Function L929: `_find_figure_with_yaxis_label(layout, predicate) -> Any | None`
-- Function L937: `_periodic_pnl_panel_source(target) -> tuple[dict[str, Any] | None, float | None]`
-- Function L955: `_build_periodic_pnl_panel_source_data(source_data: dict[str, Any]) -> dict[str, Any] | None`
-- Function L975: `_resolve_periodic_pnl_bar_width(x_values: np.ndarray, bar_width: float | None) -> float`
-- Function L983: `_yes_price_line_renderers(target) -> list[Any]`
-- Function L1005: `_remove_data_banner(layout) -> Any`
-- Function L1024: `_legend_item_label_text(item) -> str`
-- Function L1034: `_remove_yes_price_profitability_legend_items(fig) -> set[Any]`
-- Function L1050: `_remove_yes_price_profitability_connectors(layout) -> None`
-- Function L1076: `_limit_yes_price_fill_markers(layout, max_yes_price_fill_markers: int | None) -> None`
-- Function L1119: `_subset_bokeh_source_values(values, indexes: np.ndarray) -> Any`
-- Function L1129: `_limit_market_pnl_fill_markers(layout, max_market_pnl_fill_markers: int | None) -> None`
-- Function L1173: `_standardize_periodic_pnl_panel(layout) -> None`
-- Function L1221: `_relabel_market_pnl_panel(layout, axis_label: str = 'Market P&L') -> None`
-- Function L1248: `_build_multi_market_brier_panel(brier_frames: Mapping[str, pd.DataFrame], *, axis_label: str = 'Cumulative Brier Advantage', color_by_market: Mapping[str, Any] | None = None) -> Any | None`
-- Function L1382: `_standardize_yes_price_hover(layout) -> None`
-- Function L1413: `_focus_allocation_panel(layout) -> None`
-- Function L1450: `_apply_layout_overrides(layout, initial_cash: float, *, relabel_market_pnl: bool = False, max_yes_price_fill_markers: int | None = None, max_market_pnl_fill_markers: int | None = None) -> Any`
-- Function L1471: `_save_layout(layout, output_path: Path, title: str) -> None`
-- Function L1484: `save_legacy_backtest_layout(layout, output_path: str | Path, title: str) -> str`
-- Function L1494: `build_legacy_backtest_layout(engine, output_path: str | Path, strategy_name: str, platform: str, initial_cash: float, market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None = None, user_probabilities: pd.Series | None = None, market_probabilities: pd.Series | None = None, outcomes: pd.Series | None = None, legacy_repo_path: str | Path | None = None, open_browser: bool = False, max_markets: int = 30, progress: bool = False, plot_panels: Sequence[str] | None = None) -> tuple[Any, str]`
+- Function L370: `_fill_cash_delta(fill) -> float`
+- Function L377: `_dense_cash_series_from_fills(fills: list[Any], dense_dts: np.ndarray, initial_cash: float) -> np.ndarray`
+- Function L393: `_replay_fill_position_deltas(fills: list[Any], dense_dts: np.ndarray) -> tuple[dict[str, np.ndarray], dict[str, float]]`
+- Function L417: `_aligned_market_prices(market_id: str, market_prices: Mapping[str, Sequence[tuple[datetime, float]]], dense_dts: np.ndarray, n_bars: int, fallback_price: float) -> tuple[np.ndarray, np.datetime64 | None]`
+- Function L444: `_apply_resolution_cutoffs(pos_qty: dict[str, np.ndarray], pos_changes: Mapping[str, np.ndarray], market_last_ts: Mapping[str, np.datetime64 | None], dense_dts: np.ndarray) -> None`
+- Function L466: `_mark_to_market(pos_qty: Mapping[str, np.ndarray], price_on_bar: Mapping[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray]`
+- Function L486: `_build_dense_portfolio_snapshots(models_module, sparse_snapshots: list[Any], fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> list[Any]`
+- Function L559: `_normalize_market_prices(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
+- Function L590: `_market_prices_from_fills(fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
+- Function L599: `_merge_market_price_sources(primary: Mapping[str, Sequence[tuple[Any, float]]] | None, secondary: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
+- Function L623: `_market_prices_with_fill_points(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None, fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
+- Function L634: `_build_metrics(snapshots: list[Any], initial_cash: float) -> dict[str, float]`
+- Function L652: `_platform_enum(models_module, platform: str) -> Any`
+- Function L659: `_mark_panel_figure(fig, panel_id: str) -> Any`
+- Function L667: `_brier_unavailable_reason(*, user_probabilities: pd.Series | None, market_probabilities: pd.Series | None, outcomes: pd.Series | None) -> str | None`
+- Function L686: `_build_brier_placeholder_panel(message: str) -> Any`
+- Function L727: `_style_panel_legend(fig) -> None`
+- Function L739: `_build_brier_timeseries_panel(brier_frame: pd.DataFrame, *, panel_id: str, axis_label: str, legend_label: str, line_color: str = '#2ca0f0') -> Any | None`
+- Function L840: `_build_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
+- Function L849: `_build_total_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
+- Function L859: `_iter_layout_nodes(node) -> Any`
+- Function L871: `_iter_figures(layout) -> Any`
+- Function L877: `_field_name(spec) -> str | None`
+- Function L888: `_filter_tool_container(container, tools_to_remove: set[Any]) -> None`
+- Function L922: `_remove_tools_from_layout(layout, tools_to_remove: set[Any]) -> None`
+- Function L931: `_remove_hover_tools(fig, *, layout: Any | None = None) -> set[Any]`
+- Function L943: `_format_period_label(start, end) -> str`
+- Function L956: `_find_figure_with_yaxis_label(layout, predicate) -> Any | None`
+- Function L964: `_periodic_pnl_panel_source(target) -> tuple[dict[str, Any] | None, float | None]`
+- Function L982: `_build_periodic_pnl_panel_source_data(source_data: dict[str, Any]) -> dict[str, Any] | None`
+- Function L1002: `_resolve_periodic_pnl_bar_width(x_values: np.ndarray, bar_width: float | None) -> float`
+- Function L1010: `_yes_price_line_renderers(target) -> list[Any]`
+- Function L1032: `_remove_data_banner(layout) -> Any`
+- Function L1051: `_legend_item_label_text(item) -> str`
+- Function L1061: `_remove_yes_price_profitability_legend_items(fig) -> set[Any]`
+- Function L1077: `_remove_yes_price_profitability_connectors(layout) -> None`
+- Function L1103: `_limit_yes_price_fill_markers(layout, max_yes_price_fill_markers: int | None) -> None`
+- Function L1146: `_subset_bokeh_source_values(values, indexes: np.ndarray) -> Any`
+- Function L1156: `_limit_market_pnl_fill_markers(layout, max_market_pnl_fill_markers: int | None) -> None`
+- Function L1200: `_standardize_periodic_pnl_panel(layout) -> None`
+- Function L1248: `_relabel_market_pnl_panel(layout, axis_label: str = 'Market P&L') -> None`
+- Function L1275: `_build_multi_market_brier_panel(brier_frames: Mapping[str, pd.DataFrame], *, axis_label: str = 'Cumulative Brier Advantage', color_by_market: Mapping[str, Any] | None = None) -> Any | None`
+- Function L1409: `_standardize_yes_price_hover(layout) -> None`
+- Function L1440: `_focus_allocation_panel(layout) -> None`
+- Function L1477: `_apply_layout_overrides(layout, initial_cash: float, *, relabel_market_pnl: bool = False, max_yes_price_fill_markers: int | None = None, max_market_pnl_fill_markers: int | None = None) -> Any`
+- Function L1498: `_save_layout(layout, output_path: Path, title: str) -> None`
+- Function L1511: `save_legacy_backtest_layout(layout, output_path: str | Path, title: str) -> str`
+- Function L1521: `build_legacy_backtest_layout(engine, output_path: str | Path, strategy_name: str, platform: str, initial_cash: float, market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None = None, user_probabilities: pd.Series | None = None, market_probabilities: pd.Series | None = None, outcomes: pd.Series | None = None, legacy_repo_path: str | Path | None = None, open_browser: bool = False, max_markets: int = 30, progress: bool = False, plot_panels: Sequence[str] | None = None) -> tuple[Any, str]`
 
 ### `prediction_market_extensions/analysis/tearsheet.py`
 - Imports: `__future__, collections, difflib, nautilus_trader, numbers, pandas, typing`
@@ -710,7 +727,8 @@ flowchart TD
 - Function L84: `build_backtest_run_state(*, data: Sequence[object], backtest_end_ns: int | None, forced_stop: bool, requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
 - Function L130: `apply_backtest_run_state(*, result: dict[str, Any], run_state: dict[str, Any]) -> dict[str, Any]`
 - Function L137: `print_backtest_result_warnings(*, results: Sequence[dict[str, Any]], market_key: str) -> None`
-- Function L180: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = True, slippage_ticks: int = 1, entry_slippage_pct: float = 0.0, exit_slippage_pct: float = 0.0, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', return_summary_series: bool = False, book_type: BookType = BookType.L1_MBP, liquidity_consumption: bool = False, queue_position: bool = False, latency_model: Any | None = None, nautilus_log_level: str = 'INFO', requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
+- Function L180: `add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
+- Function L188: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = True, slippage_ticks: int = 1, entry_slippage_pct: float = 0.0, exit_slippage_pct: float = 0.0, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', return_summary_series: bool = False, book_type: BookType = BookType.L1_MBP, liquidity_consumption: bool = False, queue_position: bool = False, latency_model: Any | None = None, nautilus_log_level: str = 'INFO', requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
 
 ### `prediction_market_extensions/backtesting/_execution_config.py`
 - Imports: `__future__, dataclasses, math, nautilus_trader`
@@ -726,16 +744,16 @@ flowchart TD
 
 ### `prediction_market_extensions/backtesting/_experiments.py`
 - Imports: `__future__, asyncio, collections, dataclasses, datetime, pandas, prediction_market_extensions, typing`
-- Function L73: `build_backtest_for_experiment(experiment: ReplayExperiment) -> PredictionMarketBacktest`
-- Function L95: `build_replay_experiment(*, name: str, description: str, data: MarketDataConfig, replays: Sequence[ReplaySpec], strategy_configs: Sequence[StrategyConfigSpec] = (), strategy_factory: Callable[..., Any] | None = None, initial_cash: float = 100.0, probability_window: int = 30, min_book_events: int = 0, min_price_range: float = 0.0, default_lookback_days: int | None = None, default_lookback_hours: float | None = None, default_start_time: pd.Timestamp | datetime | str | None = None, default_end_time: pd.Timestamp | datetime | str | None = None, nautilus_log_level: str = 'INFO', execution: ExecutionModelConfig | None = None, chart_resample_rule: str | None = None, return_summary_series: bool = False, report: MarketReportConfig | None = None, empty_message: str | None = None, partial_message: str | None = None, result_policy: ResultPolicy | None = None) -> ReplayExperiment`
-- Function L146: `replay_experiment_from_backtest(*, backtest: PredictionMarketBacktest, description: str, report: MarketReportConfig | None = None, empty_message: str | None = None, partial_message: str | None = None, result_policy: ResultPolicy | None = None) -> ReplayExperiment`
-- Function L181: `async run_replay_experiment_async(experiment: ReplayExperiment) -> list[dict[str, Any]]`
-- Function L187: `_finalize_replay_results(experiment: ReplayExperiment, results: list[dict[str, Any]]) -> list[dict[str, Any]]`
-- Function L217: `run_experiment(experiment: Experiment) -> list[dict[str, Any]] | ParameterSearchSummary`
-- Function L235: `async run_experiment_async(experiment: Experiment) -> list[dict[str, Any]] | ParameterSearchSummary`
-- Class L34: `ReplayExperiment`
-- Class L60: `ParameterSearchExperiment`
-  - Method L66: `optimization(self) -> ParameterSearchConfig`
+- Function L74: `build_backtest_for_experiment(experiment: ReplayExperiment) -> PredictionMarketBacktest`
+- Function L96: `build_replay_experiment(*, name: str, description: str, data: MarketDataConfig, replays: Sequence[ReplaySpec], strategy_configs: Sequence[StrategyConfigSpec] = (), strategy_factory: Callable[..., Any] | None = None, initial_cash: float = 100.0, probability_window: int = 30, min_book_events: int = 0, min_price_range: float = 0.0, default_lookback_days: int | None = None, default_lookback_hours: float | None = None, default_start_time: pd.Timestamp | datetime | str | None = None, default_end_time: pd.Timestamp | datetime | str | None = None, nautilus_log_level: str = 'INFO', execution: ExecutionModelConfig | None = None, chart_resample_rule: str | None = None, return_summary_series: bool = False, report: MarketReportConfig | None = None, empty_message: str | None = None, partial_message: str | None = None, result_policy: ResultPolicy | None = None) -> ReplayExperiment`
+- Function L147: `replay_experiment_from_backtest(*, backtest: PredictionMarketBacktest, description: str, report: MarketReportConfig | None = None, empty_message: str | None = None, partial_message: str | None = None, result_policy: ResultPolicy | None = None) -> ReplayExperiment`
+- Function L182: `async run_replay_experiment_async(experiment: ReplayExperiment) -> list[dict[str, Any]]`
+- Function L188: `_finalize_replay_results(experiment: ReplayExperiment, results: list[dict[str, Any]]) -> list[dict[str, Any]]`
+- Function L219: `run_experiment(experiment: Experiment) -> list[dict[str, Any]] | ParameterSearchSummary`
+- Function L237: `async run_experiment_async(experiment: Experiment) -> list[dict[str, Any]] | ParameterSearchSummary`
+- Class L35: `ReplayExperiment`
+- Class L61: `ParameterSearchExperiment`
+  - Method L67: `optimization(self) -> ParameterSearchConfig`
 
 ### `prediction_market_extensions/backtesting/_isolated_replay_runner.py`
 - Imports: `__future__, asyncio, contextlib, multiprocessing, pathlib, pickle, tempfile, traceback, typing`
@@ -831,31 +849,31 @@ flowchart TD
 
 ### `prediction_market_extensions/backtesting/_prediction_market_backtest.py`
 - Imports: `__future__, asyncio, collections, datetime, nautilus_trader, pandas, prediction_market_extensions, typing, warnings`
-- Function L69: `_record_ts_event(record) -> int | None`
-- Function L79: `_largest_record_gap_ns(records: Sequence[Any]) -> int | None`
-- Function L93: `_emit_engine_status(engine: BacktestEngine, message: str) -> None`
-- Function L105: `_serialize_engine_result_stats(engine_result) -> dict[str, Any]`
-- Function L506: `_LoadedMarketSim(*, spec: ReplaySpec, instrument, records: Sequence[Any], count: int, count_key: str, market_key: str, market_id: str, outcome: str, realized_outcome: float | None, prices: Sequence[float], metadata: Mapping[str, Any] | None, requested_start_ns: int | None, requested_end_ns: int | None) -> LoadedReplay`
-- Class L117: `PredictionMarketBacktest`
-  - Method L118: `__init__(self, *, name: str, data: MarketDataConfig, replays: Sequence[ReplaySpec], strategy_configs: Sequence[StrategyConfigSpec] = (), strategy_factory: StrategyFactory | None = None, initial_cash: float, probability_window: int, min_book_events: int = 0, min_price_range: float = 0.0, default_lookback_days: int | None = None, default_lookback_hours: float | None = None, default_start_time: pd.Timestamp | datetime | str | None = None, default_end_time: pd.Timestamp | datetime | str | None = None, nautilus_log_level: str = 'INFO', execution: ExecutionModelConfig | None = None, chart_resample_rule: str | None = None, return_summary_series: bool = False) -> None`
-  - Method L166: `_strategy_summary_label(self) -> str`
-  - Method L173: `run(self) -> list[dict[str, Any]]`
-  - Method L183: `run_backtest(self) -> list[dict[str, Any]]`
-  - Method L186: `async run_async(self) -> list[dict[str, Any]]`
-  - Method L256: `async run_backtest_async(self) -> list[dict[str, Any]]`
-  - Method L259: `_create_artifact_builder(self) -> PredictionMarketArtifactBuilder`
-  - Method L271: `_build_result(self, *, loaded_sim: LoadedReplay, fills_report: pd.DataFrame, positions_report: pd.DataFrame, market_artifacts: Mapping[str, Any] | None = None, joint_portfolio_artifacts: Mapping[str, Any] | None = None, run_state: dict[str, Any] | None = None) -> dict[str, Any]`
-  - Method L290: `_build_market_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay], fills_report: pd.DataFrame) -> dict[str, dict[str, Any]]`
-  - Method L301: `_build_joint_portfolio_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay]) -> dict[str, Any]`
-  - Method L308: `_normalize_replays(self, replays: Sequence[ReplaySpec]) -> tuple[ReplaySpec, ...]`
-  - Method L321: `_load_request(self) -> ReplayLoadRequest`
-  - Method L331: `async _load_sims_async(self) -> list[LoadedReplay]`
-  - Method L355: `_build_engine(self) -> BacktestEngine`
-  - Method L390: `_build_importable_strategy_configs(self, loaded_sims: Sequence[LoadedReplay]) -> list[Any]`
-  - Method L412: `_is_batch_strategy_config(self, strategy_spec: StrategyConfigSpec) -> bool`
-  - Method L421: `_contains_value(self, value, target: str) -> bool`
-  - Method L430: `_bind_strategy_spec(self, *, strategy_spec: StrategyConfigSpec, loaded_sim: LoadedReplay, all_instrument_ids: Sequence[InstrumentId]) -> StrategyConfigSpec`
-  - Method L458: `_bind_value(self, value, *, instrument_id: InstrumentId, all_instrument_ids: Sequence[InstrumentId], metadata: Mapping[str, Any]) -> Any`
+- Function L73: `_record_ts_event(record) -> int | None`
+- Function L83: `_largest_record_gap_ns(records: Sequence[Any]) -> int | None`
+- Function L97: `_emit_engine_status(engine: BacktestEngine, message: str) -> None`
+- Function L109: `_serialize_engine_result_stats(engine_result) -> dict[str, Any]`
+- Function L513: `_LoadedMarketSim(*, spec: ReplaySpec, instrument, records: Sequence[Any], count: int, count_key: str, market_key: str, market_id: str, outcome: str, realized_outcome: float | None, prices: Sequence[float], metadata: Mapping[str, Any] | None, requested_start_ns: int | None, requested_end_ns: int | None) -> LoadedReplay`
+- Class L121: `PredictionMarketBacktest`
+  - Method L122: `__init__(self, *, name: str, data: MarketDataConfig, replays: Sequence[ReplaySpec], strategy_configs: Sequence[StrategyConfigSpec] = (), strategy_factory: StrategyFactory | None = None, initial_cash: float, probability_window: int, min_book_events: int = 0, min_price_range: float = 0.0, default_lookback_days: int | None = None, default_lookback_hours: float | None = None, default_start_time: pd.Timestamp | datetime | str | None = None, default_end_time: pd.Timestamp | datetime | str | None = None, nautilus_log_level: str = 'INFO', execution: ExecutionModelConfig | None = None, chart_resample_rule: str | None = None, return_summary_series: bool = False) -> None`
+  - Method L170: `_strategy_summary_label(self) -> str`
+  - Method L177: `run(self) -> list[dict[str, Any]]`
+  - Method L187: `run_backtest(self) -> list[dict[str, Any]]`
+  - Method L190: `async run_async(self) -> list[dict[str, Any]]`
+  - Method L263: `async run_backtest_async(self) -> list[dict[str, Any]]`
+  - Method L266: `_create_artifact_builder(self) -> PredictionMarketArtifactBuilder`
+  - Method L278: `_build_result(self, *, loaded_sim: LoadedReplay, fills_report: pd.DataFrame, positions_report: pd.DataFrame, market_artifacts: Mapping[str, Any] | None = None, joint_portfolio_artifacts: Mapping[str, Any] | None = None, run_state: dict[str, Any] | None = None) -> dict[str, Any]`
+  - Method L297: `_build_market_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay], fills_report: pd.DataFrame) -> dict[str, dict[str, Any]]`
+  - Method L308: `_build_joint_portfolio_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay]) -> dict[str, Any]`
+  - Method L315: `_normalize_replays(self, replays: Sequence[ReplaySpec]) -> tuple[ReplaySpec, ...]`
+  - Method L328: `_load_request(self) -> ReplayLoadRequest`
+  - Method L338: `async _load_sims_async(self) -> list[LoadedReplay]`
+  - Method L362: `_build_engine(self) -> BacktestEngine`
+  - Method L397: `_build_importable_strategy_configs(self, loaded_sims: Sequence[LoadedReplay]) -> list[Any]`
+  - Method L419: `_is_batch_strategy_config(self, strategy_spec: StrategyConfigSpec) -> bool`
+  - Method L428: `_contains_value(self, value, target: str) -> bool`
+  - Method L437: `_bind_strategy_spec(self, *, strategy_spec: StrategyConfigSpec, loaded_sim: LoadedReplay, all_instrument_ids: Sequence[InstrumentId]) -> StrategyConfigSpec`
+  - Method L465: `_bind_value(self, value, *, instrument_id: InstrumentId, all_instrument_ids: Sequence[InstrumentId], metadata: Mapping[str, Any]) -> Any`
 
 ### `prediction_market_extensions/backtesting/_prediction_market_runner.py`
 - Imports: `__future__, collections, datetime, nautilus_trader, pandas, prediction_market_extensions, typing`
@@ -867,14 +885,28 @@ flowchart TD
 
 ### `prediction_market_extensions/backtesting/_result_policies.py`
 - Imports: `__future__, collections, dataclasses, pandas, prediction_market_extensions, typing`
-- Function L24: `_timestamp_ns(value: object | None) -> int | None`
-- Function L48: `append_result_warning(result: dict[str, Any], message: str) -> None`
-- Function L57: `apply_repo_research_disclosures(results: Results) -> Results`
-- Function L70: `apply_binary_settlement_pnl(result: dict[str, Any], *, settlement_pnl_fn: SettlementPnlFn = compute_binary_settlement_pnl, pnl_key: str = 'pnl', market_exit_pnl_key: str = 'market_exit_pnl', fill_events_key: str = 'fill_events', realized_outcome_key: str = 'realized_outcome', settlement_observable_ns_key: str = 'settlement_observable_ns', settlement_observable_time_key: str = 'settlement_observable_time', simulated_through_key: str = 'simulated_through') -> dict[str, Any]`
-- Class L66: `ResultPolicy(Protocol)`
-  - Method L67: `apply(self, results: Results) -> Results | None`
-- Class L126: `BinarySettlementPnlPolicy`
-  - Method L133: `apply(self, results: Results) -> Results`
+- Function L26: `_timestamp_ns(value: object | None) -> int | None`
+- Function L50: `_timestamp_utc(value: object | None) -> pd.Timestamp | None`
+- Function L75: `_coerce_float(value: object | None) -> float | None`
+- Function L85: `_pairs_to_series(pairs: object) -> pd.Series`
+- Function L109: `_series_to_pairs(series: pd.Series) -> list[tuple[str, float]]`
+- Function L117: `_series_value_at_or_before(series: pd.Series, timestamp: pd.Timestamp) -> float | None`
+- Function L126: `_fill_event_timestamp(event: Mapping[object, object]) -> pd.Timestamp | None`
+- Function L134: `_binary_mark_to_market_pnl_at_settlement(*, fill_events: object, price_series: object, timestamp: pd.Timestamp) -> tuple[float, float] | None`
+- Function L191: `_series_bounds(*series_values: object) -> tuple[pd.Timestamp | None, pd.Timestamp | None]`
+- Function L202: `_set_series_value_at_and_after(series: pd.Series, *, timestamp: pd.Timestamp, value: float) -> pd.Series`
+- Function L215: `_add_series_delta_at_and_after(series: pd.Series, *, timestamp: pd.Timestamp, delta: float) -> pd.Series`
+- Function L231: `_add_settlement_delta_to_equity_like_series(series: pd.Series, *, timestamp: pd.Timestamp, settlement_delta: float, post_settlement_delta: float) -> pd.Series`
+- Function L256: `_settlement_timestamp(result: Mapping[str, Any], *, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> pd.Timestamp | None`
+- Function L289: `_apply_settlement_to_summary_series(result: dict[str, Any], *, settlement_pnl: float, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> None`
+- Function L366: `append_result_warning(result: dict[str, Any], message: str) -> None`
+- Function L375: `apply_repo_research_disclosures(results: Results) -> Results`
+- Function L388: `apply_binary_settlement_pnl(result: dict[str, Any], *, settlement_pnl_fn: SettlementPnlFn = compute_binary_settlement_pnl, pnl_key: str = 'pnl', market_exit_pnl_key: str = 'market_exit_pnl', fill_events_key: str = 'fill_events', realized_outcome_key: str = 'realized_outcome', settlement_observable_ns_key: str = 'settlement_observable_ns', settlement_observable_time_key: str = 'settlement_observable_time', simulated_through_key: str = 'simulated_through') -> dict[str, Any]`
+- Function L449: `apply_joint_portfolio_settlement_pnl(results: Results) -> Results`
+- Class L384: `ResultPolicy(Protocol)`
+  - Method L385: `apply(self, results: Results) -> Results | None`
+- Class L521: `BinarySettlementPnlPolicy`
+  - Method L528: `apply(self, results: Results) -> Results`
 
 ### `prediction_market_extensions/backtesting/_strategy_configs.py`
 - Imports: `__future__, collections, copy, nautilus_trader, typing`
@@ -1175,10 +1207,10 @@ flowchart TD
 
 ### `prediction_market_extensions/backtesting/prediction_market/reporting.py`
 - Imports: `__future__, collections, dataclasses, prediction_market_extensions, typing`
-- Function L39: `finalize_market_results(*, name: str, results: Sequence[dict[str, object]], report: MarketReportConfig) -> None`
-- Function L85: `run_reported_backtest(*, backtest: PredictionMarketBacktest, report: MarketReportConfig, empty_message: str | None = None) -> list[dict[str, object]]`
-- Function L101: `_resolve_report_market_key(*, results: Sequence[dict[str, object]], configured_key: str) -> str`
-- Class L29: `MarketReportConfig`
+- Function L42: `finalize_market_results(*, name: str, results: Sequence[dict[str, object]], report: MarketReportConfig) -> None`
+- Function L89: `run_reported_backtest(*, backtest: PredictionMarketBacktest, report: MarketReportConfig, empty_message: str | None = None) -> list[dict[str, object]]`
+- Function L105: `_resolve_report_market_key(*, results: Sequence[dict[str, object]], configured_key: str) -> str`
+- Class L32: `MarketReportConfig`
 
 ### `scripts/__init__.py`
 - Imports: none
@@ -1364,6 +1396,36 @@ flowchart TD
 - Function L40: `require_rsi(name: str, value: float) -> None`
 - Function L47: `require_less(name: str, left: float | int, other_name: str, right: float | int) -> None`
 
+### `strategies/binary_pair_arbitrage.py`
+- Imports: `__future__, decimal, nautilus_trader, prediction_market_extensions, strategies`
+- Function L41: `_as_float(value: object | None) -> float | None`
+- Function L55: `_decimal_or_none(value: object | None) -> Decimal | None`
+- Function L64: `_clamp_probability(value: Decimal) -> Decimal`
+- Function L68: `_fee_per_share(*, price: Decimal, taker_fee: Decimal) -> Decimal`
+- Class L74: `BookBinaryPairArbitrageConfig(StrategyConfig)`
+  - Method L100: `__post_init__(self) -> None`
+- Class L118: `BookBinaryPairArbitrageStrategy(Strategy)`
+  - Method L132: `__init__(self, config: BookBinaryPairArbitrageConfig) -> None`
+  - Method L142: `on_start(self) -> None`
+  - Method L166: `on_order_book_deltas(self, deltas) -> None`
+  - Method L178: `_best_ask_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None`
+  - Method L192: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L198: `_free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None`
+  - Method L210: `_avg_entry_price(self, instrument_id: InstrumentId, size: Decimal) -> float | None`
+  - Method L226: `_rounded_quantity(self, instrument_id: InstrumentId, size: Decimal) -> Any`
+  - Method L242: `_pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L245: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L323: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], quantities: list[object], visible_size: float, net_unit_cost: float, edge: float) -> None`
+  - Method L362: `_event_order_is_closed(self, event) -> bool`
+  - Method L377: `_mark_order_event(self, event) -> None`
+  - Method L385: `on_order_filled(self, event) -> None`
+  - Method L388: `on_order_rejected(self, event) -> None`
+  - Method L391: `on_order_denied(self, event) -> None`
+  - Method L394: `on_order_canceled(self, event) -> None`
+  - Method L397: `on_order_expired(self, event) -> None`
+  - Method L400: `on_stop(self) -> None`
+  - Method L409: `on_reset(self) -> None`
+
 ### `strategies/breakout.py`
 - Imports: `__future__, collections, decimal, math, nautilus_trader, strategies, typing`
 - Class L40: `_BreakoutConfig(Protocol)`
@@ -1477,20 +1539,31 @@ flowchart TD
 
 ### `strategies/late_favorite_limit_hold.py`
 - Imports: `__future__, decimal, nautilus_trader, strategies`
-- Function L17: `_validate_late_favorite_config(*, trade_size: Decimal, entry_price: float, activation_start_time_ns: int, market_close_time_ns: int) -> None`
-- Class L42: `BookLateFavoriteLimitHoldConfig(StrategyConfig)`
-  - Method L49: `__post_init__(self) -> None`
-- Class L58: `_LateFavoriteLimitHoldBase(LongOnlyPredictionMarketStrategy)`
-  - Method L66: `__init__(self, config: BookLateFavoriteLimitHoldConfig) -> None`
-  - Method L70: `_on_price(self, *, signal_price: float, order_price: float, ts_event_ns: int, visible_size: float | None = None, exit_visible_size: float | None = None) -> None`
-  - Method L113: `on_order_filled(self, event) -> None`
-  - Method L118: `on_order_expired(self, event) -> None`
-  - Method L121: `on_order_accepted(self, event) -> None`
-  - Method L125: `on_stop(self) -> None`
-  - Method L129: `on_reset(self) -> None`
-- Class L134: `BookLateFavoriteLimitHoldStrategy(_LateFavoriteLimitHoldBase)`
-  - Method L135: `_subscribe(self) -> None`
-  - Method L141: `on_order_book(self, order_book) -> None`
+- Function L22: `_validate_late_favorite_config(*, trade_size: Decimal, entry_price: float, activation_start_time_ns: int, market_close_time_ns: int) -> None`
+- Class L47: `BookLateFavoriteLimitHoldConfig(StrategyConfig)`
+  - Method L54: `__post_init__(self) -> None`
+- Class L63: `_LateFavoriteLimitHoldBase(LongOnlyPredictionMarketStrategy)`
+  - Method L71: `__init__(self, config: BookLateFavoriteLimitHoldConfig) -> None`
+  - Method L75: `_on_price(self, *, signal_price: float, order_price: float, ts_event_ns: int, visible_size: float | None = None, exit_visible_size: float | None = None) -> None`
+  - Method L118: `on_order_filled(self, event) -> None`
+  - Method L123: `on_order_expired(self, event) -> None`
+  - Method L126: `on_order_accepted(self, event) -> None`
+  - Method L130: `on_stop(self) -> None`
+  - Method L134: `on_reset(self) -> None`
+- Class L139: `BookLateFavoriteLimitHoldStrategy(_LateFavoriteLimitHoldBase)`
+  - Method L140: `_subscribe(self) -> None`
+  - Method L146: `on_order_book(self, order_book) -> None`
+- Class L161: `BookLateFavoriteTakerHoldConfig(StrategyConfig)`
+  - Method L176: `__post_init__(self) -> None`
+- Class L202: `BookLateFavoriteTakerHoldStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L214: `__init__(self, config: BookLateFavoriteTakerHoldConfig) -> None`
+  - Method L218: `_subscribe(self) -> None`
+  - Method L224: `on_order_book(self, order_book) -> None`
+  - Method L242: `_entry_window_is_open(self, ts_event_ns: int) -> bool`
+  - Method L253: `_on_book_signal(self, *, bid: float, ask: float, midpoint: float, spread: float, ask_size: float | None, ts_event_ns: int) -> None`
+  - Method L293: `on_order_filled(self, event) -> None`
+  - Method L298: `on_stop(self) -> None`
+  - Method L301: `on_reset(self) -> None`
 
 ### `strategies/mean_reversion.py`
 - Imports: `__future__, collections, decimal, nautilus_trader, strategies, typing`

--- a/NOTICE
+++ b/NOTICE
@@ -26,6 +26,8 @@ provenance notices with file-specific change dates:
 - `backtests/polymarket_book_ema_crossover.py`
 - `backtests/polymarket_book_ema_optimizer.py`
 - `backtests/polymarket_book_joint_portfolio_runner.py`
+- `backtests/polymarket_btc_5m_late_favorite_taker_hold.py`
+- `backtests/polymarket_btc_5m_pair_arbitrage.py`
 - `backtests/polymarket_telonex_book_joint_portfolio_runner.py`
 - `prediction_market_extensions/adapters/kalshi/data.py`
 - `prediction_market_extensions/adapters/kalshi/fee_model.py`
@@ -54,6 +56,7 @@ provenance notices with file-specific change dates:
 - `prediction_market_extensions/analysis/tearsheet.py`
 - `scripts/_script_helpers.py`
 - `strategies/__init__.py`
+- `strategies/binary_pair_arbitrage.py`
 - `strategies/breakout.py`
 - `strategies/core.py`
 - `strategies/deep_value.py`

--- a/backtests/polymarket_btc_5m_late_favorite_taker_hold.py
+++ b/backtests/polymarket_btc_5m_late_favorite_taker_hold.py
@@ -1,0 +1,173 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Added in this repository on 2026-04-27.
+# See the repository NOTICE file for provenance and licensing scope.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+if __package__ in {None, ""}:
+    from _script_helpers import ensure_repo_root
+else:
+    from ._script_helpers import ensure_repo_root
+
+ensure_repo_root(__file__)
+
+
+BTC_5M_WINDOW_START = datetime(2026, 4, 26, 18, 0, tzinfo=UTC)
+BTC_5M_WINDOW_COUNT = 24
+BTC_5M_WINDOW_SIZE = timedelta(minutes=5)
+ACTIVATION_SECONDS_BEFORE_CLOSE = 60
+SUMMARY_REPORT_PATH = "output/polymarket_btc_5m_late_favorite_taker_hold_summary.html"
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _btc_5m_windows() -> tuple[tuple[str, datetime, datetime], ...]:
+    return tuple(
+        (
+            f"btc-updown-5m-{int(start.timestamp())}",
+            start,
+            start + BTC_5M_WINDOW_SIZE,
+        )
+        for index in range(BTC_5M_WINDOW_COUNT)
+        for start in (BTC_5M_WINDOW_START + (index * BTC_5M_WINDOW_SIZE),)
+    )
+
+
+def _btc_5m_replays():  # type: ignore[no-untyped-def]
+    from prediction_market_extensions.backtesting._replay_specs import BookReplay
+
+    return tuple(
+        BookReplay(
+            market_slug=slug,
+            token_index=token_index,
+            start_time=_utc_iso(start_time),
+            end_time=_utc_iso(end_time),
+            metadata={
+                "sim_label": f"{slug}-{'up' if token_index == 0 else 'down'}",
+                "activation_start_time_ns": int(
+                    (end_time - timedelta(seconds=ACTIVATION_SECONDS_BEFORE_CLOSE)).timestamp()
+                    * 1_000_000_000
+                ),
+                "market_close_time_ns": int(end_time.timestamp() * 1_000_000_000),
+            },
+        )
+        for slug, start_time, end_time in _btc_5m_windows()
+        for token_index in (0, 1)
+    )
+
+
+def run() -> None:
+    from dotenv import load_dotenv
+
+    from prediction_market_extensions.backtesting._execution_config import (
+        ExecutionModelConfig,
+        StaticLatencyConfig,
+    )
+    from prediction_market_extensions.backtesting._experiments import (
+        build_replay_experiment,
+        run_experiment,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_backtest import (
+        MarketReportConfig,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_runner import (
+        MarketDataConfig,
+    )
+    from prediction_market_extensions.backtesting._timing_harness import timing_harness
+    from prediction_market_extensions.backtesting.data_sources import Book, PMXT, Polymarket
+
+    load_dotenv()
+
+    @timing_harness
+    def _run() -> None:
+        run_experiment(
+            build_replay_experiment(
+                name="polymarket_btc_5m_late_favorite_taker_hold",
+                description=(
+                    "BTC 5m late-window favorite and cheap-NO taker entries using PMXT L2 book data"
+                ),
+                data=MarketDataConfig(
+                    platform=Polymarket,
+                    data_type=Book,
+                    vendor=PMXT,
+                    sources=(
+                        "local:/Volumes/LaCie/pmxt_data",
+                        "archive:r2v2.pmxt.dev",
+                        "archive:r2.pmxt.dev",
+                    ),
+                ),
+                replays=_btc_5m_replays(),
+                strategy_configs=[
+                    {
+                        "strategy_path": "strategies:BookLateFavoriteTakerHoldStrategy",
+                        "config_path": "strategies:BookLateFavoriteTakerHoldConfig",
+                        "config": {
+                            "trade_size": Decimal("5"),
+                            "activation_start_time_ns": (
+                                "__SIM_METADATA__:activation_start_time_ns"
+                            ),
+                            "market_close_time_ns": "__SIM_METADATA__:market_close_time_ns",
+                            "min_midpoint": 0.90,
+                            "min_bid_price": 0.88,
+                            "max_entry_price": 0.95,
+                            "max_spread": 0.04,
+                            "min_visible_size": 5.0,
+                            "enable_cheap_no_entry": True,
+                            "max_cheap_no_entry_price": 0.05,
+                            "max_cheap_no_midpoint": 0.10,
+                            "max_cheap_no_spread": 0.05,
+                        },
+                    }
+                ],
+                initial_cash=1_000.0,
+                probability_window=256,
+                min_book_events=25,
+                min_price_range=0.0,
+                execution=ExecutionModelConfig(
+                    queue_position=True,
+                    latency_model=StaticLatencyConfig(
+                        base_latency_ms=75.0,
+                        insert_latency_ms=10.0,
+                        update_latency_ms=5.0,
+                        cancel_latency_ms=5.0,
+                    ),
+                ),
+                report=MarketReportConfig(
+                    count_key="book_events",
+                    count_label="Book Events",
+                    pnl_label="PnL (USDC)",
+                    market_key="sim_label",
+                    summary_report=True,
+                    summary_report_path=SUMMARY_REPORT_PATH,
+                    summary_plot_panels=(
+                        "total_equity",
+                        "equity",
+                        "market_pnl",
+                        "periodic_pnl",
+                        "yes_price",
+                        "allocation",
+                        "total_drawdown",
+                        "drawdown",
+                        "total_cash_equity",
+                        "cash_equity",
+                        "total_brier_advantage",
+                        "brier_advantage",
+                    ),
+                ),
+                empty_message="No BTC 5m late-favorite sims met the book requirements.",
+                partial_message="Completed {completed} of {total} BTC 5m late-favorite replays.",
+                return_summary_series=True,
+            )
+        )
+
+    _run()
+
+
+if __name__ == "__main__":
+    run()

--- a/backtests/polymarket_btc_5m_pair_arbitrage.py
+++ b/backtests/polymarket_btc_5m_pair_arbitrage.py
@@ -1,0 +1,162 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Added in this repository on 2026-04-27.
+# See the repository NOTICE file for provenance and licensing scope.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+if __package__ in {None, ""}:
+    from _script_helpers import ensure_repo_root
+else:
+    from ._script_helpers import ensure_repo_root
+
+ensure_repo_root(__file__)
+
+
+BTC_5M_WINDOW_START = datetime(2026, 4, 26, 18, 0, tzinfo=UTC)
+BTC_5M_WINDOW_COUNT = 4
+BTC_5M_WINDOW_SIZE = timedelta(minutes=5)
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _btc_5m_windows() -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        (
+            f"btc-updown-5m-{int(start.timestamp())}",
+            _utc_iso(start),
+            _utc_iso(start + BTC_5M_WINDOW_SIZE),
+        )
+        for index in range(BTC_5M_WINDOW_COUNT)
+        for start in (BTC_5M_WINDOW_START + (index * BTC_5M_WINDOW_SIZE),)
+    )
+
+
+def _btc_5m_replays():  # type: ignore[no-untyped-def]
+    from prediction_market_extensions.backtesting._replay_specs import BookReplay
+
+    return tuple(
+        BookReplay(
+            market_slug=slug,
+            token_index=token_index,
+            start_time=start_time,
+            end_time=end_time,
+            metadata={"sim_label": f"{slug}-{'up' if token_index == 0 else 'down'}"},
+        )
+        for slug, start_time, end_time in _btc_5m_windows()
+        for token_index in (0, 1)
+    )
+
+
+def run() -> None:
+    from dotenv import load_dotenv
+
+    from prediction_market_extensions.backtesting._execution_config import (
+        ExecutionModelConfig,
+        StaticLatencyConfig,
+    )
+    from prediction_market_extensions.backtesting._experiments import (
+        build_replay_experiment,
+        run_experiment,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_backtest import (
+        MarketReportConfig,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_runner import (
+        MarketDataConfig,
+    )
+    from prediction_market_extensions.backtesting._timing_harness import timing_harness
+    from prediction_market_extensions.backtesting.data_sources import Book, PMXT, Polymarket
+
+    load_dotenv()
+
+    @timing_harness
+    def _run() -> None:
+        run_experiment(
+            build_replay_experiment(
+                name="polymarket_btc_5m_pair_arbitrage",
+                description=(
+                    "BTC 5m gross complementary-token entries using only PMXT L2 book data"
+                ),
+                data=MarketDataConfig(
+                    platform=Polymarket,
+                    data_type=Book,
+                    vendor=PMXT,
+                    sources=(
+                        "local:/Volumes/LaCie/pmxt_data",
+                        "archive:r2v2.pmxt.dev",
+                        "archive:r2.pmxt.dev",
+                    ),
+                ),
+                replays=_btc_5m_replays(),
+                strategy_configs=[
+                    {
+                        "strategy_path": "strategies:BookBinaryPairArbitrageStrategy",
+                        "config_path": "strategies:BookBinaryPairArbitrageConfig",
+                        "config": {
+                            "instrument_ids": "__ALL_SIM_INSTRUMENT_IDS__",
+                            "trade_size": Decimal("5"),
+                            "min_net_edge": 0.0,
+                            "max_total_cost": 1.0,
+                            "max_leg_price": 0.985,
+                            "max_spread": 0.080,
+                            "max_expected_slippage": 0.015,
+                            "min_visible_size": 5.0,
+                            "max_entries_per_pair": 1,
+                            "reentry_cooldown_updates": 25,
+                            "pairing_mode": "sequential",
+                            "hold_to_resolution": True,
+                            "include_taker_fees_in_signal": False,
+                        },
+                    }
+                ],
+                initial_cash=1_000.0,
+                probability_window=256,
+                min_book_events=25,
+                min_price_range=0.0,
+                execution=ExecutionModelConfig(
+                    queue_position=True,
+                    latency_model=StaticLatencyConfig(
+                        base_latency_ms=75.0,
+                        insert_latency_ms=10.0,
+                        update_latency_ms=5.0,
+                        cancel_latency_ms=5.0,
+                    ),
+                ),
+                report=MarketReportConfig(
+                    count_key="book_events",
+                    count_label="Book Events",
+                    pnl_label="PnL (USDC)",
+                    market_key="sim_label",
+                    summary_report=True,
+                    summary_report_path=("output/polymarket_btc_5m_pair_arbitrage_summary.html"),
+                    summary_plot_panels=(
+                        "total_equity",
+                        "equity",
+                        "market_pnl",
+                        "periodic_pnl",
+                        "yes_price",
+                        "allocation",
+                        "total_drawdown",
+                        "drawdown",
+                        "total_cash_equity",
+                        "cash_equity",
+                        "total_brier_advantage",
+                        "brier_advantage",
+                    ),
+                ),
+                empty_message="No BTC 5m pair-arbitrage sims met the book requirements.",
+                return_summary_series=True,
+            )
+        )
+
+    _run()
+
+
+if __name__ == "__main__":
+    run()

--- a/prediction_market_extensions/adapters/prediction_market/research.py
+++ b/prediction_market_extensions/adapters/prediction_market/research.py
@@ -258,6 +258,19 @@ def _align_series_to_timeline(
     return aligned.astype(float)
 
 
+def _extend_active_range(
+    active_ranges: dict[str, tuple[pd.Timestamp, pd.Timestamp]],
+    label: str,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+) -> None:
+    if label not in active_ranges:
+        active_ranges[label] = (start, end)
+        return
+    current_start, current_end = active_ranges[label]
+    active_ranges[label] = (min(current_start, start), max(current_end, end))
+
+
 def _parse_float_like(value: Any, default: float = 0.0) -> float:
     if value is None:
         return default
@@ -765,7 +778,6 @@ def run_market_backtest(
             else None
         ),
     }
-    result = apply_binary_settlement_pnl(result)
     if return_summary_series:
         result["price_series"] = summary_price_series or []
         result["pnl_series"] = summary_pnl_series or []
@@ -775,7 +787,7 @@ def run_market_backtest(
         result["market_probability_series"] = summary_market_probability_series or []
         result["outcome_series"] = summary_outcome_series or []
         result["fill_events"] = summary_fill_events or []
-    return result
+    return apply_binary_settlement_pnl(result)
 
 
 def save_combined_backtest_report(
@@ -875,7 +887,9 @@ def save_aggregate_backtest_report(
                 market_prices[label] = [
                     (_to_legacy_datetime(ts), float(value)) for ts, value in price_series.items()
                 ]
-            active_ranges[label] = (price_series.index[0], price_series.index[-1])
+            _extend_active_range(
+                active_ranges, label, price_series.index[0], price_series.index[-1]
+            )
             timeline_points.update(price_series.index.to_list())
 
         if include_fill_events:
@@ -928,17 +942,16 @@ def save_aggregate_backtest_report(
         if not equity_series.empty:
             equity_series_by_market[label] = equity_series.astype(float)
             timeline_points.update(equity_series.index.to_list())
-            if label not in active_ranges:
-                active_ranges[label] = (equity_series.index[0], equity_series.index[-1])
+            _extend_active_range(
+                active_ranges, label, equity_series.index[0], equity_series.index[-1]
+            )
         if not cash_series.empty:
             cash_series_by_market[label] = cash_series.astype(float)
             timeline_points.update(cash_series.index.to_list())
-            if label not in active_ranges:
-                active_ranges[label] = (cash_series.index[0], cash_series.index[-1])
+            _extend_active_range(active_ranges, label, cash_series.index[0], cash_series.index[-1])
         if not pnl_series.empty:
             timeline_points.update(pnl_series.index.to_list())
-            if label not in active_ranges:
-                active_ranges[label] = (pnl_series.index[0], pnl_series.index[-1])
+            _extend_active_range(active_ranges, label, pnl_series.index[0], pnl_series.index[-1])
 
     if timeline_points:
         timeline = pd.DatetimeIndex(sorted(timeline_points))
@@ -1126,7 +1139,9 @@ def save_joint_portfolio_backtest_report(
                 market_prices[label] = [
                     (_to_legacy_datetime(ts), float(value)) for ts, value in price_series.items()
                 ]
-            active_ranges[label] = (price_series.index[0], price_series.index[-1])
+            _extend_active_range(
+                active_ranges, label, price_series.index[0], price_series.index[-1]
+            )
             timeline_points.update(price_series.index.to_list())
 
         if include_overlay_series:
@@ -1135,13 +1150,15 @@ def save_joint_portfolio_backtest_report(
             if not equity_series.empty:
                 equity_series_by_market[label] = equity_series.astype(float)
                 timeline_points.update(equity_series.index.to_list())
-                if label not in active_ranges:
-                    active_ranges[label] = (equity_series.index[0], equity_series.index[-1])
+                _extend_active_range(
+                    active_ranges, label, equity_series.index[0], equity_series.index[-1]
+                )
             if not cash_series.empty:
                 cash_series_by_market[label] = cash_series.astype(float)
                 timeline_points.update(cash_series.index.to_list())
-                if label not in active_ranges:
-                    active_ranges[label] = (cash_series.index[0], cash_series.index[-1])
+                _extend_active_range(
+                    active_ranges, label, cash_series.index[0], cash_series.index[-1]
+                )
 
         if include_fill_events:
             fills.extend(

--- a/prediction_market_extensions/analysis/legacy_plot_adapter.py
+++ b/prediction_market_extensions/analysis/legacy_plot_adapter.py
@@ -367,6 +367,29 @@ def _dense_cash_series(
     return dense_df["cash"].to_numpy(dtype=float)
 
 
+def _fill_cash_delta(fill: Any) -> float:
+    action = str(fill.action.value).lower()
+    gross = float(fill.price) * float(fill.quantity)
+    cash_delta = -gross if action == "buy" else gross
+    return cash_delta - float(getattr(fill, "commission", 0.0) or 0.0)
+
+
+def _dense_cash_series_from_fills(
+    fills: list[Any], dense_dts: np.ndarray, initial_cash: float
+) -> np.ndarray:
+    cash_changes = np.zeros(len(dense_dts), dtype=float)
+    if len(dense_dts) == 0:
+        return cash_changes
+
+    for fill in sorted(fills, key=lambda item: item.timestamp):
+        ts64 = pd.Timestamp(fill.timestamp).to_datetime64()
+        bar_idx = int(np.searchsorted(dense_dts, ts64, side="left"))
+        bar_idx = max(0, min(len(dense_dts) - 1, bar_idx))
+        cash_changes[bar_idx] += _fill_cash_delta(fill)
+
+    return float(initial_cash) + np.cumsum(cash_changes)
+
+
 def _replay_fill_position_deltas(
     fills: list[Any], dense_dts: np.ndarray
 ) -> tuple[dict[str, np.ndarray], dict[str, float]]:
@@ -483,7 +506,11 @@ def _build_dense_portfolio_snapshots(
 
     dense_dts = dense_dt.to_numpy(dtype="datetime64[ns]")
     n_bars = len(dense_dt)
-    cash_series = _dense_cash_series(sparse_snapshots, dense_dt, initial_cash=initial_cash)
+    cash_series = (
+        _dense_cash_series_from_fills(fills, dense_dts, initial_cash=initial_cash)
+        if fills
+        else _dense_cash_series(sparse_snapshots, dense_dt, initial_cash=initial_cash)
+    )
     pos_changes, fill_price_map = _replay_fill_position_deltas(fills, dense_dts)
 
     if not pos_changes:

--- a/prediction_market_extensions/backtesting/_backtest_runtime.py
+++ b/prediction_market_extensions/backtesting/_backtest_runtime.py
@@ -177,6 +177,14 @@ def print_backtest_result_warnings(*, results: Sequence[dict[str, Any]], market_
             print(line)
 
 
+def add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None:
+    records_by_type: dict[type[Any], list[Any]] = {}
+    for record in records:
+        records_by_type.setdefault(type(record), []).append(record)
+    for typed_records in records_by_type.values():
+        engine.add_data(typed_records)
+
+
 def run_market_backtest(
     *,
     market_id: str,
@@ -240,7 +248,7 @@ def run_market_backtest(
         queue_position=queue_position,
     )
     engine.add_instrument(instrument)
-    engine.add_data(data_records)
+    add_engine_data_by_type(engine, data_records)
     engine.add_strategy(strategy)
     try:
         engine.run()
@@ -353,7 +361,6 @@ def run_market_backtest(
             ),
         }
         result = apply_backtest_run_state(result=result, run_state=run_state)
-        result = apply_binary_settlement_pnl(result)
         if return_summary_series:
             result["price_series"] = summary_price_series or []
             result["pnl_series"] = summary_pnl_series or []
@@ -363,7 +370,7 @@ def run_market_backtest(
             result["market_probability_series"] = summary_market_probability_series or []
             result["outcome_series"] = summary_outcome_series or []
             result["fill_events"] = summary_fill_events or []
-        return result
+        return apply_binary_settlement_pnl(result)
     finally:
         engine.reset()
         engine.dispose()

--- a/prediction_market_extensions/backtesting/_experiments.py
+++ b/prediction_market_extensions/backtesting/_experiments.py
@@ -17,6 +17,7 @@ from prediction_market_extensions.backtesting._prediction_market_backtest import
 from prediction_market_extensions.backtesting._replay_specs import ReplaySpec
 from prediction_market_extensions.backtesting._result_policies import (
     ResultPolicy,
+    apply_joint_portfolio_settlement_pnl,
     apply_repo_research_disclosures,
 )
 from prediction_market_extensions.backtesting._strategy_configs import StrategyConfigSpec
@@ -202,6 +203,7 @@ def _finalize_replay_results(
         if transformed is not None:
             results = transformed
 
+    apply_joint_portfolio_settlement_pnl(results)
     apply_repo_research_disclosures(results)
 
     if experiment.report is not None:

--- a/prediction_market_extensions/backtesting/_prediction_market_backtest.py
+++ b/prediction_market_extensions/backtesting/_prediction_market_backtest.py
@@ -27,11 +27,15 @@ from prediction_market_extensions.adapters.prediction_market import (
 from prediction_market_extensions.adapters.prediction_market.fill_model import (
     PredictionMarketTakerFillModel,
 )
-from prediction_market_extensions.backtesting._backtest_runtime import build_backtest_run_state
+from prediction_market_extensions.backtesting._backtest_runtime import (
+    add_engine_data_by_type,
+    build_backtest_run_state,
+)
 from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
 from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig
 from prediction_market_extensions.backtesting._replay_specs import ReplaySpec
 from prediction_market_extensions.backtesting._result_policies import (
+    apply_joint_portfolio_settlement_pnl,
     apply_repo_research_disclosures,
 )
 from prediction_market_extensions.backtesting._strategy_configs import (
@@ -202,7 +206,7 @@ class PredictionMarketBacktest:
         try:
             for loaded_sim in loaded_sims:
                 engine.add_instrument(loaded_sim.instrument)
-                engine.add_data(list(loaded_sim.records))
+                add_engine_data_by_type(engine, list(loaded_sim.records))
 
             if self.strategy_factory is not None:
                 for loaded_sim in loaded_sims:
@@ -221,7 +225,7 @@ class PredictionMarketBacktest:
 
             fills_report = engine.trader.generate_order_fills_report()
             positions_report = engine.trader.generate_positions_report()
-            market_artifacts_by_market_id = self._build_market_artifacts(
+            market_artifacts_by_instrument_id = self._build_market_artifacts(
                 engine=engine, loaded_sims=loaded_sims, fills_report=fills_report
             )
             joint_portfolio_artifacts = self._build_joint_portfolio_artifacts(
@@ -232,7 +236,9 @@ class PredictionMarketBacktest:
                     loaded_sim=loaded_sim,
                     fills_report=fills_report,
                     positions_report=positions_report,
-                    market_artifacts=market_artifacts_by_market_id.get(loaded_sim.market_id),
+                    market_artifacts=market_artifacts_by_instrument_id.get(
+                        str(loaded_sim.instrument.id)
+                    ),
                     joint_portfolio_artifacts=joint_portfolio_artifacts
                     if result_index == 0
                     else None,
@@ -246,6 +252,7 @@ class PredictionMarketBacktest:
                 )
                 for result_index, loaded_sim in enumerate(loaded_sims)
             ]
+            apply_joint_portfolio_settlement_pnl(results)
             if results:
                 results[0]["portfolio_stats"] = _serialize_engine_result_stats(engine_result)
             return apply_repo_research_disclosures(results)

--- a/prediction_market_extensions/backtesting/_result_policies.py
+++ b/prediction_market_extensions/backtesting/_result_policies.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from collections.abc import Mapping
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -43,6 +45,322 @@ def _timestamp_ns(value: object | None) -> int | None:
             timestamp = timestamp.tz_convert("UTC")
         return int(timestamp.value)
     return None
+
+
+def _timestamp_utc(value: object | None) -> pd.Timestamp | None:
+    if value is None:
+        return None
+    try:
+        if (
+            isinstance(value, int | float)
+            or isinstance(value, str)
+            and value.strip().lstrip("+-").isdigit()
+        ) and abs(float(value)) > 1e12:
+            timestamp = pd.to_datetime(int(value), unit="ns", utc=True, errors="coerce")
+        else:
+            timestamp = pd.Timestamp(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if pd.isna(timestamp):
+        return None
+    if isinstance(timestamp, pd.DatetimeIndex):
+        if len(timestamp) == 0:
+            return None
+        timestamp = timestamp[0]
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize("UTC")
+    return timestamp.tz_convert("UTC")
+
+
+def _coerce_float(value: object | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if pd.notna(result) else None
+
+
+def _pairs_to_series(pairs: object) -> pd.Series:
+    if not isinstance(pairs, Sequence) or isinstance(pairs, str | bytes):
+        return pd.Series(dtype=float)
+
+    rows: list[tuple[pd.Timestamp, float]] = []
+    for pair in pairs:
+        if not isinstance(pair, Sequence) or isinstance(pair, str | bytes) or len(pair) != 2:
+            continue
+        timestamp = _timestamp_utc(pair[0])
+        value = _coerce_float(pair[1])
+        if timestamp is None or value is None:
+            continue
+        rows.append((timestamp, value))
+    if not rows:
+        return pd.Series(dtype=float)
+
+    series = pd.Series(
+        [value for _, value in rows],
+        index=pd.DatetimeIndex([timestamp for timestamp, _ in rows]),
+        dtype=float,
+    )
+    return series.groupby(series.index).last().sort_index()
+
+
+def _series_to_pairs(series: pd.Series) -> list[tuple[str, float]]:
+    if series.empty:
+        return []
+    return [
+        (pd.Timestamp(timestamp).isoformat(), float(value)) for timestamp, value in series.items()
+    ]
+
+
+def _series_value_at_or_before(series: pd.Series, timestamp: pd.Timestamp) -> float | None:
+    if series.empty:
+        return None
+    prior = series.loc[series.index <= timestamp]
+    if not prior.empty:
+        return float(prior.iloc[-1])
+    return float(series.iloc[0])
+
+
+def _fill_event_timestamp(event: Mapping[object, object]) -> pd.Timestamp | None:
+    for key in ("timestamp", "ts_last", "ts_event", "ts_init"):
+        timestamp = _timestamp_utc(event.get(key))
+        if timestamp is not None:
+            return timestamp
+    return None
+
+
+def _binary_mark_to_market_pnl_at_settlement(
+    *,
+    fill_events: object,
+    price_series: object,
+    timestamp: pd.Timestamp,
+) -> tuple[float, float] | None:
+    if not isinstance(fill_events, Sequence) or isinstance(fill_events, str | bytes):
+        return None
+
+    cash_pnl = 0.0
+    open_qty = 0.0
+    fallback_price: float | None = None
+    saw_fill = False
+
+    for event in sorted(
+        (event for event in fill_events if isinstance(event, Mapping)),
+        key=lambda item: _fill_event_timestamp(item) or pd.Timestamp.min.tz_localize("UTC"),
+    ):
+        fill_timestamp = _fill_event_timestamp(event)
+        if fill_timestamp is not None and fill_timestamp > timestamp:
+            continue
+
+        action = str(event.get("action") or "").strip().lower()
+        fill_price = _coerce_float(event.get("price"))
+        quantity = _coerce_float(event.get("quantity")) or 0.0
+        commission = _coerce_float(event.get("commission")) or 0.0
+        if fill_price is None or quantity <= 0.0:
+            continue
+
+        if action == "buy":
+            cash_pnl -= fill_price * quantity
+            open_qty += quantity
+        elif action == "sell":
+            cash_pnl += fill_price * quantity
+            open_qty -= quantity
+        else:
+            continue
+
+        cash_pnl -= commission
+        fallback_price = fill_price
+        saw_fill = True
+
+    if not saw_fill:
+        return None
+
+    market_price = _series_value_at_or_before(_pairs_to_series(price_series), timestamp)
+    if market_price is None:
+        market_price = fallback_price
+    if market_price is None:
+        return None
+
+    position_value = (
+        open_qty * market_price if open_qty >= 0.0 else abs(open_qty) * (1.0 - market_price)
+    )
+    return float(cash_pnl + max(position_value, 0.0)), float(cash_pnl)
+
+
+def _series_bounds(*series_values: object) -> tuple[pd.Timestamp | None, pd.Timestamp | None]:
+    starts: list[pd.Timestamp] = []
+    ends: list[pd.Timestamp] = []
+    for value in series_values:
+        series = _pairs_to_series(value)
+        if not series.empty:
+            starts.append(pd.Timestamp(series.index[0]))
+            ends.append(pd.Timestamp(series.index[-1]))
+    return (min(starts), max(ends)) if starts and ends else (None, None)
+
+
+def _set_series_value_at_and_after(
+    series: pd.Series, *, timestamp: pd.Timestamp, value: float
+) -> pd.Series:
+    if series.empty:
+        return pd.Series([float(value)], index=pd.DatetimeIndex([timestamp]), dtype=float)
+
+    updated = series.copy()
+    updated.loc[timestamp] = float(value)
+    updated = updated.groupby(updated.index).last().sort_index()
+    updated.loc[updated.index >= timestamp] = float(value)
+    return updated.astype(float)
+
+
+def _add_series_delta_at_and_after(
+    series: pd.Series, *, timestamp: pd.Timestamp, delta: float
+) -> pd.Series:
+    if series.empty:
+        return series
+
+    updated = series.copy()
+    if timestamp not in updated.index:
+        baseline = _series_value_at_or_before(updated, timestamp)
+        if baseline is not None:
+            updated.loc[timestamp] = baseline
+    updated = updated.groupby(updated.index).last().sort_index()
+    updated.loc[updated.index >= timestamp] = updated.loc[updated.index >= timestamp] + float(delta)
+    return updated.astype(float)
+
+
+def _add_settlement_delta_to_equity_like_series(
+    series: pd.Series,
+    *,
+    timestamp: pd.Timestamp,
+    settlement_delta: float,
+    post_settlement_delta: float,
+) -> pd.Series:
+    if series.empty:
+        return series
+
+    updated = series.copy()
+    if timestamp not in updated.index:
+        baseline = _series_value_at_or_before(updated, timestamp)
+        if baseline is not None:
+            updated.loc[timestamp] = baseline
+    updated = updated.groupby(updated.index).last().sort_index()
+    updated.loc[updated.index == timestamp] = updated.loc[updated.index == timestamp] + float(
+        settlement_delta
+    )
+    updated.loc[updated.index > timestamp] = updated.loc[updated.index > timestamp] + float(
+        post_settlement_delta
+    )
+    return updated.astype(float)
+
+
+def _settlement_timestamp(
+    result: Mapping[str, Any],
+    *,
+    settlement_observable_ns_key: str,
+    settlement_observable_time_key: str,
+) -> pd.Timestamp | None:
+    series_start, series_end = _series_bounds(
+        result.get("equity_series"),
+        result.get("cash_series"),
+        result.get("pnl_series"),
+        result.get("price_series"),
+    )
+    candidates = (
+        result.get("market_close_time_ns"),
+        result.get(settlement_observable_time_key),
+        result.get(settlement_observable_ns_key),
+        result.get("planned_end"),
+        result.get("simulated_through"),
+        series_end,
+    )
+    fallback: pd.Timestamp | None = None
+    for candidate in candidates:
+        timestamp = _timestamp_utc(candidate)
+        if timestamp is None:
+            continue
+        if fallback is None:
+            fallback = timestamp
+        if series_start is not None and timestamp < series_start:
+            continue
+        return timestamp
+    return series_end or fallback
+
+
+def _apply_settlement_to_summary_series(
+    result: dict[str, Any],
+    *,
+    settlement_pnl: float,
+    settlement_observable_ns_key: str,
+    settlement_observable_time_key: str,
+) -> None:
+    timestamp = _settlement_timestamp(
+        result,
+        settlement_observable_ns_key=settlement_observable_ns_key,
+        settlement_observable_time_key=settlement_observable_time_key,
+    )
+    if timestamp is None:
+        return
+
+    equity_series = _pairs_to_series(result.get("equity_series"))
+    cash_series = _pairs_to_series(result.get("cash_series"))
+    pnl_series = _pairs_to_series(result.get("pnl_series"))
+    initial_equity = (
+        float(equity_series.iloc[0])
+        if not equity_series.empty
+        else float(cash_series.iloc[0])
+        if not cash_series.empty
+        else None
+    )
+
+    result["settlement_series_time"] = timestamp.isoformat()
+    mark_to_market_pnl = _binary_mark_to_market_pnl_at_settlement(
+        fill_events=result.get("fill_events"),
+        price_series=result.get("price_series"),
+        timestamp=timestamp,
+    )
+    if mark_to_market_pnl is not None:
+        current_mtm_pnl, current_cash_pnl = mark_to_market_pnl
+        result["settlement_equity_adjustment"] = float(settlement_pnl - current_mtm_pnl)
+        result["settlement_cash_adjustment"] = float(settlement_pnl - current_cash_pnl)
+
+    if initial_equity is None:
+        if not pnl_series.empty:
+            current_pnl = _series_value_at_or_before(pnl_series, timestamp)
+            if current_pnl is not None and "settlement_equity_adjustment" not in result:
+                result["settlement_equity_adjustment"] = float(settlement_pnl - current_pnl)
+            result["pnl_series"] = _series_to_pairs(
+                _set_series_value_at_and_after(
+                    pnl_series, timestamp=timestamp, value=settlement_pnl
+                )
+            )
+        return
+
+    final_equity = float(initial_equity + settlement_pnl)
+
+    if not equity_series.empty:
+        current_equity = _series_value_at_or_before(equity_series, timestamp)
+        if current_equity is not None and "settlement_equity_adjustment" not in result:
+            result["settlement_equity_adjustment"] = float(final_equity - current_equity)
+        result["equity_series"] = _series_to_pairs(
+            _set_series_value_at_and_after(equity_series, timestamp=timestamp, value=final_equity)
+        )
+    elif not pnl_series.empty:
+        current_pnl = _series_value_at_or_before(pnl_series, timestamp)
+        if current_pnl is not None and "settlement_equity_adjustment" not in result:
+            result["settlement_equity_adjustment"] = float(settlement_pnl - current_pnl)
+
+    if not cash_series.empty:
+        current_cash = _series_value_at_or_before(cash_series, timestamp)
+        if current_cash is not None and "settlement_cash_adjustment" not in result:
+            result["settlement_cash_adjustment"] = float(final_equity - current_cash)
+        result["cash_series"] = _series_to_pairs(
+            _set_series_value_at_and_after(cash_series, timestamp=timestamp, value=final_equity)
+        )
+
+    if not pnl_series.empty:
+        result["pnl_series"] = _series_to_pairs(
+            _set_series_value_at_and_after(pnl_series, timestamp=timestamp, value=settlement_pnl)
+        )
 
 
 def append_result_warning(result: dict[str, Any], message: str) -> None:
@@ -119,7 +437,84 @@ def apply_binary_settlement_pnl(
     result[market_exit_pnl_key] = float(result.get(pnl_key, 0.0))
     result[pnl_key] = float(settlement_pnl)
     result["settlement_pnl_applied"] = True
+    _apply_settlement_to_summary_series(
+        result,
+        settlement_pnl=float(settlement_pnl),
+        settlement_observable_ns_key=settlement_observable_ns_key,
+        settlement_observable_time_key=settlement_observable_time_key,
+    )
     return result
+
+
+def apply_joint_portfolio_settlement_pnl(results: Results) -> Results:
+    if not results:
+        return results
+
+    joint_result = next(
+        (
+            result
+            for result in results
+            if result.get("joint_portfolio_equity_series")
+            or result.get("joint_portfolio_cash_series")
+            or result.get("joint_portfolio_pnl_series")
+        ),
+        None,
+    )
+    if joint_result is None or bool(joint_result.get("joint_portfolio_settlement_pnl_applied")):
+        return results
+
+    equity_series = _pairs_to_series(joint_result.get("joint_portfolio_equity_series"))
+    cash_series = _pairs_to_series(joint_result.get("joint_portfolio_cash_series"))
+    pnl_series = _pairs_to_series(joint_result.get("joint_portfolio_pnl_series"))
+    applied = False
+
+    for result in results:
+        if not bool(result.get("settlement_pnl_applied")):
+            continue
+        timestamp = _timestamp_utc(result.get("settlement_series_time"))
+        if timestamp is None:
+            continue
+
+        equity_adjustment = _coerce_float(result.get("settlement_equity_adjustment"))
+        if equity_adjustment is not None and abs(equity_adjustment) > 1e-12:
+            cash_adjustment = _coerce_float(result.get("settlement_cash_adjustment"))
+            post_settlement_adjustment = (
+                cash_adjustment if cash_adjustment is not None else equity_adjustment
+            )
+            equity_series = _add_settlement_delta_to_equity_like_series(
+                equity_series,
+                timestamp=timestamp,
+                settlement_delta=equity_adjustment,
+                post_settlement_delta=post_settlement_adjustment,
+            )
+            pnl_series = _add_settlement_delta_to_equity_like_series(
+                pnl_series,
+                timestamp=timestamp,
+                settlement_delta=equity_adjustment,
+                post_settlement_delta=post_settlement_adjustment,
+            )
+            applied = True
+
+        cash_adjustment = _coerce_float(result.get("settlement_cash_adjustment"))
+        if cash_adjustment is not None and abs(cash_adjustment) > 1e-12:
+            cash_series = _add_series_delta_at_and_after(
+                cash_series, timestamp=timestamp, delta=cash_adjustment
+            )
+            applied = True
+
+    if not applied:
+        return results
+
+    if not equity_series.empty:
+        joint_result["joint_portfolio_equity_series"] = _series_to_pairs(equity_series)
+    if not cash_series.empty:
+        joint_result["joint_portfolio_cash_series"] = _series_to_pairs(cash_series)
+    if pnl_series.empty and not equity_series.empty:
+        pnl_series = equity_series - float(equity_series.iloc[0])
+    if not pnl_series.empty:
+        joint_result["joint_portfolio_pnl_series"] = _series_to_pairs(pnl_series)
+    joint_result["joint_portfolio_settlement_pnl_applied"] = True
+    return results
 
 
 @dataclass(frozen=True)
@@ -147,6 +542,7 @@ __all__ = [
     "BinarySettlementPnlPolicy",
     "ResultPolicy",
     "apply_binary_settlement_pnl",
+    "apply_joint_portfolio_settlement_pnl",
     "apply_repo_research_disclosures",
     "append_result_warning",
 ]

--- a/prediction_market_extensions/backtesting/prediction_market/artifacts.py
+++ b/prediction_market_extensions/backtesting/prediction_market/artifacts.py
@@ -112,7 +112,7 @@ class PredictionMarketArtifactBuilder:
     ) -> dict[str, dict[str, Any]]:
         include_portfolio_series = self.return_summary_series
         return {
-            loaded_sim.market_id: self._build_market_artifacts_for_loaded_sim(
+            str(loaded_sim.instrument.id): self._build_market_artifacts_for_loaded_sim(
                 engine=engine,
                 loaded_sim=loaded_sim,
                 fills_report=self._filter_report_rows(

--- a/prediction_market_extensions/backtesting/prediction_market/reporting.py
+++ b/prediction_market_extensions/backtesting/prediction_market/reporting.py
@@ -15,6 +15,9 @@ from prediction_market_extensions.analysis.legacy_backtesting.models import (
 from prediction_market_extensions.backtesting._backtest_runtime import (
     print_backtest_result_warnings,
 )
+from prediction_market_extensions.backtesting._result_policies import (
+    apply_joint_portfolio_settlement_pnl,
+)
 from prediction_market_extensions.backtesting.prediction_market.artifacts import (
     resolve_repo_relative_path,
 )
@@ -42,6 +45,7 @@ def finalize_market_results(
     results: Sequence[dict[str, object]],
     report: MarketReportConfig,
 ) -> None:
+    results = apply_joint_portfolio_settlement_pnl(list(results))
     market_key = _resolve_report_market_key(results=results, configured_key=report.market_key)
     print_backtest_summary(
         results=list(results),

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -25,6 +25,10 @@ from strategies.breakout import (
     BookBreakoutConfig,
     BookBreakoutStrategy,
 )
+from strategies.binary_pair_arbitrage import (
+    BookBinaryPairArbitrageConfig,
+    BookBinaryPairArbitrageStrategy,
+)
 from strategies.deep_value import (
     BookDeepValueHoldConfig,
     BookDeepValueHoldStrategy,
@@ -44,6 +48,8 @@ from strategies.final_period_momentum import (
 from strategies.late_favorite_limit_hold import (
     BookLateFavoriteLimitHoldConfig,
     BookLateFavoriteLimitHoldStrategy,
+    BookLateFavoriteTakerHoldConfig,
+    BookLateFavoriteTakerHoldStrategy,
 )
 from strategies.mean_reversion import (
     BarMeanReversionConfig,
@@ -93,6 +99,8 @@ __all__ = [
     "BarRSIReversionStrategy",
     "BarThresholdMomentumConfig",
     "BarThresholdMomentumStrategy",
+    "BookBinaryPairArbitrageConfig",
+    "BookBinaryPairArbitrageStrategy",
     "BookBreakoutConfig",
     "BookBreakoutStrategy",
     "BookDeepValueHoldConfig",
@@ -103,6 +111,8 @@ __all__ = [
     "BookFinalPeriodMomentumStrategy",
     "BookLateFavoriteLimitHoldConfig",
     "BookLateFavoriteLimitHoldStrategy",
+    "BookLateFavoriteTakerHoldConfig",
+    "BookLateFavoriteTakerHoldStrategy",
     "BookMeanReversionConfig",
     "BookMeanReversionStrategy",
     "BookMicropriceImbalanceConfig",

--- a/strategies/binary_pair_arbitrage.py
+++ b/strategies/binary_pair_arbitrage.py
@@ -1,0 +1,416 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+# https://nautechsystems.io
+#
+# Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------------------------------
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Added in this repository on 2026-04-27.
+# See the repository NOTICE file for provenance and licensing scope.
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+from nautilus_trader.model.book import OrderBook
+from nautilus_trader.model.enums import BookType, OrderSide, TimeInForce
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.trading.strategy import Strategy, StrategyConfig
+
+from prediction_market_extensions.adapters.prediction_market.order_tags import (
+    format_order_intent_tag,
+    format_visible_liquidity_tag,
+)
+from strategies._validation import (
+    require_finite_nonnegative_float,
+    require_nonnegative_int,
+    require_positive_decimal,
+    require_probability,
+)
+
+ENTRY_AFFORDABILITY_BUFFER = Decimal("0.97")
+
+
+def _as_float(value: object | None) -> float | None:
+    if value is None:
+        return None
+    if callable(value):
+        value = value()
+    as_double = getattr(value, "as_double", None)
+    if callable(as_double):
+        return float(as_double())
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _decimal_or_none(value: object | None) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _clamp_probability(value: Decimal) -> Decimal:
+    return min(max(value, Decimal("0")), Decimal("1"))
+
+
+def _fee_per_share(*, price: Decimal, taker_fee: Decimal) -> Decimal:
+    price = _clamp_probability(price)
+    fee_rate = max(taker_fee, Decimal("0"))
+    return fee_rate * price * (Decimal("1") - price)
+
+
+class BookBinaryPairArbitrageConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]
+    """
+    Buy both complementary binary outcomes when the combined executable ask
+    is sufficiently below 1.00 after taker fees.
+
+    This is a book-only strategy. It does not use wallets, comments, trader
+    identities, or external forecasts. It assumes the configured instruments
+    are ordered as complementary binary pairs: (YES/UP, NO/DOWN), repeated.
+    The signal includes taker fees by default; turning that off is useful for
+    gross-edge fill diagnostics, while the execution model still charges fees.
+    """
+
+    instrument_ids: tuple[InstrumentId, ...]
+    trade_size: Decimal = Decimal("25")
+    min_net_edge: float = 0.020
+    max_total_cost: float = 0.985
+    max_leg_price: float = 0.985
+    max_spread: float = 0.080
+    max_expected_slippage: float = 0.015
+    min_visible_size: float = 1.0
+    max_entries_per_pair: int = 1
+    reentry_cooldown_updates: int = 25
+    pairing_mode: str = "sequential"
+    hold_to_resolution: bool = True
+    include_taker_fees_in_signal: bool = True
+
+    def __post_init__(self) -> None:
+        require_positive_decimal("trade_size", self.trade_size)
+        require_finite_nonnegative_float("min_net_edge", self.min_net_edge)
+        require_probability("max_total_cost", self.max_total_cost)
+        require_probability("max_leg_price", self.max_leg_price)
+        require_probability("max_spread", self.max_spread)
+        require_finite_nonnegative_float("max_expected_slippage", self.max_expected_slippage)
+        require_finite_nonnegative_float("min_visible_size", self.min_visible_size)
+        require_nonnegative_int("max_entries_per_pair", self.max_entries_per_pair)
+        require_nonnegative_int("reentry_cooldown_updates", self.reentry_cooldown_updates)
+        if self.pairing_mode != "sequential":
+            raise ValueError("pairing_mode currently supports only 'sequential'")
+        if len(self.instrument_ids) < 2 or len(self.instrument_ids) % 2 != 0:
+            raise ValueError(
+                "instrument_ids must contain an even number of instruments ordered as pairs"
+            )
+
+
+class BookBinaryPairArbitrageStrategy(Strategy):
+    """
+    Multi-instrument complementary-token arbitrage.
+
+    For a binary market, one share of each complementary outcome settles to
+    exactly 1.00 USDC in aggregate. The strategy watches both L2 books and
+    submits market IOC buys for both legs when the executable pair cost is
+    below 1.00 by at least `min_net_edge`, after estimated taker fees.
+
+    Live caveat: Polymarket orders are not atomic across the two legs. This
+    strategy sizes against visible liquidity and slippage, but a live bot
+    should add an immediate hedge/flatten path for a one-leg fill.
+    """
+
+    def __init__(self, config: BookBinaryPairArbitrageConfig) -> None:
+        super().__init__(config)
+        self._books: dict[InstrumentId, OrderBook] = {}
+        self._instruments: dict[InstrumentId, object] = {}
+        self._pairs: list[tuple[InstrumentId, InstrumentId]] = []
+        self._pair_by_instrument: dict[InstrumentId, tuple[InstrumentId, InstrumentId]] = {}
+        self._pending_by_pair: dict[tuple[InstrumentId, InstrumentId], int] = {}
+        self._cooldown_by_pair: dict[tuple[InstrumentId, InstrumentId], int] = {}
+        self._entries_by_pair: dict[tuple[InstrumentId, InstrumentId], int] = {}
+
+    def on_start(self) -> None:
+        instrument_ids = tuple(self.config.instrument_ids)
+        self._pairs = [
+            (instrument_ids[i], instrument_ids[i + 1]) for i in range(0, len(instrument_ids), 2)
+        ]
+        self._pair_by_instrument = {
+            instrument_id: pair for pair in self._pairs for instrument_id in pair
+        }
+        self._pending_by_pair = {pair: 0 for pair in self._pairs}
+        self._cooldown_by_pair = {pair: 0 for pair in self._pairs}
+        self._entries_by_pair = {pair: 0 for pair in self._pairs}
+
+        for instrument_id in instrument_ids:
+            instrument = self.cache.instrument(instrument_id)
+            if instrument is None:
+                self.log.error(f"Instrument {instrument_id} not found - stopping.")
+                self.stop()
+                return
+            self._instruments[instrument_id] = instrument
+            self.subscribe_order_book_deltas(
+                instrument_id=instrument_id,
+                book_type=BookType.L2_MBP,
+            )
+
+    def on_order_book_deltas(self, deltas) -> None:  # type: ignore[no-untyped-def]
+        instrument_id = getattr(deltas, "instrument_id", None)
+        if instrument_id not in self._pair_by_instrument:
+            return
+        if instrument_id not in self._books:
+            self._books[instrument_id] = OrderBook(
+                instrument_id,
+                book_type=BookType.L2_MBP,
+            )
+        self._books[instrument_id].apply_deltas(deltas)
+        self._evaluate_pair(self._pair_by_instrument[instrument_id])
+
+    def _best_ask_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None:
+        book = self._books.get(instrument_id)
+        if book is None:
+            return None
+        bid = _as_float(book.best_bid_price())
+        ask = _as_float(book.best_ask_price())
+        ask_size = _as_float(book.best_ask_size())
+        spread = _as_float(book.spread())
+        if bid is None or ask is None or ask_size is None or spread is None:
+            return None
+        if ask <= 0.0 or ask >= 1.0 or ask <= bid or ask_size <= 0.0 or spread <= 0.0:
+            return None
+        return ask, ask_size, spread
+
+    def _instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal:
+        instrument = self._instruments.get(instrument_id)
+        if instrument is None:
+            return Decimal("0")
+        return _decimal_or_none(getattr(instrument, "taker_fee", None)) or Decimal("0")
+
+    def _free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None:
+        instrument = self._instruments.get(instrument_id)
+        if instrument is None:
+            return None
+        account = self.portfolio.account(venue=instrument_id.venue)
+        if account is None:
+            return None
+        free_balance = account.balance_free(instrument.quote_currency)
+        if free_balance is None:
+            return None
+        return _decimal_or_none(free_balance.as_double())
+
+    def _avg_entry_price(self, instrument_id: InstrumentId, size: Decimal) -> float | None:
+        instrument = self._instruments.get(instrument_id)
+        book = self._books.get(instrument_id)
+        if instrument is None or book is None or size <= 0:
+            return None
+        try:
+            quantity = instrument.make_qty(float(size), round_down=True)
+        except ValueError:
+            return None
+        if quantity.as_double() <= 0.0:
+            return None
+        avg_px = _as_float(book.get_avg_px_for_quantity(quantity, OrderSide.BUY))
+        if avg_px is None or avg_px <= 0.0:
+            return None
+        return avg_px
+
+    def _rounded_quantity(self, instrument_id: InstrumentId, size: Decimal):  # type: ignore[no-untyped-def]
+        instrument = self._instruments[instrument_id]
+        try:
+            quantity = instrument.make_qty(float(size), round_down=True)
+        except ValueError:
+            return None
+        if quantity.as_double() <= 0.0:
+            return None
+        min_quantity = getattr(instrument, "min_quantity", None)
+        if min_quantity is not None and quantity.as_double() + 1e-12 < min_quantity.as_double():
+            return None
+        lot_size = getattr(instrument, "lot_size", None)
+        if lot_size is not None and quantity.as_double() + 1e-12 < lot_size.as_double():
+            return None
+        return quantity
+
+    def _pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool:
+        return any(not self.portfolio.is_flat(instrument_id) for instrument_id in pair)
+
+    def _evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None:
+        if self._pending_by_pair.get(pair, 0) > 0:
+            return
+        if self._cooldown_by_pair.get(pair, 0) > 0:
+            self._cooldown_by_pair[pair] -= 1
+            return
+        if self._entries_by_pair.get(pair, 0) >= int(self.config.max_entries_per_pair):
+            return
+        if self._pair_has_position(pair):
+            return
+
+        states = [self._best_ask_state(instrument_id) for instrument_id in pair]
+        if any(state is None for state in states):
+            return
+        assert states[0] is not None
+        assert states[1] is not None
+
+        asks = [Decimal(str(states[i][0])) for i in range(2)]
+        ask_sizes = [Decimal(str(states[i][1])) for i in range(2)]
+        spreads = [float(states[i][2]) for i in range(2)]
+
+        if any(float(ask) > float(self.config.max_leg_price) for ask in asks):
+            return
+        if any(spread > float(self.config.max_spread) for spread in spreads):
+            return
+        if any(size < Decimal(str(self.config.min_visible_size)) for size in ask_sizes):
+            return
+
+        desired_size = min(Decimal(str(self.config.trade_size)), ask_sizes[0], ask_sizes[1])
+        if desired_size <= 0:
+            return
+
+        avg_prices = [self._avg_entry_price(pair[i], desired_size) for i in range(2)]
+        if avg_prices[0] is None or avg_prices[1] is None:
+            return
+        avg_price_decimals = [Decimal(str(avg_prices[i])) for i in range(2)]
+
+        expected_slippages = [float(avg_price_decimals[i] - asks[i]) for i in range(2)]
+        if any(
+            slippage > float(self.config.max_expected_slippage) for slippage in expected_slippages
+        ):
+            return
+
+        fee_rates = (
+            [self._instrument_fee_rate(pair[i]) for i in range(2)]
+            if self.config.include_taker_fees_in_signal
+            else [Decimal("0"), Decimal("0")]
+        )
+        fees = [
+            _fee_per_share(price=avg_price_decimals[i], taker_fee=fee_rates[i]) for i in range(2)
+        ]
+        net_unit_cost = avg_price_decimals[0] + avg_price_decimals[1] + fees[0] + fees[1]
+        edge = Decimal("1") - net_unit_cost
+
+        if edge < Decimal(str(self.config.min_net_edge)):
+            return
+        if net_unit_cost > Decimal(str(self.config.max_total_cost)):
+            return
+
+        free_balance = self._free_quote_balance(pair[0])
+        if free_balance is not None:
+            affordable_size = (free_balance * ENTRY_AFFORDABILITY_BUFFER) / net_unit_cost
+            desired_size = min(desired_size, affordable_size)
+        if desired_size <= 0:
+            return
+
+        quantities = [self._rounded_quantity(pair[i], desired_size) for i in range(2)]
+        if quantities[0] is None or quantities[1] is None:
+            return
+
+        self._submit_pair_entry(
+            pair=pair,
+            quantities=quantities,
+            visible_size=float(min(ask_sizes[0], ask_sizes[1])),
+            net_unit_cost=float(net_unit_cost),
+            edge=float(edge),
+        )
+
+    def _submit_pair_entry(
+        self,
+        *,
+        pair: tuple[InstrumentId, InstrumentId],
+        quantities: list[object],
+        visible_size: float,
+        net_unit_cost: float,
+        edge: float,
+    ) -> None:
+        self.log.info(
+            "Submitting binary pair arb entry "
+            f"pair={pair}, net_unit_cost={net_unit_cost:.6f}, edge={edge:.6f}, "
+            f"visible_size={visible_size:.6f}"
+        )
+        tags = [format_order_intent_tag("pair_arb_entry")]
+        visible_liquidity_tag = format_visible_liquidity_tag(visible_size)
+        if visible_liquidity_tag is not None:
+            tags.append(visible_liquidity_tag)
+
+        orders = [
+            self.order_factory.market(
+                instrument_id=pair[i],
+                order_side=OrderSide.BUY,
+                quantity=quantities[i],
+                time_in_force=TimeInForce.IOC,
+                tags=tags,
+            )
+            for i in range(2)
+        ]
+        self._pending_by_pair[pair] = len(orders)
+        self._entries_by_pair[pair] = self._entries_by_pair.get(pair, 0) + 1
+        self._cooldown_by_pair[pair] = int(self.config.reentry_cooldown_updates)
+        try:
+            for order in orders:
+                self.submit_order(order)
+        except Exception:
+            self._pending_by_pair[pair] = 0
+            raise
+
+    def _event_order_is_closed(self, event) -> bool:  # type: ignore[no-untyped-def]
+        client_order_id = getattr(event, "client_order_id", None)
+        if client_order_id is None:
+            return True
+        try:
+            order = self.cache.order(client_order_id)
+        except (AttributeError, KeyError, TypeError):
+            return True
+        if order is None:
+            return True
+        is_closed = getattr(order, "is_closed", True)
+        if callable(is_closed):
+            return bool(is_closed())
+        return bool(is_closed)
+
+    def _mark_order_event(self, event) -> None:  # type: ignore[no-untyped-def]
+        instrument_id = getattr(event, "instrument_id", None)
+        pair = self._pair_by_instrument.get(instrument_id)
+        if pair is None:
+            return
+        if self._event_order_is_closed(event):
+            self._pending_by_pair[pair] = max(0, self._pending_by_pair.get(pair, 0) - 1)
+
+    def on_order_filled(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._mark_order_event(event)
+
+    def on_order_rejected(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._mark_order_event(event)
+
+    def on_order_denied(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._mark_order_event(event)
+
+    def on_order_canceled(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._mark_order_event(event)
+
+    def on_order_expired(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._mark_order_event(event)
+
+    def on_stop(self) -> None:
+        for instrument_id in self.config.instrument_ids:
+            self.cancel_all_orders(instrument_id)
+        if not self.config.hold_to_resolution:
+            self.log.warning(
+                "hold_to_resolution=False is not implemented for pair arbitrage; "
+                "positions are left for the runner/settlement model."
+            )
+
+    def on_reset(self) -> None:
+        self._books.clear()
+        self._instruments.clear()
+        self._pairs.clear()
+        self._pair_by_instrument.clear()
+        self._pending_by_pair.clear()
+        self._cooldown_by_pair.clear()
+        self._entries_by_pair.clear()

--- a/strategies/late_favorite_limit_hold.py
+++ b/strategies/late_favorite_limit_hold.py
@@ -11,6 +11,11 @@ from nautilus_trader.model.enums import BookType, OrderSide, TimeInForce
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.strategy import StrategyConfig
 
+from strategies._validation import (
+    require_finite_nonnegative_float,
+    require_positive_decimal,
+    require_probability,
+)
 from strategies.core import LongOnlyPredictionMarketStrategy
 
 
@@ -151,3 +156,148 @@ class BookLateFavoriteLimitHoldStrategy(_LateFavoriteLimitHoldBase):
             ts_event_ns=int(order_book.ts_event),
             visible_size=float(ask_size) if ask_size is not None else None,
         )
+
+
+class BookLateFavoriteTakerHoldConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]
+    instrument_id: InstrumentId
+    trade_size: Decimal = Decimal(5)
+    activation_start_time_ns: int = 0
+    market_close_time_ns: int = 0
+    min_midpoint: float = 0.90
+    min_bid_price: float = 0.88
+    max_entry_price: float = 0.99
+    max_spread: float = 0.04
+    min_visible_size: float = 5.0
+    enable_cheap_no_entry: bool = False
+    max_cheap_no_entry_price: float = 0.05
+    max_cheap_no_midpoint: float = 0.10
+    max_cheap_no_spread: float = 0.05
+
+    def __post_init__(self) -> None:
+        require_positive_decimal("trade_size", self.trade_size)
+        require_probability("min_midpoint", self.min_midpoint)
+        require_probability("min_bid_price", self.min_bid_price)
+        require_probability("max_entry_price", self.max_entry_price)
+        require_probability("max_spread", self.max_spread)
+        require_probability("max_cheap_no_entry_price", self.max_cheap_no_entry_price)
+        require_probability("max_cheap_no_midpoint", self.max_cheap_no_midpoint)
+        require_probability("max_cheap_no_spread", self.max_cheap_no_spread)
+        require_finite_nonnegative_float("min_visible_size", self.min_visible_size)
+        if int(self.activation_start_time_ns) < 0:
+            raise ValueError(
+                f"activation_start_time_ns must be >= 0, got {self.activation_start_time_ns}"
+            )
+        if int(self.market_close_time_ns) < 0:
+            raise ValueError(f"market_close_time_ns must be >= 0, got {self.market_close_time_ns}")
+        if (
+            int(self.activation_start_time_ns) > 0
+            and int(self.market_close_time_ns) > 0
+            and int(self.activation_start_time_ns) > int(self.market_close_time_ns)
+        ):
+            raise ValueError(
+                "activation_start_time_ns must be <= market_close_time_ns when both are set"
+            )
+
+
+class BookLateFavoriteTakerHoldStrategy(LongOnlyPredictionMarketStrategy):
+    """
+    Buy a late-window favorite, optionally also taking cheap complementary tails.
+
+    This is intentionally more conservative than ``BookLateFavoriteLimitHoldStrategy``:
+    it requires the late book to show a high midpoint, high bid support, a bounded
+    executable ask, enough visible ask size, and a bounded spread before submitting
+    a marketable IOC favorite entry. If enabled, the cheap complementary path uses
+    separate low-price and spread thresholds. Positions are left open for the binary
+    settlement PnL policy instead of being force-exited at strategy stop.
+    """
+
+    def __init__(self, config: BookLateFavoriteTakerHoldConfig) -> None:
+        super().__init__(config)
+        self._entered_once = False
+
+    def _subscribe(self) -> None:
+        self.subscribe_order_book_deltas(
+            instrument_id=self.config.instrument_id,
+            book_type=BookType.L2_MBP,
+        )
+
+    def on_order_book(self, order_book) -> None:  # type: ignore[no-untyped-def]
+        bid = order_book.best_bid_price()
+        ask = order_book.best_ask_price()
+        if bid is None or ask is None:
+            return
+        bid_float = float(bid)
+        ask_float = float(ask)
+        ask_size = order_book.best_ask_size()
+        spread = ask_float - bid_float
+        self._on_book_signal(
+            bid=bid_float,
+            ask=ask_float,
+            midpoint=(bid_float + ask_float) / 2.0,
+            spread=spread,
+            ask_size=float(ask_size) if ask_size is not None else None,
+            ts_event_ns=int(order_book.ts_event),
+        )
+
+    def _entry_window_is_open(self, ts_event_ns: int) -> bool:
+        activation_start_ns = int(self.config.activation_start_time_ns)
+        if activation_start_ns > 0 and ts_event_ns < activation_start_ns:
+            return False
+
+        market_close_ns = int(self.config.market_close_time_ns)
+        if market_close_ns > 0 and ts_event_ns > market_close_ns:
+            return False
+
+        return True
+
+    def _on_book_signal(
+        self,
+        *,
+        bid: float,
+        ask: float,
+        midpoint: float,
+        spread: float,
+        ask_size: float | None,
+        ts_event_ns: int,
+    ) -> None:
+        self._remember_market_context(
+            entry_reference_price=ask,
+            entry_visible_size=ask_size,
+            exit_visible_size=None,
+        )
+        if self._pending or self._in_position() or self._entered_once:
+            return
+        if not self._entry_window_is_open(ts_event_ns):
+            return
+        if ask <= bid or spread <= 0.0:
+            return
+        favorite_signal = (
+            midpoint >= float(self.config.min_midpoint)
+            and bid >= float(self.config.min_bid_price)
+            and ask <= float(self.config.max_entry_price)
+            and spread <= float(self.config.max_spread)
+        )
+        cheap_no_signal = (
+            bool(self.config.enable_cheap_no_entry)
+            and midpoint <= float(self.config.max_cheap_no_midpoint)
+            and ask <= float(self.config.max_cheap_no_entry_price)
+            and spread <= float(self.config.max_cheap_no_spread)
+        )
+        if not favorite_signal and not cheap_no_signal:
+            return
+        if ask_size is None or ask_size < float(self.config.min_visible_size):
+            return
+
+        self._submit_entry(reference_price=ask, visible_size=ask_size)
+
+    def on_order_filled(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().on_order_filled(event)
+        if event.order_side == OrderSide.BUY:
+            self._entered_once = True
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+
+    def on_reset(self) -> None:
+        super().on_reset()
+        self._entered_once = False

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import runpy
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,8 @@ EXPECTED_PUBLIC_RUNNER_PATHS = [
     Path("backtests/polymarket_book_ema_crossover.py"),
     Path("backtests/polymarket_book_ema_optimizer.py"),
     Path("backtests/polymarket_book_joint_portfolio_runner.py"),
+    Path("backtests/polymarket_btc_5m_late_favorite_taker_hold.py"),
+    Path("backtests/polymarket_btc_5m_pair_arbitrage.py"),
     Path("backtests/polymarket_telonex_book_joint_portfolio_runner.py"),
     Path("backtests/telonex_book_joint_portfolio_runner.ipynb"),
 ]
@@ -260,6 +263,95 @@ def test_pmxt_book_joint_runners_build_inline_summary_contract(
     assert experiment.strategy_configs[0]["config"]["max_entry_price"] == 0.20
     assert "yes_price" in experiment.report.summary_plot_panels
     assert "allocation" in experiment.report.summary_plot_panels
+    assert experiment.return_summary_series is True
+
+
+def test_btc_5m_pair_arbitrage_runner_builds_pmxt_book_pairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experiment = _capture_script_experiment(
+        monkeypatch, Path("backtests/polymarket_btc_5m_pair_arbitrage.py")
+    )
+
+    assert experiment.name == "polymarket_btc_5m_pair_arbitrage"
+    assert experiment.data.platform == "polymarket"
+    assert experiment.data.data_type == "book"
+    assert experiment.data.vendor == "pmxt"
+    assert experiment.data.sources == (
+        "local:/Volumes/LaCie/pmxt_data",
+        "archive:r2v2.pmxt.dev",
+        "archive:r2.pmxt.dev",
+    )
+    assert len(experiment.replays) == 8
+    assert experiment.replays[0].market_slug == "btc-updown-5m-1777226400"
+    assert experiment.replays[0].token_index == 0
+    assert experiment.replays[1].market_slug == "btc-updown-5m-1777226400"
+    assert experiment.replays[1].token_index == 1
+    assert experiment.replays[-1].market_slug == "btc-updown-5m-1777227300"
+    assert experiment.replays[-1].token_index == 1
+    assert all(replay.market_slug.startswith("btc-updown-5m-") for replay in experiment.replays)
+    assert experiment.strategy_configs[0]["config"]["trade_size"] == Decimal("5")
+    assert experiment.strategy_configs[0]["config"]["min_net_edge"] == 0.0
+    assert experiment.strategy_configs[0]["config"]["max_total_cost"] == 1.0
+    assert experiment.strategy_configs[0]["config"]["include_taker_fees_in_signal"] is False
+    assert experiment.report.market_key == "sim_label"
+    assert experiment.report.summary_report is True
+    assert (
+        experiment.report.summary_report_path
+        == "output/polymarket_btc_5m_pair_arbitrage_summary.html"
+    )
+    assert experiment.return_summary_series is True
+
+
+def test_btc_5m_late_favorite_taker_runner_builds_pmxt_book_replays(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experiment = _capture_script_experiment(
+        monkeypatch, Path("backtests/polymarket_btc_5m_late_favorite_taker_hold.py")
+    )
+
+    assert experiment.name == "polymarket_btc_5m_late_favorite_taker_hold"
+    assert experiment.data.platform == "polymarket"
+    assert experiment.data.data_type == "book"
+    assert experiment.data.vendor == "pmxt"
+    assert experiment.data.sources == (
+        "local:/Volumes/LaCie/pmxt_data",
+        "archive:r2v2.pmxt.dev",
+        "archive:r2.pmxt.dev",
+    )
+    assert len(experiment.replays) == 48
+    assert experiment.replays[0].market_slug == "btc-updown-5m-1777226400"
+    assert experiment.replays[0].token_index == 0
+    assert experiment.replays[0].metadata["activation_start_time_ns"] == 1777226640000000000
+    assert experiment.replays[0].metadata["market_close_time_ns"] == 1777226700000000000
+    assert experiment.replays[-1].market_slug == "btc-updown-5m-1777233300"
+    assert experiment.replays[-1].token_index == 1
+    assert experiment.strategy_configs[0]["strategy_path"] == (
+        "strategies:BookLateFavoriteTakerHoldStrategy"
+    )
+    assert experiment.strategy_configs[0]["config_path"] == (
+        "strategies:BookLateFavoriteTakerHoldConfig"
+    )
+    assert experiment.strategy_configs[0]["config"]["trade_size"] == Decimal("5")
+    assert experiment.strategy_configs[0]["config"]["min_midpoint"] == 0.90
+    assert experiment.strategy_configs[0]["config"]["min_bid_price"] == 0.88
+    assert experiment.strategy_configs[0]["config"]["max_entry_price"] == 0.95
+    assert experiment.strategy_configs[0]["config"]["max_spread"] == 0.04
+    assert experiment.strategy_configs[0]["config"]["min_visible_size"] == 5.0
+    assert experiment.strategy_configs[0]["config"]["enable_cheap_no_entry"] is True
+    assert experiment.strategy_configs[0]["config"]["max_cheap_no_entry_price"] == 0.05
+    assert experiment.strategy_configs[0]["config"]["max_cheap_no_midpoint"] == 0.10
+    assert experiment.strategy_configs[0]["config"]["max_cheap_no_spread"] == 0.05
+    assert (
+        experiment.strategy_configs[0]["config"]["activation_start_time_ns"]
+        == "__SIM_METADATA__:activation_start_time_ns"
+    )
+    assert experiment.report.market_key == "sim_label"
+    assert experiment.report.summary_report is True
+    assert (
+        experiment.report.summary_report_path
+        == "output/polymarket_btc_5m_late_favorite_taker_hold_summary.html"
+    )
     assert experiment.return_summary_series is True
 
 

--- a/tests/test_binary_pair_arbitrage.py
+++ b/tests/test_binary_pair_arbitrage.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
+
+from strategies.binary_pair_arbitrage import (
+    BookBinaryPairArbitrageConfig,
+    BookBinaryPairArbitrageStrategy,
+)
+
+LEG_ONE = InstrumentId(Symbol("PM-PAIR-YES"), Venue("POLYMARKET"))
+LEG_TWO = InstrumentId(Symbol("PM-PAIR-NO"), Venue("POLYMARKET"))
+PAIR = (LEG_ONE, LEG_TWO)
+
+
+class _PairArbHarness(BookBinaryPairArbitrageStrategy):
+    def __init__(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(
+            BookBinaryPairArbitrageConfig(
+                instrument_ids=PAIR,
+                trade_size=Decimal("5"),
+                min_net_edge=0.02,
+                max_total_cost=0.99,
+                max_leg_price=0.99,
+                max_spread=0.05,
+                max_expected_slippage=0.02,
+                min_visible_size=1.0,
+                **kwargs,
+            )
+        )
+        self.states = {
+            LEG_ONE: (0.45, 10.0, 0.01),
+            LEG_TWO: (0.52, 10.0, 0.01),
+        }
+        self.avg_prices = {LEG_ONE: 0.45, LEG_TWO: 0.52}
+        self.fee_rates = {LEG_ONE: Decimal("0"), LEG_TWO: Decimal("0")}
+        self.submissions: list[dict[str, object]] = []
+
+    def _best_ask_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None:
+        return self.states.get(instrument_id)
+
+    def _avg_entry_price(self, instrument_id: InstrumentId, size: Decimal) -> float | None:
+        _ = size
+        return self.avg_prices.get(instrument_id)
+
+    def _instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal:
+        return self.fee_rates[instrument_id]
+
+    def _free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None:
+        _ = instrument_id
+        return None
+
+    def _rounded_quantity(self, instrument_id: InstrumentId, size: Decimal):  # type: ignore[no-untyped-def]
+        _ = instrument_id
+        return SimpleNamespace(as_double=lambda: float(size))
+
+    def _pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool:
+        _ = pair
+        return False
+
+    def _submit_pair_entry(
+        self,
+        *,
+        pair: tuple[InstrumentId, InstrumentId],
+        quantities: list[object],
+        visible_size: float,
+        net_unit_cost: float,
+        edge: float,
+    ) -> None:
+        self.submissions.append(
+            {
+                "pair": pair,
+                "quantities": quantities,
+                "visible_size": visible_size,
+                "net_unit_cost": net_unit_cost,
+                "edge": edge,
+            }
+        )
+
+
+def test_pair_arbitrage_enters_when_combined_cost_is_below_settlement_value() -> None:
+    strategy = _PairArbHarness()
+
+    strategy._evaluate_pair(PAIR)
+
+    assert len(strategy.submissions) == 1
+    assert strategy.submissions[0]["pair"] == PAIR
+    assert strategy.submissions[0]["visible_size"] == pytest.approx(10.0)
+    assert strategy.submissions[0]["net_unit_cost"] == pytest.approx(0.97)
+    assert strategy.submissions[0]["edge"] == pytest.approx(0.03)
+
+
+def test_pair_arbitrage_rejects_entries_without_required_edge() -> None:
+    strategy = _PairArbHarness()
+    strategy.avg_prices[LEG_TWO] = 0.985
+
+    strategy._evaluate_pair(PAIR)
+
+    assert strategy.submissions == []

--- a/tests/test_joint_portfolio_artifacts.py
+++ b/tests/test_joint_portfolio_artifacts.py
@@ -85,6 +85,58 @@ def test_joint_portfolio_dense_prices_are_keyed_by_instrument_id(monkeypatch) ->
     ]
 
 
+def test_market_artifacts_are_keyed_by_instrument_id_for_shared_slug(monkeypatch) -> None:
+    def _fake_build_market_artifacts_for_loaded_sim(
+        self, *, engine, loaded_sim, fills_report, include_portfolio_series
+    ):
+        return {
+            "instrument_id": str(loaded_sim.instrument.id),
+            "fill_count": len(fills_report),
+        }
+
+    monkeypatch.setattr(
+        PredictionMarketArtifactBuilder,
+        "_build_market_artifacts_for_loaded_sim",
+        _fake_build_market_artifacts_for_loaded_sim,
+    )
+    builder = PredictionMarketArtifactBuilder(
+        name="shared-slug-demo",
+        platform="polymarket",
+        data_type="book",
+        initial_cash=100.0,
+        probability_window=5,
+        chart_resample_rule=None,
+        return_summary_series=True,
+        sim_count=2,
+    )
+
+    result = builder.build_market_artifacts(
+        engine=SimpleNamespace(),
+        loaded_sims=(
+            _loaded_replay(market_id="shared-slug", instrument_id="PM-SHARED-UP.POLYMARKET"),
+            _loaded_replay(market_id="shared-slug", instrument_id="PM-SHARED-DOWN.POLYMARKET"),
+        ),
+        fills_report=pd.DataFrame(
+            {
+                "instrument_id": [
+                    "PM-SHARED-UP.POLYMARKET",
+                    "PM-SHARED-DOWN.POLYMARKET",
+                ]
+            }
+        ),
+    )
+
+    assert set(result) == {"PM-SHARED-UP.POLYMARKET", "PM-SHARED-DOWN.POLYMARKET"}
+    assert result["PM-SHARED-UP.POLYMARKET"] == {
+        "instrument_id": "PM-SHARED-UP.POLYMARKET",
+        "fill_count": 1,
+    }
+    assert result["PM-SHARED-DOWN.POLYMARKET"] == {
+        "instrument_id": "PM-SHARED-DOWN.POLYMARKET",
+        "fill_count": 1,
+    }
+
+
 def test_single_summary_dense_prices_are_keyed_by_instrument_id(monkeypatch) -> None:
     start = datetime(2026, 3, 14, 17, 57, tzinfo=UTC)
     price_points = [(start, 0.40), (start + timedelta(minutes=1), 0.50)]

--- a/tests/test_legacy_plot_fill_markers.py
+++ b/tests/test_legacy_plot_fill_markers.py
@@ -158,6 +158,47 @@ def test_build_portfolio_snapshots_truncates_nanoseconds_without_warning() -> No
     assert not any("Discarding nonzero nanoseconds" in str(warning.message) for warning in caught)
 
 
+def test_dense_portfolio_snapshots_apply_fill_cash_and_position_atomically() -> None:
+    start = datetime(2026, 4, 26, 18, 4, 42)
+    fill_time = datetime(2026, 4, 26, 18, 4, 42, 993000)
+    cash_report_time = datetime(2026, 4, 26, 18, 4, 43, 43000)
+    models_module = SimpleNamespace(PortfolioSnapshot=lambda **kwargs: SimpleNamespace(**kwargs))
+    sparse_snapshots = [
+        SimpleNamespace(timestamp=start, cash=100.0),
+        SimpleNamespace(timestamp=cash_report_time, cash=95.25),
+    ]
+    fills = [
+        Fill(
+            order_id="fill-1",
+            market_id="late-favorite",
+            action=OrderAction.BUY,
+            side=Side.YES,
+            price=0.95,
+            quantity=5.0,
+            timestamp=fill_time,
+        )
+    ]
+
+    snapshots = adapter._build_dense_portfolio_snapshots(
+        models_module=models_module,
+        sparse_snapshots=sparse_snapshots,
+        fills=fills,
+        market_prices={
+            "late-favorite": [
+                (start, 0.95),
+                (fill_time, 0.95),
+                (cash_report_time, 0.95),
+            ]
+        },
+        initial_cash=100.0,
+    )
+
+    fill_snapshot = next(snapshot for snapshot in snapshots if snapshot.timestamp == fill_time)
+    assert fill_snapshot.cash == pytest.approx(95.25)
+    assert fill_snapshot.total_equity == pytest.approx(100.0)
+    assert max(snapshot.total_equity for snapshot in snapshots) == pytest.approx(100.0)
+
+
 @pytest.mark.parametrize("fill_count", [250, 251, 1_667])
 def test_build_legacy_backtest_layout_never_auto_limits_yes_price_fill_markers(
     monkeypatch: pytest.MonkeyPatch, tmp_path, fill_count: int

--- a/tests/test_limit_hold_regressions.py
+++ b/tests/test_limit_hold_regressions.py
@@ -5,7 +5,12 @@ from types import SimpleNamespace
 
 from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
-from strategies import BookLateFavoriteLimitHoldConfig, BookLateFavoriteLimitHoldStrategy
+from strategies import (
+    BookLateFavoriteLimitHoldConfig,
+    BookLateFavoriteLimitHoldStrategy,
+    BookLateFavoriteTakerHoldConfig,
+    BookLateFavoriteTakerHoldStrategy,
+)
 
 INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
 
@@ -24,3 +29,143 @@ def test_late_favorite_limit_order_acceptance_unblocks_strategy_state() -> None:
 
     assert strategy._pending is False
     assert strategy._entered_once is True
+
+
+class _LateFavoriteTakerHarness(BookLateFavoriteTakerHoldStrategy):
+    def __init__(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(
+            BookLateFavoriteTakerHoldConfig(
+                instrument_id=INSTRUMENT_ID,
+                trade_size=Decimal(5),
+                **kwargs,
+            )
+        )
+        self.entries: list[tuple[float | None, float | None]] = []
+        self.canceled: list[InstrumentId] = []
+        self.exit_submitted = False
+        self.in_position = False
+
+    def _in_position(self) -> bool:
+        return self.in_position
+
+    def _submit_entry(
+        self, *, reference_price: float | None = None, visible_size: float | None = None
+    ) -> None:
+        self.entries.append((reference_price, visible_size))
+
+    def _submit_exit(self) -> None:
+        self.exit_submitted = True
+
+    def cancel_all_orders(self, instrument_id) -> None:  # type: ignore[no-untyped-def]
+        self.canceled.append(instrument_id)
+
+
+def test_late_favorite_taker_enters_only_inside_configured_late_window() -> None:
+    strategy = _LateFavoriteTakerHarness(activation_start_time_ns=100, market_close_time_ns=200)
+
+    strategy._on_book_signal(
+        bid=0.91,
+        ask=0.93,
+        midpoint=0.92,
+        spread=0.02,
+        ask_size=10.0,
+        ts_event_ns=99,
+    )
+    strategy._on_book_signal(
+        bid=0.91,
+        ask=0.93,
+        midpoint=0.92,
+        spread=0.02,
+        ask_size=10.0,
+        ts_event_ns=150,
+    )
+
+    assert strategy.entries == [(0.93, 10.0)]
+
+
+def test_late_favorite_taker_requires_executable_book_quality() -> None:
+    strategy = _LateFavoriteTakerHarness()
+
+    strategy._on_book_signal(
+        bid=0.87,
+        ask=0.93,
+        midpoint=0.90,
+        spread=0.06,
+        ask_size=10.0,
+        ts_event_ns=1,
+    )
+    strategy._on_book_signal(
+        bid=0.91,
+        ask=0.995,
+        midpoint=0.9525,
+        spread=0.085,
+        ask_size=10.0,
+        ts_event_ns=2,
+    )
+    strategy._on_book_signal(
+        bid=0.91,
+        ask=0.93,
+        midpoint=0.92,
+        spread=0.02,
+        ask_size=4.0,
+        ts_event_ns=3,
+    )
+
+    assert strategy.entries == []
+
+
+def test_late_favorite_taker_can_enter_cheap_no_when_enabled() -> None:
+    strategy = _LateFavoriteTakerHarness(enable_cheap_no_entry=True)
+
+    strategy._on_book_signal(
+        bid=0.01,
+        ask=0.05,
+        midpoint=0.03,
+        spread=0.04,
+        ask_size=10.0,
+        ts_event_ns=1,
+    )
+
+    assert strategy.entries == [(0.05, 10.0)]
+
+
+def test_late_favorite_taker_ignores_cheap_no_when_disabled() -> None:
+    strategy = _LateFavoriteTakerHarness()
+
+    strategy._on_book_signal(
+        bid=0.01,
+        ask=0.05,
+        midpoint=0.03,
+        spread=0.04,
+        ask_size=10.0,
+        ts_event_ns=1,
+    )
+
+    assert strategy.entries == []
+
+
+def test_late_favorite_taker_rejects_wide_cheap_no_spread() -> None:
+    strategy = _LateFavoriteTakerHarness(
+        enable_cheap_no_entry=True,
+        max_cheap_no_spread=0.04,
+    )
+
+    strategy._on_book_signal(
+        bid=0.00,
+        ask=0.05,
+        midpoint=0.025,
+        spread=0.05,
+        ask_size=10.0,
+        ts_event_ns=1,
+    )
+
+    assert strategy.entries == []
+
+
+def test_late_favorite_taker_stop_holds_position_for_settlement() -> None:
+    strategy = _LateFavoriteTakerHarness()
+
+    strategy.on_stop()
+
+    assert strategy.canceled == [INSTRUMENT_ID]
+    assert strategy.exit_submitted is False

--- a/tests/test_prediction_market_execution.py
+++ b/tests/test_prediction_market_execution.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 from prediction_market_extensions.backtesting import _prediction_market_backtest as backtest_module
 from prediction_market_extensions.backtesting._backtest_runtime import (
+    add_engine_data_by_type,
     build_backtest_run_state,
     print_backtest_result_warnings,
 )
@@ -47,6 +48,30 @@ class _EngineStub:
 
     def add_venue(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
         self.venues.append(kwargs)
+
+
+def test_add_engine_data_by_type_splits_mixed_replay_records() -> None:
+    class _BookRecord:
+        pass
+
+    class _TradeRecord:
+        pass
+
+    class _DataEngineStub:
+        def __init__(self) -> None:
+            self.added: list[list[object]] = []
+
+        def add_data(self, records):  # type: ignore[no-untyped-def]
+            self.added.append(list(records))
+
+    trade = _TradeRecord()
+    first_book = _BookRecord()
+    second_book = _BookRecord()
+    engine = _DataEngineStub()
+
+    add_engine_data_by_type(engine, [trade, first_book, second_book])
+
+    assert engine.added == [[trade], [first_book, second_book]]
 
 
 def test_prediction_market_backtest_build_engine_forwards_execution(monkeypatch):

--- a/tests/test_result_policies.py
+++ b/tests/test_result_policies.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from prediction_market_extensions.backtesting._result_policies import apply_binary_settlement_pnl
+import pandas as pd
+import pytest
+
+from prediction_market_extensions.backtesting._result_policies import (
+    apply_binary_settlement_pnl,
+    apply_joint_portfolio_settlement_pnl,
+)
 
 
 def test_settlement_pnl_is_not_applied_when_resolution_occurs_after_replay() -> None:
@@ -33,3 +39,264 @@ def test_settlement_pnl_is_not_applied_when_simulated_through_is_missing() -> No
     assert result["pnl"] == 1.25
     assert result["settlement_pnl_applied"] is False
     assert "simulated_through is missing" in result["warnings"][0]
+
+
+def test_settlement_pnl_updates_summary_series_at_resolution_time() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -0.02375,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.02375,
+                }
+            ],
+            "simulated_through": "2026-04-01T00:05:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 999.97625),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -0.02375),
+            ],
+        }
+    )
+
+    assert result["pnl"] == pytest.approx(0.22625)
+    assert result["equity_series"][-1][0] == "2026-04-01T00:05:00+00:00"
+    assert result["equity_series"][-1][1] == pytest.approx(1000.22625)
+    assert result["cash_series"][-1][0] == "2026-04-01T00:05:00+00:00"
+    assert result["cash_series"][-1][1] == pytest.approx(1000.22625)
+    assert result["pnl_series"][-1][0] == "2026-04-01T00:05:00+00:00"
+    assert result["pnl_series"][-1][1] == pytest.approx(0.22625)
+    assert result["settlement_equity_adjustment"] == pytest.approx(0.25)
+    assert result["settlement_cash_adjustment"] == pytest.approx(5.0)
+
+
+def test_settlement_series_prefers_market_close_when_expiration_precedes_replay() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -0.02375,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.02375,
+                }
+            ],
+            "simulated_through": "2026-04-26T18:05:00+00:00",
+            "settlement_observable_time": "2026-04-26T00:00:00+00:00",
+            "market_close_time_ns": pd.Timestamp("2026-04-26T18:05:00+00:00").value,
+            "equity_series": [
+                ("2026-04-26T18:04:30+00:00", 1000.0),
+                ("2026-04-26T18:04:59.996000+00:00", 999.97625),
+            ],
+            "cash_series": [
+                ("2026-04-26T18:04:30+00:00", 1000.0),
+                ("2026-04-26T18:04:59.996000+00:00", 995.22625),
+            ],
+            "pnl_series": [
+                ("2026-04-26T18:04:30+00:00", 0.0),
+                ("2026-04-26T18:04:59.996000+00:00", -0.02375),
+            ],
+        }
+    )
+
+    assert result["settlement_series_time"] == "2026-04-26T18:05:00+00:00"
+    assert result["equity_series"][-2][1] == pytest.approx(999.97625)
+    assert result["equity_series"][-1] == ("2026-04-26T18:05:00+00:00", pytest.approx(1000.22625))
+    assert result["cash_series"][-1] == ("2026-04-26T18:05:00+00:00", pytest.approx(1000.22625))
+    assert result["pnl_series"][-1] == ("2026-04-26T18:05:00+00:00", pytest.approx(0.22625))
+    assert result["settlement_equity_adjustment"] == pytest.approx(0.25)
+    assert result["settlement_cash_adjustment"] == pytest.approx(5.0)
+
+
+def test_joint_portfolio_series_receive_settlement_adjustments() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -0.02375,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.02375,
+                }
+            ],
+            "simulated_through": "2026-04-01T00:05:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 999.97625),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -0.02375),
+            ],
+            "joint_portfolio_equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 999.97625),
+            ],
+            "joint_portfolio_cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+            ],
+            "joint_portfolio_pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -0.02375),
+            ],
+        }
+    )
+
+    results = apply_joint_portfolio_settlement_pnl([result])
+
+    assert results[0]["joint_portfolio_equity_series"][-1][0] == ("2026-04-01T00:05:00+00:00")
+    assert results[0]["joint_portfolio_equity_series"][-1][1] == pytest.approx(1000.22625)
+    assert results[0]["joint_portfolio_cash_series"][-1][0] == ("2026-04-01T00:05:00+00:00")
+    assert results[0]["joint_portfolio_cash_series"][-1][1] == pytest.approx(1000.22625)
+    assert results[0]["joint_portfolio_pnl_series"][-1][0] == "2026-04-01T00:05:00+00:00"
+    assert results[0]["joint_portfolio_pnl_series"][-1][1] == pytest.approx(0.22625)
+
+
+def test_joint_portfolio_equity_carries_cash_payout_after_settlement() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -0.02375,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.02375,
+                }
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 999.97625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -0.02375),
+                ("2026-04-01T00:06:00+00:00", -4.77375),
+            ],
+            "joint_portfolio_equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 999.97625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "joint_portfolio_cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "joint_portfolio_pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -0.02375),
+                ("2026-04-01T00:06:00+00:00", -4.77375),
+            ],
+        }
+    )
+
+    results = apply_joint_portfolio_settlement_pnl([result])
+
+    assert results[0]["joint_portfolio_equity_series"][-2][1] == pytest.approx(1000.22625)
+    assert results[0]["joint_portfolio_equity_series"][-1][1] == pytest.approx(1000.22625)
+    assert results[0]["joint_portfolio_cash_series"][-1][1] == pytest.approx(1000.22625)
+    assert results[0]["joint_portfolio_pnl_series"][-2][1] == pytest.approx(0.22625)
+    assert results[0]["joint_portfolio_pnl_series"][-1][1] == pytest.approx(0.22625)
+
+
+def test_joint_portfolio_settlement_does_not_double_count_stale_position_value() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -4.77375,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.02375,
+                    "timestamp": "2026-04-01T00:04:50+00:00",
+                }
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "market_close_time_ns": pd.Timestamp("2026-04-01T00:05:00+00:00").value,
+            "price_series": [
+                ("2026-04-01T00:04:30+00:00", 0.95),
+                ("2026-04-01T00:05:00+00:00", 0.95),
+            ],
+            "equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -4.77375),
+                ("2026-04-01T00:06:00+00:00", -4.77375),
+            ],
+            "joint_portfolio_equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 999.97625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "joint_portfolio_cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+                ("2026-04-01T00:06:00+00:00", 995.22625),
+            ],
+            "joint_portfolio_pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -0.02375),
+                ("2026-04-01T00:06:00+00:00", -4.77375),
+            ],
+        }
+    )
+
+    assert result["settlement_equity_adjustment"] == pytest.approx(0.25)
+    assert result["settlement_cash_adjustment"] == pytest.approx(5.0)
+
+    results = apply_joint_portfolio_settlement_pnl([result])
+
+    assert results[0]["joint_portfolio_equity_series"][-2][1] == pytest.approx(1000.22625)
+    assert results[0]["joint_portfolio_equity_series"][-1][1] == pytest.approx(1000.22625)
+    assert max(value for _, value in results[0]["joint_portfolio_equity_series"]) == pytest.approx(
+        1000.22625
+    )

--- a/tests/test_strategy_config_validation.py
+++ b/tests/test_strategy_config_validation.py
@@ -10,6 +10,7 @@ from strategies import (
     BookDeepValueHoldConfig,
     BookEMACrossoverConfig,
     BookFinalPeriodMomentumConfig,
+    BookLateFavoriteTakerHoldConfig,
     BookMicropriceImbalanceConfig,
     BookPanicFadeConfig,
     BookRSIReversionConfig,
@@ -56,6 +57,21 @@ BAR_TYPE = "unused-bar-type"
             BookFinalPeriodMomentumConfig,
             {"final_period_minutes": 0},
             "final_period_minutes",
+        ),
+        (
+            BookLateFavoriteTakerHoldConfig,
+            {"max_cheap_no_entry_price": 1.1},
+            "max_cheap_no_entry_price",
+        ),
+        (
+            BookLateFavoriteTakerHoldConfig,
+            {"max_cheap_no_midpoint": 1.1},
+            "max_cheap_no_midpoint",
+        ),
+        (
+            BookLateFavoriteTakerHoldConfig,
+            {"max_cheap_no_spread": 1.1},
+            "max_cheap_no_spread",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- Add BTC 5m late-favorite/cheap-NO taker runner and complementary-token pair-arbitrage runner.
- Fix settlement-adjusted summary and joint portfolio series so resolved positions jump to cash settlement instead of stale mark-to-market values.
- Rebuild dense chart cash/position replay atomically to remove bogus fill-time equity spikes.
- Add strategy, reporting, artifact, and entrypoint regression tests; refresh `CODEBASE_UML.md`.

## Validation
- `uv run python scripts/generate_codebase_uml.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` (`435 passed, 1 skipped`)
- `uv run python backtests/polymarket_btc_5m_pair_arbitrage.py`
- `uv run python backtests/polymarket_btc_5m_late_favorite_taker_hold.py`

Note: the notebook rerun deltas were generated from the old maker-rebates branch and did not apply cleanly to fresh `v3`; I left them out of this scoped PR rather than carrying large stale notebook-output churn.