### PR TITLE
Audit backtest realism edge cases

### DIFF
--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-04-28T03:14:17+00:00
-Modules: 107 | Classes: 159 | Functions/methods: 1358
+Generated: 2026-04-28T03:28:00+00:00
+Modules: 109 | Classes: 161 | Functions/methods: 1373
 
 ## Backtesting Data Flow
 
@@ -30,6 +30,10 @@ flowchart TD
 - Function L8: `ensure_repo_root(script_path: str | Path) -> Path`
 - Function L23: `parse_csv_env(raw: str) -> list[str]`
 - Function L27: `parse_bool_env(raw: str, *, default: bool = True) -> bool`
+
+### `backtests/polymarket_book_buy_sell_random.py`
+- Imports: `__future__, decimal`
+- Function L18: `run() -> None`
 
 ### `backtests/polymarket_book_ema_crossover.py`
 - Imports: `__future__, decimal`
@@ -1613,6 +1617,25 @@ flowchart TD
 - Class L230: `BookBreakoutStrategy(_BreakoutBase)`
   - Method L231: `_subscribe(self) -> None`
   - Method L237: `on_order_book(self, order_book) -> None`
+
+### `strategies/buy_sell_random.py`
+- Imports: `__future__, decimal, nautilus_trader, random, strategies`
+- Function L48: `_as_float(value: object | None) -> float | None`
+- Function L62: `_as_int(value: object | None) -> int | None`
+- Class L28: `BookBuySellRandomConfig(StrategyConfig)`
+  - Method L37: `__post_init__(self) -> None`
+- Class L74: `BookBuySellRandomStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L84: `__init__(self, config: BookBuySellRandomConfig) -> None`
+  - Method L96: `_subscribe(self) -> None`
+  - Method L102: `_random_offset_ns(self) -> int`
+  - Method L105: `_schedule_buy_from(self, window_start_ns: int) -> None`
+  - Method L109: `_schedule_sell_from(self, window_start_ns: int) -> None`
+  - Method L113: `_advance_buy_window_after_attempt(self, current_ts_ns: int) -> None`
+  - Method L122: `_advance_sell_window_after_attempt(self, current_ts_ns: int) -> None`
+  - Method L131: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L155: `_on_book_signal(self, *, bid: float, ask: float, bid_size: float, ask_size: float, current_ts_ns: int) -> None`
+  - Method L203: `on_order_filled(self, event) -> None`
+  - Method L210: `on_reset(self) -> None`
 
 ### `strategies/core.py`
 - Imports: `__future__, decimal, nautilus_trader, prediction_market_extensions, typing`

--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-04-28T02:15:14+00:00
-Modules: 107 | Classes: 159 | Functions/methods: 1354
+Generated: 2026-04-28T03:00:23+00:00
+Modules: 107 | Classes: 159 | Functions/methods: 1358
 
 ## Backtesting Data Flow
 
@@ -61,12 +61,13 @@ flowchart TD
 - Imports: `__future__, decimal, os, typing`
 - Function L51: `_env_int(name: str, default: int) -> int`
 - Function L61: `_env_float(name: str, default: float) -> float`
-- Function L71: `_load_profile_trades() -> Any`
-- Function L88: `_initial_cash_for_profile_trades(groups) -> float`
-- Function L97: `_build_experiment(groups, *, profile_user: str, lead_seconds: float) -> Any`
-- Function L186: `_simulated_net_quantity(fill_events: object) -> float`
-- Function L199: `_print_profile_comparison(results: list[dict[str, Any]], groups) -> None`
-- Function L232: `run() -> None`
+- Function L71: `_env_timestamp(*names: str) -> Any`
+- Function L87: `_load_profile_trades() -> Any`
+- Function L104: `_initial_cash_for_profile_trades(groups) -> float`
+- Function L113: `_build_experiment(groups, *, profile_user: str, lead_seconds: float) -> Any`
+- Function L202: `_simulated_net_quantity(fill_events: object) -> float`
+- Function L215: `_print_profile_comparison(results: list[dict[str, Any]], groups) -> None`
+- Function L248: `run() -> None`
 
 ### `backtests/polymarket_telonex_book_joint_portfolio_runner.py`
 - Imports: `__future__, decimal`
@@ -549,42 +550,43 @@ flowchart TD
 - Function L705: `_first_non_missing_fill_value(source, *keys: str) -> Any`
 - Function L716: `_fill_value_text(value) -> str`
 - Function L722: `_result_has_position_activity(result: Mapping[str, Any]) -> bool`
-- Function L741: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
-- Function L836: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
-- Function L882: `_aggregate_brier_frames(results: Sequence[dict[str, Any]], *, market_key: str | None) -> dict[str, pd.DataFrame]`
-- Function L915: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
-- Function L940: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
-- Function L944: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
-- Function L950: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
-- Function L957: `_yes_price_fill_marker_budget(max_points: int) -> int`
-- Function L963: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
-- Function L974: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
-- Function L1021: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
-- Function L1035: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
-- Function L1056: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], market_key: str | None, resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
-- Function L1102: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
-- Function L1117: `_add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
-- Function L1125: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = False, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L2_MBP, liquidity_consumption: bool = True, queue_position: bool = True, latency_model: Any | None = _DEFAULT_LATENCY_MODEL, nautilus_log_level: str = 'INFO') -> dict[str, Any]`
-- Function L1291: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
-- Function L1345: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1650: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1945: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
-- Function L2007: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
-- Function L2042: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
-- Function L2068: `_summary_total_equity_series(results: Sequence[Mapping[str, Any]]) -> list[tuple[str, float]]`
-- Function L2136: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
-- Function L2154: `_summary_returns_from_pairs(pairs: object, *, initial_capital: float | None = None) -> dict[int, float]`
-- Function L2163: `_summary_returns_from_series(series: pd.Series, *, initial_capital: float | None = None) -> dict[int, float]`
-- Function L2189: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
-- Function L2206: `_summary_total_return_pct(pairs: object, *, initial_capital: float | None = None) -> float | None`
-- Function L2215: `_summary_total_return_pct_from_series(series: pd.Series, *, initial_capital: float | None = None) -> float | None`
-- Function L2234: `_safe_stat(func, returns: dict[int, float]) -> float | None`
-- Function L2242: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
-- Function L2247: `_coerce_float(value: object) -> float | None`
-- Function L2255: `_format_summary_float(value: object, decimals: int) -> str`
-- Function L2262: `_format_summary_pct(value: object) -> str`
-- Function L2269: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
-- Function L2332: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
+- Function L741: `_fill_event_side_hint(*, outcome: object | None = None, token_index: object | None = None) -> str | None`
+- Function L763: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame, default_side: str | None = None) -> list[dict[str, Any]]`
+- Function L868: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
+- Function L917: `_aggregate_brier_frames(results: Sequence[dict[str, Any]], *, market_key: str | None) -> dict[str, pd.DataFrame]`
+- Function L950: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
+- Function L975: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
+- Function L979: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
+- Function L985: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
+- Function L992: `_yes_price_fill_marker_budget(max_points: int) -> int`
+- Function L998: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
+- Function L1009: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
+- Function L1056: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
+- Function L1070: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
+- Function L1091: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], market_key: str | None, resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
+- Function L1137: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
+- Function L1152: `_add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
+- Function L1160: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = False, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L2_MBP, liquidity_consumption: bool = True, queue_position: bool = True, latency_model: Any | None = _DEFAULT_LATENCY_MODEL, nautilus_log_level: str = 'INFO') -> dict[str, Any]`
+- Function L1326: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
+- Function L1380: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1691: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1992: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
+- Function L2054: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
+- Function L2089: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
+- Function L2115: `_summary_total_equity_series(results: Sequence[Mapping[str, Any]]) -> list[tuple[str, float]]`
+- Function L2183: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
+- Function L2201: `_summary_returns_from_pairs(pairs: object, *, initial_capital: float | None = None) -> dict[int, float]`
+- Function L2210: `_summary_returns_from_series(series: pd.Series, *, initial_capital: float | None = None) -> dict[int, float]`
+- Function L2236: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
+- Function L2253: `_summary_total_return_pct(pairs: object, *, initial_capital: float | None = None) -> float | None`
+- Function L2262: `_summary_total_return_pct_from_series(series: pd.Series, *, initial_capital: float | None = None) -> float | None`
+- Function L2281: `_safe_stat(func, returns: dict[int, float]) -> float | None`
+- Function L2289: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
+- Function L2294: `_coerce_float(value: object) -> float | None`
+- Function L2302: `_format_summary_float(value: object, decimals: int) -> str`
+- Function L2309: `_format_summary_pct(value: object) -> str`
+- Function L2316: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
+- Function L2379: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
 
 ### `prediction_market_extensions/analysis/__init__.py`
 - Imports: none
@@ -682,45 +684,45 @@ flowchart TD
 - Function L482: `_build_dense_portfolio_snapshots(models_module, sparse_snapshots: list[Any], fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> list[Any]`
 - Function L555: `_normalize_market_prices(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
 - Function L586: `_market_prices_from_fills(fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
-- Function L595: `_merge_market_price_sources(primary: Mapping[str, Sequence[tuple[Any, float]]] | None, secondary: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
-- Function L619: `_market_prices_with_fill_points(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None, fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
-- Function L630: `_build_metrics(snapshots: list[Any], initial_cash: float) -> dict[str, float]`
-- Function L648: `_platform_enum(models_module, platform: str) -> Any`
-- Function L655: `_mark_panel_figure(fig, panel_id: str) -> Any`
-- Function L663: `_brier_unavailable_reason(*, user_probabilities: pd.Series | None, market_probabilities: pd.Series | None, outcomes: pd.Series | None) -> str | None`
-- Function L682: `_build_brier_placeholder_panel(message: str) -> Any`
-- Function L723: `_style_panel_legend(fig) -> None`
-- Function L735: `_build_brier_timeseries_panel(brier_frame: pd.DataFrame, *, panel_id: str, axis_label: str, legend_label: str, line_color: str = '#2ca0f0') -> Any | None`
-- Function L841: `_build_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
-- Function L850: `_build_total_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
-- Function L860: `_iter_layout_nodes(node) -> Any`
-- Function L872: `_iter_figures(layout) -> Any`
-- Function L878: `_field_name(spec) -> str | None`
-- Function L889: `_filter_tool_container(container, tools_to_remove: set[Any]) -> None`
-- Function L923: `_remove_tools_from_layout(layout, tools_to_remove: set[Any]) -> None`
-- Function L932: `_remove_hover_tools(fig, *, layout: Any | None = None) -> set[Any]`
-- Function L944: `_format_period_label(start, end) -> str`
-- Function L957: `_find_figure_with_yaxis_label(layout, predicate) -> Any | None`
-- Function L965: `_periodic_pnl_panel_source(target) -> tuple[dict[str, Any] | None, float | None]`
-- Function L983: `_build_periodic_pnl_panel_source_data(source_data: dict[str, Any]) -> dict[str, Any] | None`
-- Function L1003: `_resolve_periodic_pnl_bar_width(x_values: np.ndarray, bar_width: float | None) -> float`
-- Function L1011: `_yes_price_line_renderers(target) -> list[Any]`
-- Function L1033: `_remove_data_banner(layout) -> Any`
-- Function L1052: `_legend_item_label_text(item) -> str`
-- Function L1062: `_remove_yes_price_profitability_legend_items(fig) -> set[Any]`
-- Function L1078: `_remove_yes_price_profitability_connectors(layout) -> None`
-- Function L1104: `_limit_yes_price_fill_markers(layout, max_yes_price_fill_markers: int | None) -> None`
-- Function L1147: `_subset_bokeh_source_values(values, indexes: np.ndarray) -> Any`
-- Function L1157: `_limit_market_pnl_fill_markers(layout, max_market_pnl_fill_markers: int | None) -> None`
-- Function L1201: `_standardize_periodic_pnl_panel(layout) -> None`
-- Function L1249: `_relabel_market_pnl_panel(layout, axis_label: str = 'Market P&L') -> None`
-- Function L1276: `_build_multi_market_brier_panel(brier_frames: Mapping[str, pd.DataFrame], *, axis_label: str = 'Cumulative Brier Advantage', color_by_market: Mapping[str, Any] | None = None) -> Any | None`
-- Function L1410: `_standardize_yes_price_hover(layout) -> None`
-- Function L1441: `_focus_allocation_panel(layout) -> None`
-- Function L1480: `_apply_layout_overrides(layout, initial_cash: float, *, relabel_market_pnl: bool = False, max_yes_price_fill_markers: int | None = None, max_market_pnl_fill_markers: int | None = None) -> Any`
-- Function L1501: `_save_layout(layout, output_path: Path, title: str) -> None`
-- Function L1514: `save_legacy_backtest_layout(layout, output_path: str | Path, title: str) -> str`
-- Function L1524: `build_legacy_backtest_layout(engine, output_path: str | Path, strategy_name: str, platform: str, initial_cash: float, market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None = None, user_probabilities: pd.Series | None = None, market_probabilities: pd.Series | None = None, outcomes: pd.Series | None = None, legacy_repo_path: str | Path | None = None, open_browser: bool = False, max_markets: int = 30, progress: bool = False, plot_panels: Sequence[str] | None = None) -> tuple[Any, str]`
+- Function L602: `_merge_market_price_sources(primary: Mapping[str, Sequence[tuple[Any, float]]] | None, secondary: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
+- Function L626: `_market_prices_with_fill_points(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None, fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
+- Function L637: `_build_metrics(snapshots: list[Any], initial_cash: float) -> dict[str, float]`
+- Function L655: `_platform_enum(models_module, platform: str) -> Any`
+- Function L662: `_mark_panel_figure(fig, panel_id: str) -> Any`
+- Function L670: `_brier_unavailable_reason(*, user_probabilities: pd.Series | None, market_probabilities: pd.Series | None, outcomes: pd.Series | None) -> str | None`
+- Function L689: `_build_brier_placeholder_panel(message: str) -> Any`
+- Function L730: `_style_panel_legend(fig) -> None`
+- Function L742: `_build_brier_timeseries_panel(brier_frame: pd.DataFrame, *, panel_id: str, axis_label: str, legend_label: str, line_color: str = '#2ca0f0') -> Any | None`
+- Function L848: `_build_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
+- Function L857: `_build_total_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
+- Function L867: `_iter_layout_nodes(node) -> Any`
+- Function L879: `_iter_figures(layout) -> Any`
+- Function L885: `_field_name(spec) -> str | None`
+- Function L896: `_filter_tool_container(container, tools_to_remove: set[Any]) -> None`
+- Function L930: `_remove_tools_from_layout(layout, tools_to_remove: set[Any]) -> None`
+- Function L939: `_remove_hover_tools(fig, *, layout: Any | None = None) -> set[Any]`
+- Function L951: `_format_period_label(start, end) -> str`
+- Function L964: `_find_figure_with_yaxis_label(layout, predicate) -> Any | None`
+- Function L972: `_periodic_pnl_panel_source(target) -> tuple[dict[str, Any] | None, float | None]`
+- Function L990: `_build_periodic_pnl_panel_source_data(source_data: dict[str, Any]) -> dict[str, Any] | None`
+- Function L1010: `_resolve_periodic_pnl_bar_width(x_values: np.ndarray, bar_width: float | None) -> float`
+- Function L1018: `_yes_price_line_renderers(target) -> list[Any]`
+- Function L1040: `_remove_data_banner(layout) -> Any`
+- Function L1059: `_legend_item_label_text(item) -> str`
+- Function L1069: `_remove_yes_price_profitability_legend_items(fig) -> set[Any]`
+- Function L1085: `_remove_yes_price_profitability_connectors(layout) -> None`
+- Function L1111: `_limit_yes_price_fill_markers(layout, max_yes_price_fill_markers: int | None) -> None`
+- Function L1154: `_subset_bokeh_source_values(values, indexes: np.ndarray) -> Any`
+- Function L1164: `_limit_market_pnl_fill_markers(layout, max_market_pnl_fill_markers: int | None) -> None`
+- Function L1208: `_standardize_periodic_pnl_panel(layout) -> None`
+- Function L1256: `_relabel_market_pnl_panel(layout, axis_label: str = 'Market P&L') -> None`
+- Function L1283: `_build_multi_market_brier_panel(brier_frames: Mapping[str, pd.DataFrame], *, axis_label: str = 'Cumulative Brier Advantage', color_by_market: Mapping[str, Any] | None = None) -> Any | None`
+- Function L1417: `_standardize_yes_price_hover(layout) -> None`
+- Function L1448: `_focus_allocation_panel(layout) -> None`
+- Function L1487: `_apply_layout_overrides(layout, initial_cash: float, *, relabel_market_pnl: bool = False, max_yes_price_fill_markers: int | None = None, max_market_pnl_fill_markers: int | None = None) -> Any`
+- Function L1508: `_save_layout(layout, output_path: Path, title: str) -> None`
+- Function L1521: `save_legacy_backtest_layout(layout, output_path: str | Path, title: str) -> str`
+- Function L1531: `build_legacy_backtest_layout(engine, output_path: str | Path, strategy_name: str, platform: str, initial_cash: float, market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None = None, user_probabilities: pd.Series | None = None, market_probabilities: pd.Series | None = None, outcomes: pd.Series | None = None, legacy_repo_path: str | Path | None = None, open_browser: bool = False, max_markets: int = 30, progress: bool = False, plot_panels: Sequence[str] | None = None) -> tuple[Any, str]`
 
 ### `prediction_market_extensions/analysis/tearsheet.py`
 - Imports: `__future__, collections, difflib, nautilus_trader, numbers, pandas, typing`
@@ -1273,49 +1275,50 @@ flowchart TD
   - Method L925: `_api_url(*, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
   - Method L945: `_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
   - Method L974: `_load_api_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L1003: `_write_api_cache_day(self, *, payload: bytes, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
-  - Method L1040: `_fast_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L1063: `_fast_api_cache_metadata_path(fast_path: Path) -> Path`
-  - Method L1066: `_fast_api_cache_metadata_payload(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
-  - Method L1091: `_fast_api_cache_metadata_matches(self, *, fast_path: Path, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> bool`
-  - Method L1119: `_load_fast_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L1163: `_write_fast_cache_day(self, *, frame: pd.DataFrame, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
-  - Method L1259: `_load_api_day_cached(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L1334: `_deltas_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
-  - Method L1367: `_deltas_cache_metadata_path(cache_path: Path) -> Path`
-  - Method L1371: `_local_file_fingerprint(path: Path) -> dict[str, object] | None`
-  - Method L1384: `_local_blob_source_fingerprint_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
-  - Method L1457: `_telonex_source_fingerprint_for_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
-  - Method L1518: `_deltas_cache_source_fingerprint(self, *, config: TelonexLoaderConfig, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
-  - Method L1540: `_deltas_cache_metadata_payload(self, *, source: Mapping[str, object] | None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, object] | None`
-  - Method L1569: `_deltas_cache_metadata_matches(self, *, cache_path: Path, expected_metadata: Mapping[str, object] | None) -> bool`
-  - Method L1581: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, expected_metadata: Mapping[str, object] | None) -> tuple[list[OrderBookDeltas] | None, str]`
-  - Method L1628: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, metadata: Mapping[str, object] | None) -> None`
-  - Method L1688: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
-  - Method L1723: `_deltas_records_from_columns(self, data: dict[str, list[object]]) -> list[OrderBookDeltas]`
-  - Method L1770: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
-  - Method L1797: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
-  - Method L1889: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
-  - Method L1900: `_scaled_column_to_ns(column: pd.Series, multiplier: int) -> np.ndarray`
-  - Method L1915: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
-  - Method L1920: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
-  - Method L1934: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
-  - Method L1941: `_book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]`
-  - Method L1976: `_book_levels_from_arrays(*, prices: object, sizes: object, side: str) -> tuple[PolymarketBookLevel, ...]`
-  - Method L1993: `_book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]`
-  - Method L1997: `_book_levels_are_crossed(*, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel]) -> bool`
-  - Method L2006: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
-  - Method L2025: `_retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
-  - Method L2040: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
-  - Method L2089: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True, invalid_snapshot_warning: bool = True, invalid_snapshot_counter: Callable[[int], None] | None = None) -> list[OrderBookDeltas]`
-  - Method L2205: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
-  - Method L2253: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
-  - Method L2352: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L2392: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L2434: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L2453: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None], invalid_snapshot_counter: Callable[[int], None] | None = None) -> _TelonexDayResult`
-  - Method L2597: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, invalid_snapshot_counter: Callable[[int], None] | None = None) -> Iterator[_TelonexDayResult]`
-  - Method L2666: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
+  - Method L1003: `_api_cache_source_fingerprint_for_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1039: `_write_api_cache_day(self, *, payload: bytes, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
+  - Method L1076: `_fast_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L1099: `_fast_api_cache_metadata_path(fast_path: Path) -> Path`
+  - Method L1102: `_fast_api_cache_metadata_payload(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1127: `_fast_api_cache_metadata_matches(self, *, fast_path: Path, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> bool`
+  - Method L1155: `_load_fast_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L1199: `_write_fast_cache_day(self, *, frame: pd.DataFrame, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
+  - Method L1295: `_load_api_day_cached(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L1370: `_deltas_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
+  - Method L1403: `_deltas_cache_metadata_path(cache_path: Path) -> Path`
+  - Method L1407: `_local_file_fingerprint(path: Path) -> dict[str, object] | None`
+  - Method L1420: `_local_blob_source_fingerprint_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1493: `_telonex_source_fingerprint_for_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1559: `_deltas_cache_source_fingerprint(self, *, config: TelonexLoaderConfig, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1581: `_deltas_cache_metadata_payload(self, *, source: Mapping[str, object] | None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, object] | None`
+  - Method L1610: `_deltas_cache_metadata_matches(self, *, cache_path: Path, expected_metadata: Mapping[str, object] | None) -> bool`
+  - Method L1622: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, expected_metadata: Mapping[str, object] | None) -> tuple[list[OrderBookDeltas] | None, str]`
+  - Method L1669: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, metadata: Mapping[str, object] | None) -> None`
+  - Method L1729: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
+  - Method L1764: `_deltas_records_from_columns(self, data: dict[str, list[object]]) -> list[OrderBookDeltas]`
+  - Method L1811: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
+  - Method L1838: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
+  - Method L1930: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
+  - Method L1941: `_scaled_column_to_ns(column: pd.Series, multiplier: int) -> np.ndarray`
+  - Method L1956: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
+  - Method L1961: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
+  - Method L1975: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
+  - Method L1982: `_book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]`
+  - Method L2017: `_book_levels_from_arrays(*, prices: object, sizes: object, side: str) -> tuple[PolymarketBookLevel, ...]`
+  - Method L2034: `_book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]`
+  - Method L2038: `_book_levels_are_crossed(*, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel]) -> bool`
+  - Method L2047: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
+  - Method L2066: `_retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
+  - Method L2081: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
+  - Method L2130: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True, invalid_snapshot_warning: bool = True, invalid_snapshot_counter: Callable[[int], None] | None = None) -> list[OrderBookDeltas]`
+  - Method L2246: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
+  - Method L2294: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
+  - Method L2393: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2433: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L2475: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L2494: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None], invalid_snapshot_counter: Callable[[int], None] | None = None) -> _TelonexDayResult`
+  - Method L2638: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, invalid_snapshot_counter: Callable[[int], None] | None = None) -> Iterator[_TelonexDayResult]`
+  - Method L2707: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
 
 ### `prediction_market_extensions/backtesting/data_sources/vendors.py`
 - Imports: `__future__, dataclasses`
@@ -1338,7 +1341,7 @@ flowchart TD
   - Method L126: `build_joint_portfolio_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay]) -> dict[str, Any]`
   - Method L173: `_build_market_artifacts_for_loaded_sim(self, *, engine: BacktestEngine, loaded_sim: LoadedReplay, fills_report: pd.DataFrame, include_portfolio_series: bool) -> dict[str, Any]`
   - Method L216: `_build_market_summary_series(self, *, engine: BacktestEngine, loaded_sim: LoadedReplay, fills_report: pd.DataFrame, market_prices, user_probabilities: pd.Series, market_probabilities: pd.Series, outcomes: pd.Series, include_portfolio_series: bool) -> dict[str, Any]`
-  - Method L293: `_filter_report_rows(report: pd.DataFrame, *, instrument_id: str) -> pd.DataFrame`
+  - Method L300: `_filter_report_rows(report: pd.DataFrame, *, instrument_id: str) -> pd.DataFrame`
 
 ### `prediction_market_extensions/backtesting/prediction_market/reporting.py`
 - Imports: `__future__, collections, dataclasses, prediction_market_extensions, typing`
@@ -1352,16 +1355,17 @@ flowchart TD
 - Function L63: `profile_replay_key(*, slug: str, outcome_index: int) -> str`
 - Function L67: `_decimal_from_payload(value: object, *, field: str) -> Decimal`
 - Function L77: `_timestamp_from_payload(value: object) -> pd.Timestamp`
-- Function L87: `normalize_profile_trade(payload: Mapping[str, object]) -> ProfileTrade`
-- Function L121: `normalize_profile_trades(payloads: Iterable[Mapping[str, object]]) -> tuple[ProfileTrade, ...]`
-- Function L131: `fetch_profile_trades(*, user: str, limit: int = 500, taker_only: bool = False, base_url: str = POLYMARKET_PROFILE_TRADES_URL, timeout_seconds: float = 30.0) -> tuple[ProfileTrade, ...]`
-- Function L157: `_inventory_never_negative(trades: Sequence[ProfileTrade]) -> bool`
-- Function L169: `select_profile_trade_groups(trades: Sequence[ProfileTrade], *, max_groups: int, allowed_slug_prefixes: Sequence[str] = DEFAULT_PROFILE_REPLAY_PREFIXES, require_complete_inventory: bool = True) -> tuple[ProfileTradeGroup, ...]`
-- Function L196: `infer_profile_replay_window(group: ProfileTradeGroup, *, lead_time_seconds: float, start_buffer_seconds: float, end_buffer_seconds: float) -> tuple[pd.Timestamp, pd.Timestamp]`
-- Function L222: `profile_trades_by_key(groups: Sequence[ProfileTradeGroup]) -> dict[str, list[dict[str, object]]]`
-- Function L240: `build_profile_replays(groups: Sequence[ProfileTradeGroup], *, profile_user: str, lead_time_seconds: float, start_buffer_seconds: float = 120.0, end_buffer_seconds: float = 1800.0) -> tuple[BookReplay, ...]`
-- Function L274: `profile_actual_pnl(trades: Sequence[ProfileTrade], *, realized_outcome: float | int | None) -> dict[str, float | None]`
-- Function L312: `append_profile_replay_diagnostics(results: Sequence[Mapping[str, object]], groups: Sequence[ProfileTradeGroup]) -> list[dict[str, object]]`
+- Function L87: `_normalize_timestamp_bound(value: object) -> pd.Timestamp | None`
+- Function L98: `normalize_profile_trade(payload: Mapping[str, object]) -> ProfileTrade`
+- Function L132: `normalize_profile_trades(payloads: Iterable[Mapping[str, object]]) -> tuple[ProfileTrade, ...]`
+- Function L142: `fetch_profile_trades(*, user: str, limit: int = 500, taker_only: bool = False, base_url: str = POLYMARKET_PROFILE_TRADES_URL, timeout_seconds: float = 30.0) -> tuple[ProfileTrade, ...]`
+- Function L168: `_inventory_never_negative(trades: Sequence[ProfileTrade]) -> bool`
+- Function L180: `select_profile_trade_groups(trades: Sequence[ProfileTrade], *, max_groups: int, allowed_slug_prefixes: Sequence[str] = DEFAULT_PROFILE_REPLAY_PREFIXES, require_complete_inventory: bool = True, min_latest_trade_time: object | None = None, max_latest_trade_time: object | None = None) -> tuple[ProfileTradeGroup, ...]`
+- Function L216: `infer_profile_replay_window(group: ProfileTradeGroup, *, lead_time_seconds: float, start_buffer_seconds: float, end_buffer_seconds: float) -> tuple[pd.Timestamp, pd.Timestamp]`
+- Function L242: `profile_trades_by_key(groups: Sequence[ProfileTradeGroup]) -> dict[str, list[dict[str, object]]]`
+- Function L260: `build_profile_replays(groups: Sequence[ProfileTradeGroup], *, profile_user: str, lead_time_seconds: float, start_buffer_seconds: float = 120.0, end_buffer_seconds: float = 1800.0) -> tuple[BookReplay, ...]`
+- Function L294: `profile_actual_pnl(trades: Sequence[ProfileTrade], *, realized_outcome: float | int | None) -> dict[str, float | None]`
+- Function L332: `append_profile_replay_diagnostics(results: Sequence[Mapping[str, object]], groups: Sequence[ProfileTradeGroup]) -> list[dict[str, object]]`
 - Class L24: `ProfileTrade`
   - Method L36: `key(self) -> str`
   - Method L40: `timestamp_ns(self) -> int`

--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,7 +1,7 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-04-28T03:00:23+00:00
+Generated: 2026-04-28T03:14:17+00:00
 Modules: 107 | Classes: 159 | Functions/methods: 1358
 
 ## Backtesting Data Flow
@@ -1289,36 +1289,36 @@ flowchart TD
   - Method L1407: `_local_file_fingerprint(path: Path) -> dict[str, object] | None`
   - Method L1420: `_local_blob_source_fingerprint_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
   - Method L1493: `_telonex_source_fingerprint_for_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
-  - Method L1559: `_deltas_cache_source_fingerprint(self, *, config: TelonexLoaderConfig, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
-  - Method L1581: `_deltas_cache_metadata_payload(self, *, source: Mapping[str, object] | None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, object] | None`
-  - Method L1610: `_deltas_cache_metadata_matches(self, *, cache_path: Path, expected_metadata: Mapping[str, object] | None) -> bool`
-  - Method L1622: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, expected_metadata: Mapping[str, object] | None) -> tuple[list[OrderBookDeltas] | None, str]`
-  - Method L1669: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, metadata: Mapping[str, object] | None) -> None`
-  - Method L1729: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
-  - Method L1764: `_deltas_records_from_columns(self, data: dict[str, list[object]]) -> list[OrderBookDeltas]`
-  - Method L1811: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
-  - Method L1838: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
-  - Method L1930: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
-  - Method L1941: `_scaled_column_to_ns(column: pd.Series, multiplier: int) -> np.ndarray`
-  - Method L1956: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
-  - Method L1961: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
-  - Method L1975: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
-  - Method L1982: `_book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]`
-  - Method L2017: `_book_levels_from_arrays(*, prices: object, sizes: object, side: str) -> tuple[PolymarketBookLevel, ...]`
-  - Method L2034: `_book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]`
-  - Method L2038: `_book_levels_are_crossed(*, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel]) -> bool`
-  - Method L2047: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
-  - Method L2066: `_retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
-  - Method L2081: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
-  - Method L2130: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True, invalid_snapshot_warning: bool = True, invalid_snapshot_counter: Callable[[int], None] | None = None) -> list[OrderBookDeltas]`
-  - Method L2246: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
-  - Method L2294: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
-  - Method L2393: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L2433: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L2475: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L2494: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None], invalid_snapshot_counter: Callable[[int], None] | None = None) -> _TelonexDayResult`
-  - Method L2638: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, invalid_snapshot_counter: Callable[[int], None] | None = None) -> Iterator[_TelonexDayResult]`
-  - Method L2707: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
+  - Method L1551: `_deltas_cache_source_fingerprint(self, *, config: TelonexLoaderConfig, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1573: `_deltas_cache_metadata_payload(self, *, source: Mapping[str, object] | None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, object] | None`
+  - Method L1602: `_deltas_cache_metadata_matches(self, *, cache_path: Path, expected_metadata: Mapping[str, object] | None) -> bool`
+  - Method L1614: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, expected_metadata: Mapping[str, object] | None) -> tuple[list[OrderBookDeltas] | None, str]`
+  - Method L1661: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, metadata: Mapping[str, object] | None) -> None`
+  - Method L1721: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
+  - Method L1756: `_deltas_records_from_columns(self, data: dict[str, list[object]]) -> list[OrderBookDeltas]`
+  - Method L1803: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
+  - Method L1830: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
+  - Method L1922: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
+  - Method L1933: `_scaled_column_to_ns(column: pd.Series, multiplier: int) -> np.ndarray`
+  - Method L1948: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
+  - Method L1953: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
+  - Method L1967: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
+  - Method L1974: `_book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]`
+  - Method L2009: `_book_levels_from_arrays(*, prices: object, sizes: object, side: str) -> tuple[PolymarketBookLevel, ...]`
+  - Method L2026: `_book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]`
+  - Method L2030: `_book_levels_are_crossed(*, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel]) -> bool`
+  - Method L2039: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
+  - Method L2058: `_retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
+  - Method L2073: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
+  - Method L2122: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True, invalid_snapshot_warning: bool = True, invalid_snapshot_counter: Callable[[int], None] | None = None) -> list[OrderBookDeltas]`
+  - Method L2238: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
+  - Method L2286: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
+  - Method L2385: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2425: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L2467: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L2486: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None], invalid_snapshot_counter: Callable[[int], None] | None = None) -> _TelonexDayResult`
+  - Method L2630: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, invalid_snapshot_counter: Callable[[int], None] | None = None) -> Iterator[_TelonexDayResult]`
+  - Method L2699: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
 
 ### `prediction_market_extensions/backtesting/data_sources/vendors.py`
 - Imports: `__future__, dataclasses`

--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-04-27T15:00:39+00:00
-Modules: 103 | Classes: 152 | Functions/methods: 1194
+Generated: 2026-04-27T23:09:41+00:00
+Modules: 104 | Classes: 154 | Functions/methods: 1314
 
 ## Backtesting Data Flow
 
@@ -269,14 +269,15 @@ flowchart TD
 
 ### `prediction_market_extensions/adapters/polymarket/fee_model.py`
 - Imports: `__future__, collections, decimal, nautilus_trader, prediction_market_extensions, typing`
-- Function L62: `_normalize_label(value: object) -> str | None`
-- Function L71: `_iter_tag_labels(tags: object) -> Iterable[str]`
-- Function L93: `_market_labels(info: Mapping[str, Any] | None) -> set[str]`
-- Function L121: `infer_maker_rebate_rate(*, market_info: Mapping[str, Any] | None, fee_rate_bps: Decimal) -> Decimal`
-- Function L151: `calculate_maker_rebate(*, quantity: Decimal, price: Decimal, fee_rate_bps: Decimal, maker_rebate_rate: Decimal) -> float`
-- Class L176: `PolymarketFeeModel(FeeModel)`
-  - Method L200: `__init__(self, *, maker_rebates_enabled: bool = True) -> None`
-  - Method L203: `get_commission(self, order, fill_qty, fill_px, instrument) -> Money`
+- Function L63: `_normalize_label(value: object) -> str | None`
+- Function L72: `_iter_tag_labels(tags: object) -> Iterable[str]`
+- Function L94: `_market_labels(info: Mapping[str, Any] | None) -> set[str]`
+- Function L122: `infer_maker_rebate_rate(*, market_info: Mapping[str, Any] | None, fee_rate_bps: Decimal) -> Decimal`
+- Function L152: `calculate_maker_rebate(*, quantity: Decimal, price: Decimal, fee_rate_bps: Decimal, maker_rebate_rate: Decimal) -> float`
+- Function L177: `_order_liquidity_side(order: object) -> LiquiditySide | None`
+- Class L200: `PolymarketFeeModel(FeeModel)`
+  - Method L224: `__init__(self, *, maker_rebates_enabled: bool = True) -> None`
+  - Method L227: `get_commission(self, order, fill_qty, fill_px, instrument) -> Money`
 
 ### `prediction_market_extensions/adapters/polymarket/gamma_markets.py`
 - Imports: `__future__, collections, math, msgspec, nautilus_trader, os, typing`
@@ -344,66 +345,73 @@ flowchart TD
 - Function L75: `calculate_commission(quantity: Decimal, price: Decimal, fee_rate_bps: Decimal, fee_exponent: int = 1, **_kwargs: object) -> float`
 
 ### `prediction_market_extensions/adapters/polymarket/pmxt.py`
-- Imports: `__future__, collections, concurrent, contextlib, datetime, decimal, msgspec, nautilus_trader, os, pandas, pathlib, pyarrow, re, shutil, tempfile, time, typing, urllib, warnings`
-- Class L42: `_PMXTBookSnapshotPayload(msgspec.Struct)`
-- Class L54: `_PMXTPriceChangePayload(msgspec.Struct)`
-- Class L71: `PolymarketPMXTDataLoader(PolymarketDataLoader)`
-  - Method L93: `__init__(self, *args, **kwargs) -> None`
-  - Method L114: `last_load_gap_hours(self) -> tuple[pd.Timestamp, ...]`
-  - Method L119: `_normalize_timestamp(value: pd.Timestamp | str | None) -> pd.Timestamp | None`
-  - Method L128: `_archive_hours(start: pd.Timestamp, end: pd.Timestamp) -> list[pd.Timestamp]`
-  - Method L138: `_archive_filename_for_hour(cls, hour: pd.Timestamp) -> str`
-  - Method L143: `_archive_url_for_hour(cls, hour: pd.Timestamp) -> str`
-  - Method L147: `_archive_relative_path_for_hour(cls, hour: pd.Timestamp) -> str`
-  - Method L155: `_env_flag_enabled(value: str | None) -> bool`
-  - Method L161: `_default_cache_dir(cls) -> Path`
-  - Method L167: `_resolve_cache_dir(cls) -> Path | None`
-  - Method L183: `_resolve_local_archive_dir(cls) -> Path | None`
-  - Method L194: `_resolve_prefetch_workers(cls) -> int`
-  - Method L209: `_market_cache_path_for_hour(cls, cache_dir: Path, condition_id: str, token_id: str, hour: pd.Timestamp) -> Path`
-  - Method L214: `_cache_path_for_hour(self, hour: pd.Timestamp) -> Path | None`
-  - Method L223: `_local_archive_candidate_paths_for_hour(cls, archive_dir: Path, hour: pd.Timestamp) -> tuple[Path, ...]`
-  - Method L230: `_local_archive_paths_for_hour(self, hour: pd.Timestamp) -> tuple[Path, ...]`
-  - Method L235: `_market_filter(self) -> Any`
-  - Method L242: `_empty_market_table(cls) -> pa.Table`
-  - Method L248: `_to_market_batch(cls, batch: pa.RecordBatch) -> pa.RecordBatch`
-  - Method L255: `_filter_batch_to_token(self, batch: pa.RecordBatch) -> pa.RecordBatch`
-  - Method L265: `_filter_raw_batch(self, batch: pa.RecordBatch) -> pa.RecordBatch`
-  - Method L282: `_load_cached_market_table(self, hour: pd.Timestamp) -> pa.Table | None`
-  - Method L294: `_load_cached_market_batches(self, hour: pd.Timestamp) -> list[pa.RecordBatch] | None`
-  - Method L307: `_write_market_cache(self, hour: pd.Timestamp, table: pa.Table) -> None`
-  - Method L320: `_scan_raw_market_batches(self, dataset: ds.Dataset, *, batch_size: int, source: str | None = None, total_bytes: int | None = None) -> list[pa.RecordBatch]`
-  - Method L375: `_load_remote_market_table(self, hour: pd.Timestamp, *, batch_size: int) -> pa.Table | None`
-  - Method L383: `_load_remote_market_batches(self, hour: pd.Timestamp, *, batch_size: int) -> list[pa.RecordBatch] | None`
-  - Method L389: `_load_raw_market_batches_via_download(self, archive_url: str, *, batch_size: int) -> list[pa.RecordBatch] | None`
-  - Method L412: `_load_local_archive_market_batches(self, hour: pd.Timestamp, *, batch_size: int) -> list[pa.RecordBatch] | None`
-  - Method L436: `_filter_table_to_token(self, table: pa.Table) -> pa.Table`
-  - Method L446: `_load_market_table(self, hour: pd.Timestamp, *, batch_size: int) -> pa.Table | None`
-  - Method L473: `_load_market_batches(self, hour: pd.Timestamp, *, batch_size: int) -> list[pa.RecordBatch] | None`
-  - Method L498: `_emit_download_progress(self, url: str, *, downloaded_bytes: int, total_bytes: int | None, finished: bool) -> None`
-  - Method L506: `_emit_scan_progress(self, source: str, *, scanned_batches: int, scanned_rows: int, matched_rows: int, total_bytes: int | None, finished: bool) -> None`
-  - Method L522: `_content_length_from_response(response: object) -> int | None`
-  - Method L534: `_progress_total_bytes(self, source: str) -> int | None`
-  - Method L561: `_download_to_file_with_progress(self, url: str, destination: Path) -> int | None`
-  - Method L610: `_download_payload_with_progress(self, url: str) -> bytes | None`
-  - Method L649: `_load_raw_market_batches_from_local_file(self, parquet_path: Path, *, batch_size: int, progress_source: str, total_bytes: int | None) -> list[pa.RecordBatch] | None`
-  - Method L661: `_temporary_download_filename(url: str) -> str`
-  - Method L666: `_pid_is_active(pid: int) -> bool`
-  - Method L678: `_temporary_download_path(self, url: str) -> Iterator[Path]`
-  - Method L690: `_cleanup_stale_temp_downloads(self) -> None`
-  - Method L719: `_iter_market_tables(self, hours: list[pd.Timestamp], *, batch_size: int) -> Iterator[tuple[pd.Timestamp, pa.Table | None]]`
-  - Method L750: `_iter_market_batches(self, hours: list[pd.Timestamp], *, batch_size: int) -> Iterator[tuple[pd.Timestamp, list[pa.RecordBatch] | None]]`
-  - Method L782: `_timestamp_to_ms_string(timestamp_secs: float) -> str`
-  - Method L786: `_decode_book_snapshot(payload_text: str) -> _PMXTBookSnapshotPayload`
-  - Method L790: `_decode_price_change(payload_text: str) -> _PMXTPriceChangePayload`
-  - Method L794: `_to_book_snapshot(payload: _PMXTBookSnapshotPayload) -> PolymarketBookSnapshot`
-  - Method L813: `_to_price_change(payload: _PMXTPriceChangePayload) -> PolymarketQuotes`
-  - Method L835: `_event_sort_key(record: OrderBookDeltas) -> tuple[int, int]`
-  - Method L840: `_payload_sort_key(self, update_type: str, payload_text: str) -> tuple[int, int]`
-  - Method L852: `_process_book_snapshot(self, payload_text: str, *, token_id: str, instrument, local_book: OrderBook, has_snapshot: bool, events: list[OrderBookDeltas], start_ns: int, end_ns: int, include_order_book: bool) -> tuple[OrderBook, bool]`
-  - Method L888: `_process_price_change(self, payload_text: str, *, token_id: str, instrument, local_book: OrderBook, has_snapshot: bool, events: list[OrderBookDeltas], start_ns: int, end_ns: int, include_order_book: bool) -> OrderBook`
-  - Method L923: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, batch_size: int = 25000, include_order_book: bool = True) -> list[OrderBookDeltas]`
-  - Method L1031: `_timestamp_to_ns(value: object) -> int`
+- Imports: `__future__, collections, concurrent, contextlib, datetime, decimal, json, msgspec, nautilus_trader, os, pandas, pathlib, pyarrow, re, shutil, tempfile, time, typing, urllib, warnings`
+- Class L43: `_PMXTBookSnapshotPayload(msgspec.Struct)`
+- Class L55: `_PMXTPriceChangePayload(msgspec.Struct)`
+- Class L72: `PolymarketPMXTDataLoader(PolymarketDataLoader)`
+  - Method L95: `__init__(self, *args, **kwargs) -> None`
+  - Method L116: `last_load_gap_hours(self) -> tuple[pd.Timestamp, ...]`
+  - Method L121: `_normalize_timestamp(value: pd.Timestamp | str | None) -> pd.Timestamp | None`
+  - Method L130: `_archive_hours(start: pd.Timestamp, end: pd.Timestamp) -> list[pd.Timestamp]`
+  - Method L140: `_archive_filename_for_hour(cls, hour: pd.Timestamp) -> str`
+  - Method L145: `_archive_url_for_hour(cls, hour: pd.Timestamp) -> str`
+  - Method L149: `_archive_relative_path_for_hour(cls, hour: pd.Timestamp) -> str`
+  - Method L157: `_env_flag_enabled(value: str | None) -> bool`
+  - Method L163: `_default_cache_dir(cls) -> Path`
+  - Method L169: `_resolve_cache_dir(cls) -> Path | None`
+  - Method L185: `_resolve_local_archive_dir(cls) -> Path | None`
+  - Method L196: `_resolve_prefetch_workers(cls) -> int`
+  - Method L211: `_market_cache_path_for_hour(cls, cache_dir: Path, condition_id: str, token_id: str, hour: pd.Timestamp) -> Path`
+  - Method L216: `_cache_path_for_hour(self, hour: pd.Timestamp) -> Path | None`
+  - Method L225: `_cache_metadata_path(cache_path: Path) -> Path`
+  - Method L229: `_local_file_fingerprint(path: Path) -> dict[str, object] | None`
+  - Method L242: `_source_cache_fingerprint_for_hour(self, hour: pd.Timestamp) -> dict[str, object] | None`
+  - Method L252: `_cache_metadata_for_hour(self, hour: pd.Timestamp) -> dict[str, object] | None`
+  - Method L256: `_cache_metadata_payload(self, hour: pd.Timestamp, *, source: Mapping[str, object] | None) -> dict[str, object] | None`
+  - Method L269: `_cache_metadata_matches(self, hour: pd.Timestamp, cache_path: Path) -> bool`
+  - Method L281: `_local_archive_candidate_paths_for_hour(cls, archive_dir: Path, hour: pd.Timestamp) -> tuple[Path, ...]`
+  - Method L288: `_local_archive_paths_for_hour(self, hour: pd.Timestamp) -> tuple[Path, ...]`
+  - Method L293: `_market_filter(self) -> Any`
+  - Method L300: `_empty_market_table(cls) -> pa.Table`
+  - Method L306: `_to_market_batch(cls, batch: pa.RecordBatch) -> pa.RecordBatch`
+  - Method L313: `_filter_batch_to_token(self, batch: pa.RecordBatch) -> pa.RecordBatch`
+  - Method L323: `_filter_raw_batch(self, batch: pa.RecordBatch) -> pa.RecordBatch`
+  - Method L340: `_load_cached_market_table(self, hour: pd.Timestamp) -> pa.Table | None`
+  - Method L354: `_load_cached_market_batches(self, hour: pd.Timestamp) -> list[pa.RecordBatch] | None`
+  - Method L369: `_write_market_cache(self, hour: pd.Timestamp, table: pa.Table, *, metadata: Mapping[str, object] | None = None) -> None`
+  - Method L401: `_scan_raw_market_batches(self, dataset: ds.Dataset, *, batch_size: int, source: str | None = None, total_bytes: int | None = None) -> list[pa.RecordBatch]`
+  - Method L456: `_load_remote_market_table(self, hour: pd.Timestamp, *, batch_size: int) -> pa.Table | None`
+  - Method L464: `_load_remote_market_batches(self, hour: pd.Timestamp, *, batch_size: int) -> list[pa.RecordBatch] | None`
+  - Method L470: `_load_raw_market_batches_via_download(self, archive_url: str, *, batch_size: int) -> list[pa.RecordBatch] | None`
+  - Method L493: `_load_local_archive_market_batches(self, hour: pd.Timestamp, *, batch_size: int) -> list[pa.RecordBatch] | None`
+  - Method L517: `_filter_table_to_token(self, table: pa.Table) -> pa.Table`
+  - Method L527: `_load_market_table(self, hour: pd.Timestamp, *, batch_size: int) -> pa.Table | None`
+  - Method L558: `_load_market_batches(self, hour: pd.Timestamp, *, batch_size: int) -> list[pa.RecordBatch] | None`
+  - Method L587: `_emit_download_progress(self, url: str, *, downloaded_bytes: int, total_bytes: int | None, finished: bool) -> None`
+  - Method L595: `_emit_scan_progress(self, source: str, *, scanned_batches: int, scanned_rows: int, matched_rows: int, total_bytes: int | None, finished: bool) -> None`
+  - Method L611: `_content_length_from_response(response: object) -> int | None`
+  - Method L623: `_progress_total_bytes(self, source: str) -> int | None`
+  - Method L650: `_download_to_file_with_progress(self, url: str, destination: Path) -> int | None`
+  - Method L699: `_download_payload_with_progress(self, url: str) -> bytes | None`
+  - Method L738: `_load_raw_market_batches_from_local_file(self, parquet_path: Path, *, batch_size: int, progress_source: str, total_bytes: int | None) -> list[pa.RecordBatch] | None`
+  - Method L750: `_temporary_download_filename(url: str) -> str`
+  - Method L755: `_pid_is_active(pid: int) -> bool`
+  - Method L767: `_temporary_download_path(self, url: str) -> Iterator[Path]`
+  - Method L779: `_cleanup_stale_temp_downloads(self) -> None`
+  - Method L808: `_iter_market_tables(self, hours: list[pd.Timestamp], *, batch_size: int) -> Iterator[tuple[pd.Timestamp, pa.Table | None]]`
+  - Method L839: `_iter_market_batches(self, hours: list[pd.Timestamp], *, batch_size: int) -> Iterator[tuple[pd.Timestamp, list[pa.RecordBatch] | None]]`
+  - Method L871: `_timestamp_to_ms_string(timestamp_secs: float) -> str`
+  - Method L875: `_decode_book_snapshot(payload_text: str) -> _PMXTBookSnapshotPayload`
+  - Method L879: `_decode_price_change(payload_text: str) -> _PMXTPriceChangePayload`
+  - Method L883: `_to_book_snapshot(payload: _PMXTBookSnapshotPayload) -> PolymarketBookSnapshot`
+  - Method L902: `_to_price_change(payload: _PMXTPriceChangePayload) -> PolymarketQuotes`
+  - Method L924: `_event_sort_key(record: OrderBookDeltas) -> tuple[int, int]`
+  - Method L930: `_retimestamp_deltas(deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
+  - Method L945: `_payload_sort_key(self, update_type: str, payload_text: str) -> tuple[int, int]`
+  - Method L957: `_process_book_snapshot(self, payload_text: str, *, token_id: str, instrument, local_book: OrderBook, has_snapshot: bool, events: list[OrderBookDeltas], start_ns: int, end_ns: int, include_order_book: bool) -> tuple[OrderBook, bool]`
+  - Method L997: `_process_price_change(self, payload_text: str, *, token_id: str, instrument, local_book: OrderBook, has_snapshot: bool, events: list[OrderBookDeltas], start_ns: int, end_ns: int, include_order_book: bool) -> OrderBook`
+  - Method L1036: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, batch_size: int = 25000, include_order_book: bool = True) -> list[OrderBookDeltas]`
+  - Method L1172: `_timestamp_to_ns(value: object) -> int`
 
 ### `prediction_market_extensions/adapters/polymarket/research.py`
 - Imports: `__future__, collections, datetime, msgspec, nautilus_trader, pandas, prediction_market_extensions, typing`
@@ -440,8 +448,8 @@ flowchart TD
 - Function L306: `infer_realized_outcome_from_metadata(metadata: Mapping[object, object] | None, outcome_name: str) -> float | None`
 - Function L337: `infer_realized_outcome(source: object | None) -> float | None`
 - Function L356: `compute_binary_settlement_pnl(fill_events: Sequence[Mapping[object, object]], resolved_outcome: float | None) -> float | None`
-- Function L401: `build_brier_inputs(points: Sequence[PricePoint], window: int, realized_outcome: float | None = None, warnings_out: list[str] | None = None) -> tuple[pd.Series, pd.Series, pd.Series]`
-- Function L447: `build_market_prices(points: Sequence[PricePoint], *, resample_rule: str | None = None) -> list[tuple[datetime, float]]`
+- Function L400: `build_brier_inputs(points: Sequence[PricePoint], window: int, realized_outcome: float | None = None, warnings_out: list[str] | None = None) -> tuple[pd.Series, pd.Series, pd.Series]`
+- Function L446: `build_market_prices(points: Sequence[PricePoint], *, resample_rule: str | None = None) -> list[tuple[datetime, float]]`
 
 ### `prediction_market_extensions/adapters/prediction_market/fill_model.py`
 - Imports: `__future__, decimal, nautilus_trader, prediction_market_extensions`
@@ -458,6 +466,8 @@ flowchart TD
 - Imports: `__future__, collections, typing`
 - Function L40: `extract_resolution_metadata(info: Mapping[str, Any] | None) -> dict[str, Any]`
 - Function L77: `sanitize_info_for_simulation(info: Mapping[str, Any] | None) -> dict[str, Any]`
+- Function L89: `_sanitize_value(value) -> Any`
+- Function L99: `_sanitize_mapping(value: Mapping[str, Any]) -> dict[str, Any]`
 
 ### `prediction_market_extensions/adapters/prediction_market/order_tags.py`
 - Imports: `__future__, decimal, typing`
@@ -492,48 +502,78 @@ flowchart TD
 
 ### `prediction_market_extensions/adapters/prediction_market/research.py`
 - Imports: `__future__, collections, datetime, math, nautilus_trader, pandas, pathlib, prediction_market_extensions, re, typing`
-- Function L72: `_extract_account_pnl_series(engine: BacktestEngine) -> pd.Series`
-- Function L95: `_dense_account_series_from_engine(*, engine: BacktestEngine, market_id: str, market_prices: Sequence[tuple[datetime, float]], initial_cash: float) -> tuple[pd.Series, pd.Series]`
-- Function L107: `_dense_account_series_from_engine_for_markets(*, engine: BacktestEngine, market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> tuple[pd.Series, pd.Series]`
-- Function L146: `_dense_market_account_series_from_fill_events(*, market_id: str, market_prices: Sequence[tuple[datetime, float]], fill_events: Sequence[dict[str, Any]], initial_cash: float) -> tuple[pd.Series, pd.Series]`
-- Function L223: `_pairs_to_series(pairs: Sequence[tuple[str, float]] | Sequence[tuple[Any, float]]) -> pd.Series`
-- Function L238: `_to_legacy_datetime(timestamp: pd.Timestamp) -> datetime`
-- Function L242: `_series_to_iso_pairs(series: pd.Series) -> list[tuple[str, float]]`
-- Function L249: `_align_series_to_timeline(series: pd.Series, timeline: pd.DatetimeIndex, *, before: float, after: float) -> pd.Series`
-- Function L261: `_extend_active_range(active_ranges: dict[str, tuple[pd.Timestamp, pd.Timestamp]], label: str, start: pd.Timestamp, end: pd.Timestamp) -> None`
-- Function L274: `_parse_float_like(value, default: float = 0.0) -> float`
-- Function L294: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
-- Function L371: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
-- Function L414: `_aggregate_brier_frames(results: Sequence[dict[str, Any]]) -> dict[str, pd.DataFrame]`
-- Function L442: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
-- Function L464: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
-- Function L468: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
-- Function L474: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
-- Function L481: `_yes_price_fill_marker_budget(max_points: int) -> int`
-- Function L487: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
-- Function L498: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
-- Function L545: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
-- Function L559: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
-- Function L580: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
-- Function L625: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
-- Function L640: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = True, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L1_MBP, liquidity_consumption: bool = False, queue_position: bool = False, latency_model: Any | None = None) -> dict[str, Any]`
-- Function L793: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
-- Function L847: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1093: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1335: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
-- Function L1398: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
-- Function L1416: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
-- Function L1442: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
-- Function L1460: `_summary_returns_from_pairs(pairs: object) -> dict[int, float]`
-- Function L1481: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
-- Function L1498: `_summary_total_return_pct(pairs: object) -> float | None`
-- Function L1514: `_safe_stat(func, returns: dict[int, float]) -> float | None`
-- Function L1522: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
-- Function L1527: `_coerce_float(value: object) -> float | None`
-- Function L1535: `_format_summary_float(value: object, decimals: int) -> str`
-- Function L1542: `_format_summary_pct(value: object) -> str`
-- Function L1549: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
-- Function L1612: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
+- Function L86: `_default_prediction_market_latency_model() -> Any`
+- Function L93: `_extract_account_pnl_series(engine: BacktestEngine) -> pd.Series`
+- Function L116: `_dense_account_series_from_engine(*, engine: BacktestEngine, market_id: str, market_prices: Sequence[tuple[datetime, float]], initial_cash: float) -> tuple[pd.Series, pd.Series]`
+- Function L128: `_dense_account_series_from_engine_for_markets(*, engine: BacktestEngine, market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> tuple[pd.Series, pd.Series]`
+- Function L167: `_dense_market_account_series_from_fill_events(*, market_id: str, market_prices: Sequence[tuple[datetime, float]], fill_events: Sequence[dict[str, Any]], initial_cash: float) -> tuple[pd.Series, pd.Series]`
+- Function L244: `_pairs_to_series(pairs: Sequence[tuple[str, float]] | Sequence[tuple[Any, float]]) -> pd.Series`
+- Function L259: `_series_value_at_or_before(series: pd.Series, timestamp: pd.Timestamp) -> float | None`
+- Function L268: `_result_initial_capital(result: Mapping[str, Any], *, equity_series: pd.Series, cash_series: pd.Series, pnl_series: pd.Series) -> float | None`
+- Function L296: `_initial_capital_from_pnl_series(*, equity_series: pd.Series, pnl_series: pd.Series) -> float | None`
+- Function L307: `_joint_portfolio_initial_capital(result: Mapping[str, Any], *, equity_series: pd.Series) -> float | None`
+- Function L320: `_return_fraction(*, initial_capital: float, final_equity: float) -> float`
+- Function L326: `_series_with_initial_capital_basis(series: pd.Series, *, initial_capital: float | None) -> pd.Series`
+- Function L352: `_to_legacy_datetime(timestamp: pd.Timestamp) -> datetime`
+- Function L356: `_result_base_label(result: Mapping[str, Any], market_key: str | None) -> str`
+- Function L369: `_result_label_disambiguator(result: Mapping[str, Any]) -> str | None`
+- Function L378: `_unique_result_labels(results: Sequence[dict[str, Any]], market_key: str | None) -> list[str]`
+- Function L407: `_series_to_iso_pairs(series: pd.Series) -> list[tuple[str, float]]`
+- Function L414: `_align_series_to_timeline(series: pd.Series, timeline: pd.DatetimeIndex, *, before: float, after: float) -> pd.Series`
+- Function L426: `_extend_active_range(active_ranges: dict[str, tuple[pd.Timestamp, pd.Timestamp]], label: str, start: pd.Timestamp, end: pd.Timestamp) -> None`
+- Function L439: `_result_settlement_active_cutoff(result: Mapping[str, Any]) -> pd.Timestamp | None`
+- Function L448: `_record_active_cutoff(active_cutoffs: dict[str, pd.Timestamp], label: str, result: Mapping[str, Any]) -> None`
+- Function L461: `_result_brier_cutoff(result: Mapping[str, Any]) -> pd.Timestamp | None`
+- Function L469: `_truncate_brier_series_at_cutoff(result: Mapping[str, Any], *series_values: pd.Series) -> tuple[pd.Series, ...]`
+- Function L478: `_active_range_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
+- Function L490: `_fill_event_timestamp(event: Mapping[str, Any]) -> pd.Timestamp | None`
+- Function L503: `_fill_event_position_delta(event: Mapping[str, Any]) -> float | None`
+- Function L516: `_normalize_fill_action_value(value: object, *, default_for_token_side: str | None) -> str | None`
+- Function L533: `_is_missing_fill_value(value: object) -> bool`
+- Function L546: `_fill_event_action(event: Mapping[str, Any], *, default_missing: str | None) -> str | None`
+- Function L583: `_result_active_position_intervals(result: Mapping[str, Any]) -> list[tuple[pd.Timestamp, pd.Timestamp | None]] | None`
+- Function L633: `_position_interval_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp | None, fallback_end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
+- Function L653: `_overlay_range_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
+- Function L665: `_parse_float_like(value, default: float = 0.0) -> float`
+- Function L687: `_first_non_missing_fill_value(source, *keys: str) -> Any`
+- Function L698: `_fill_value_text(value) -> str`
+- Function L704: `_result_has_position_activity(result: Mapping[str, Any]) -> bool`
+- Function L723: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
+- Function L818: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
+- Function L864: `_aggregate_brier_frames(results: Sequence[dict[str, Any]], *, market_key: str | None) -> dict[str, pd.DataFrame]`
+- Function L897: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
+- Function L922: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
+- Function L926: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
+- Function L932: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
+- Function L939: `_yes_price_fill_marker_budget(max_points: int) -> int`
+- Function L945: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
+- Function L956: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
+- Function L1003: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
+- Function L1017: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
+- Function L1038: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], market_key: str | None, resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
+- Function L1084: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
+- Function L1099: `_add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
+- Function L1107: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = False, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L2_MBP, liquidity_consumption: bool = True, queue_position: bool = True, latency_model: Any | None = _DEFAULT_LATENCY_MODEL, nautilus_log_level: str = 'INFO') -> dict[str, Any]`
+- Function L1273: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
+- Function L1327: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1632: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1927: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
+- Function L1989: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
+- Function L2024: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
+- Function L2050: `_summary_total_equity_series(results: Sequence[Mapping[str, Any]]) -> list[tuple[str, float]]`
+- Function L2118: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
+- Function L2136: `_summary_returns_from_pairs(pairs: object, *, initial_capital: float | None = None) -> dict[int, float]`
+- Function L2145: `_summary_returns_from_series(series: pd.Series, *, initial_capital: float | None = None) -> dict[int, float]`
+- Function L2171: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
+- Function L2188: `_summary_total_return_pct(pairs: object, *, initial_capital: float | None = None) -> float | None`
+- Function L2197: `_summary_total_return_pct_from_series(series: pd.Series, *, initial_capital: float | None = None) -> float | None`
+- Function L2216: `_safe_stat(func, returns: dict[int, float]) -> float | None`
+- Function L2224: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
+- Function L2229: `_coerce_float(value: object) -> float | None`
+- Function L2237: `_format_summary_float(value: object, decimals: int) -> str`
+- Function L2244: `_format_summary_pct(value: object) -> str`
+- Function L2251: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
+- Function L2314: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
 
 ### `prediction_market_extensions/analysis/__init__.py`
 - Imports: none
@@ -583,9 +623,10 @@ flowchart TD
 - Function L267: `_build_dataframes(result: BacktestResult, bar: PinnedProgress[None] | None = None, max_markets: int = 10) -> Any`
 - Function L397: `_select_display_markets(market_df: pd.DataFrame, fills_df: pd.DataFrame, *, max_markets: int) -> list[str]`
 - Function L425: `_finite_idxmax(series: pd.Series) -> int | None`
-- Function L432: `_downsample(eq: pd.DataFrame, fills_df: pd.DataFrame, market_df: pd.DataFrame, max_points: int = 5000, alloc_df: pd.DataFrame | None = None, keep_indices: set[int] | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame | None]`
-- Function L510: `_build_allocation_data(eq: pd.DataFrame, fills_df: pd.DataFrame, market_prices: dict[str, list[tuple]], top_n: int | None = None) -> pd.DataFrame`
-- Function L661: `plot(result: BacktestResult, *, filename: str = '', plot_width: int | None = None, plot_equity: bool = True, plot_drawdown: bool = True, plot_pl: bool = True, plot_cash: bool = True, plot_market_prices: bool = True, plot_allocation: bool = True, show_legend: bool = True, open_browser: bool = True, relative_equity: bool = True, plot_monthly_returns: bool | None = None, max_markets: int = 30, progress: bool = True, plot_panels: Sequence[str] | None = None, extra_panels: Mapping[str, Any] | None = None) -> Any`
+- Function L432: `_finite_idxmin(series: pd.Series) -> int | None`
+- Function L439: `_downsample(eq: pd.DataFrame, fills_df: pd.DataFrame, market_df: pd.DataFrame, max_points: int = 5000, alloc_df: pd.DataFrame | None = None, keep_indices: set[int] | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame | None]`
+- Function L544: `_build_allocation_data(eq: pd.DataFrame, fills_df: pd.DataFrame, market_prices: dict[str, list[tuple]], top_n: int | None = None) -> pd.DataFrame`
+- Function L699: `plot(result: BacktestResult, *, filename: str = '', plot_width: int | None = None, plot_equity: bool = True, plot_drawdown: bool = True, plot_pl: bool = True, plot_cash: bool = True, plot_market_prices: bool = True, plot_allocation: bool = True, show_legend: bool = True, open_browser: bool = True, relative_equity: bool = True, plot_monthly_returns: bool | None = None, max_markets: int = 30, progress: bool = True, plot_panels: Sequence[str] | None = None, extra_panels: Mapping[str, Any] | None = None) -> Any`
 
 ### `prediction_market_extensions/analysis/legacy_backtesting/progress.py`
 - Imports: `__future__, collections, os, sys, time, typing`
@@ -616,59 +657,59 @@ flowchart TD
 - Function L181: `_extract_account_report(engine) -> pd.DataFrame`
 - Function L214: `_infer_market_side(models_module, market_id: str) -> Any`
 - Function L221: `_signed_quantity(action: str, side: str, qty: float) -> float`
-- Function L233: `_convert_fills(fills_report: pd.DataFrame, models_module) -> list[Any]`
-- Function L292: `_position_count_by_snapshot(snapshot_times: list[datetime], fills: list[Any]) -> list[int]`
-- Function L317: `_build_portfolio_snapshots(models_module, account_report: pd.DataFrame, fills: list[Any]) -> list[Any]`
-- Function L343: `_build_dense_timeline(fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]]) -> pd.DatetimeIndex`
-- Function L353: `_dense_cash_series(sparse_snapshots: list[Any], dense_dt: pd.DatetimeIndex, initial_cash: float) -> np.ndarray`
-- Function L370: `_fill_cash_delta(fill) -> float`
-- Function L377: `_dense_cash_series_from_fills(fills: list[Any], dense_dts: np.ndarray, initial_cash: float) -> np.ndarray`
-- Function L393: `_replay_fill_position_deltas(fills: list[Any], dense_dts: np.ndarray) -> tuple[dict[str, np.ndarray], dict[str, float]]`
-- Function L417: `_aligned_market_prices(market_id: str, market_prices: Mapping[str, Sequence[tuple[datetime, float]]], dense_dts: np.ndarray, n_bars: int, fallback_price: float) -> tuple[np.ndarray, np.datetime64 | None]`
-- Function L444: `_apply_resolution_cutoffs(pos_qty: dict[str, np.ndarray], pos_changes: Mapping[str, np.ndarray], market_last_ts: Mapping[str, np.datetime64 | None], dense_dts: np.ndarray) -> None`
-- Function L466: `_mark_to_market(pos_qty: Mapping[str, np.ndarray], price_on_bar: Mapping[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray]`
-- Function L486: `_build_dense_portfolio_snapshots(models_module, sparse_snapshots: list[Any], fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> list[Any]`
-- Function L559: `_normalize_market_prices(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
-- Function L590: `_market_prices_from_fills(fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
-- Function L599: `_merge_market_price_sources(primary: Mapping[str, Sequence[tuple[Any, float]]] | None, secondary: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
-- Function L623: `_market_prices_with_fill_points(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None, fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
-- Function L634: `_build_metrics(snapshots: list[Any], initial_cash: float) -> dict[str, float]`
-- Function L652: `_platform_enum(models_module, platform: str) -> Any`
-- Function L659: `_mark_panel_figure(fig, panel_id: str) -> Any`
-- Function L667: `_brier_unavailable_reason(*, user_probabilities: pd.Series | None, market_probabilities: pd.Series | None, outcomes: pd.Series | None) -> str | None`
-- Function L686: `_build_brier_placeholder_panel(message: str) -> Any`
-- Function L727: `_style_panel_legend(fig) -> None`
-- Function L739: `_build_brier_timeseries_panel(brier_frame: pd.DataFrame, *, panel_id: str, axis_label: str, legend_label: str, line_color: str = '#2ca0f0') -> Any | None`
-- Function L840: `_build_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
-- Function L849: `_build_total_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
-- Function L859: `_iter_layout_nodes(node) -> Any`
-- Function L871: `_iter_figures(layout) -> Any`
-- Function L877: `_field_name(spec) -> str | None`
-- Function L888: `_filter_tool_container(container, tools_to_remove: set[Any]) -> None`
-- Function L922: `_remove_tools_from_layout(layout, tools_to_remove: set[Any]) -> None`
-- Function L931: `_remove_hover_tools(fig, *, layout: Any | None = None) -> set[Any]`
-- Function L943: `_format_period_label(start, end) -> str`
-- Function L956: `_find_figure_with_yaxis_label(layout, predicate) -> Any | None`
-- Function L964: `_periodic_pnl_panel_source(target) -> tuple[dict[str, Any] | None, float | None]`
-- Function L982: `_build_periodic_pnl_panel_source_data(source_data: dict[str, Any]) -> dict[str, Any] | None`
-- Function L1002: `_resolve_periodic_pnl_bar_width(x_values: np.ndarray, bar_width: float | None) -> float`
-- Function L1010: `_yes_price_line_renderers(target) -> list[Any]`
-- Function L1032: `_remove_data_banner(layout) -> Any`
-- Function L1051: `_legend_item_label_text(item) -> str`
-- Function L1061: `_remove_yes_price_profitability_legend_items(fig) -> set[Any]`
-- Function L1077: `_remove_yes_price_profitability_connectors(layout) -> None`
-- Function L1103: `_limit_yes_price_fill_markers(layout, max_yes_price_fill_markers: int | None) -> None`
-- Function L1146: `_subset_bokeh_source_values(values, indexes: np.ndarray) -> Any`
-- Function L1156: `_limit_market_pnl_fill_markers(layout, max_market_pnl_fill_markers: int | None) -> None`
-- Function L1200: `_standardize_periodic_pnl_panel(layout) -> None`
-- Function L1248: `_relabel_market_pnl_panel(layout, axis_label: str = 'Market P&L') -> None`
-- Function L1275: `_build_multi_market_brier_panel(brier_frames: Mapping[str, pd.DataFrame], *, axis_label: str = 'Cumulative Brier Advantage', color_by_market: Mapping[str, Any] | None = None) -> Any | None`
-- Function L1409: `_standardize_yes_price_hover(layout) -> None`
-- Function L1440: `_focus_allocation_panel(layout) -> None`
-- Function L1477: `_apply_layout_overrides(layout, initial_cash: float, *, relabel_market_pnl: bool = False, max_yes_price_fill_markers: int | None = None, max_market_pnl_fill_markers: int | None = None) -> Any`
-- Function L1498: `_save_layout(layout, output_path: Path, title: str) -> None`
-- Function L1511: `save_legacy_backtest_layout(layout, output_path: str | Path, title: str) -> str`
-- Function L1521: `build_legacy_backtest_layout(engine, output_path: str | Path, strategy_name: str, platform: str, initial_cash: float, market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None = None, user_probabilities: pd.Series | None = None, market_probabilities: pd.Series | None = None, outcomes: pd.Series | None = None, legacy_repo_path: str | Path | None = None, open_browser: bool = False, max_markets: int = 30, progress: bool = False, plot_panels: Sequence[str] | None = None) -> tuple[Any, str]`
+- Function L230: `_convert_fills(fills_report: pd.DataFrame, models_module) -> list[Any]`
+- Function L289: `_position_count_by_snapshot(snapshot_times: list[datetime], fills: list[Any]) -> list[int]`
+- Function L314: `_build_portfolio_snapshots(models_module, account_report: pd.DataFrame, fills: list[Any]) -> list[Any]`
+- Function L340: `_build_dense_timeline(fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]]) -> pd.DatetimeIndex`
+- Function L350: `_dense_cash_series(sparse_snapshots: list[Any], dense_dt: pd.DatetimeIndex, initial_cash: float) -> np.ndarray`
+- Function L367: `_fill_cash_delta(fill) -> float`
+- Function L374: `_dense_cash_series_from_fills(fills: list[Any], dense_dts: np.ndarray, initial_cash: float) -> np.ndarray`
+- Function L390: `_replay_fill_position_deltas(fills: list[Any], dense_dts: np.ndarray) -> tuple[dict[str, np.ndarray], dict[str, float]]`
+- Function L414: `_aligned_market_prices(market_id: str, market_prices: Mapping[str, Sequence[tuple[datetime, float]]], dense_dts: np.ndarray, n_bars: int, fallback_price: float) -> tuple[np.ndarray, np.datetime64 | None]`
+- Function L441: `_apply_resolution_cutoffs(pos_qty: dict[str, np.ndarray], pos_changes: Mapping[str, np.ndarray], market_last_ts: Mapping[str, np.datetime64 | None], dense_dts: np.ndarray) -> None`
+- Function L463: `_mark_to_market(pos_qty: Mapping[str, np.ndarray], price_on_bar: Mapping[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray]`
+- Function L482: `_build_dense_portfolio_snapshots(models_module, sparse_snapshots: list[Any], fills: list[Any], market_prices: Mapping[str, Sequence[tuple[datetime, float]]], initial_cash: float) -> list[Any]`
+- Function L555: `_normalize_market_prices(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
+- Function L586: `_market_prices_from_fills(fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
+- Function L595: `_merge_market_price_sources(primary: Mapping[str, Sequence[tuple[Any, float]]] | None, secondary: Mapping[str, Sequence[tuple[Any, float]]] | None) -> dict[str, list[tuple[datetime, float]]]`
+- Function L619: `_market_prices_with_fill_points(market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None, fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]`
+- Function L630: `_build_metrics(snapshots: list[Any], initial_cash: float) -> dict[str, float]`
+- Function L648: `_platform_enum(models_module, platform: str) -> Any`
+- Function L655: `_mark_panel_figure(fig, panel_id: str) -> Any`
+- Function L663: `_brier_unavailable_reason(*, user_probabilities: pd.Series | None, market_probabilities: pd.Series | None, outcomes: pd.Series | None) -> str | None`
+- Function L682: `_build_brier_placeholder_panel(message: str) -> Any`
+- Function L723: `_style_panel_legend(fig) -> None`
+- Function L735: `_build_brier_timeseries_panel(brier_frame: pd.DataFrame, *, panel_id: str, axis_label: str, legend_label: str, line_color: str = '#2ca0f0') -> Any | None`
+- Function L841: `_build_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
+- Function L850: `_build_total_brier_panel(brier_frame: pd.DataFrame) -> Any | None`
+- Function L860: `_iter_layout_nodes(node) -> Any`
+- Function L872: `_iter_figures(layout) -> Any`
+- Function L878: `_field_name(spec) -> str | None`
+- Function L889: `_filter_tool_container(container, tools_to_remove: set[Any]) -> None`
+- Function L923: `_remove_tools_from_layout(layout, tools_to_remove: set[Any]) -> None`
+- Function L932: `_remove_hover_tools(fig, *, layout: Any | None = None) -> set[Any]`
+- Function L944: `_format_period_label(start, end) -> str`
+- Function L957: `_find_figure_with_yaxis_label(layout, predicate) -> Any | None`
+- Function L965: `_periodic_pnl_panel_source(target) -> tuple[dict[str, Any] | None, float | None]`
+- Function L983: `_build_periodic_pnl_panel_source_data(source_data: dict[str, Any]) -> dict[str, Any] | None`
+- Function L1003: `_resolve_periodic_pnl_bar_width(x_values: np.ndarray, bar_width: float | None) -> float`
+- Function L1011: `_yes_price_line_renderers(target) -> list[Any]`
+- Function L1033: `_remove_data_banner(layout) -> Any`
+- Function L1052: `_legend_item_label_text(item) -> str`
+- Function L1062: `_remove_yes_price_profitability_legend_items(fig) -> set[Any]`
+- Function L1078: `_remove_yes_price_profitability_connectors(layout) -> None`
+- Function L1104: `_limit_yes_price_fill_markers(layout, max_yes_price_fill_markers: int | None) -> None`
+- Function L1147: `_subset_bokeh_source_values(values, indexes: np.ndarray) -> Any`
+- Function L1157: `_limit_market_pnl_fill_markers(layout, max_market_pnl_fill_markers: int | None) -> None`
+- Function L1201: `_standardize_periodic_pnl_panel(layout) -> None`
+- Function L1249: `_relabel_market_pnl_panel(layout, axis_label: str = 'Market P&L') -> None`
+- Function L1276: `_build_multi_market_brier_panel(brier_frames: Mapping[str, pd.DataFrame], *, axis_label: str = 'Cumulative Brier Advantage', color_by_market: Mapping[str, Any] | None = None) -> Any | None`
+- Function L1410: `_standardize_yes_price_hover(layout) -> None`
+- Function L1441: `_focus_allocation_panel(layout) -> None`
+- Function L1480: `_apply_layout_overrides(layout, initial_cash: float, *, relabel_market_pnl: bool = False, max_yes_price_fill_markers: int | None = None, max_market_pnl_fill_markers: int | None = None) -> Any`
+- Function L1501: `_save_layout(layout, output_path: Path, title: str) -> None`
+- Function L1514: `save_legacy_backtest_layout(layout, output_path: str | Path, title: str) -> str`
+- Function L1524: `build_legacy_backtest_layout(engine, output_path: str | Path, strategy_name: str, platform: str, initial_cash: float, market_prices: Mapping[str, Sequence[tuple[Any, float]]] | None = None, user_probabilities: pd.Series | None = None, market_probabilities: pd.Series | None = None, outcomes: pd.Series | None = None, legacy_repo_path: str | Path | None = None, open_browser: bool = False, max_markets: int = 30, progress: bool = False, plot_panels: Sequence[str] | None = None) -> tuple[Any, str]`
 
 ### `prediction_market_extensions/analysis/tearsheet.py`
 - Imports: `__future__, collections, difflib, nautilus_trader, numbers, pandas, typing`
@@ -720,15 +761,16 @@ flowchart TD
 
 ### `prediction_market_extensions/backtesting/_backtest_runtime.py`
 - Imports: `__future__, collections, nautilus_trader, pandas, prediction_market_extensions, typing`
-- Function L36: `_record_timestamp_ns(record: object) -> int | None`
-- Function L50: `_iso_from_nanos(timestamp_ns: int | None) -> str | None`
-- Function L56: `_data_window_ns(data: Sequence[object]) -> tuple[int | None, int | None]`
-- Function L70: `_coverage_ratio_for_window(*, start_ns: int | None, end_ns: int | None, simulated_through_ns: int | None) -> float | None`
-- Function L84: `build_backtest_run_state(*, data: Sequence[object], backtest_end_ns: int | None, forced_stop: bool, requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
-- Function L130: `apply_backtest_run_state(*, result: dict[str, Any], run_state: dict[str, Any]) -> dict[str, Any]`
-- Function L137: `print_backtest_result_warnings(*, results: Sequence[dict[str, Any]], market_key: str) -> None`
-- Function L180: `add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
-- Function L188: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = True, slippage_ticks: int = 1, entry_slippage_pct: float = 0.0, exit_slippage_pct: float = 0.0, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', return_summary_series: bool = False, book_type: BookType = BookType.L1_MBP, liquidity_consumption: bool = False, queue_position: bool = False, latency_model: Any | None = None, nautilus_log_level: str = 'INFO', requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
+- Function L48: `_default_prediction_market_latency_model() -> Any`
+- Function L55: `_record_timestamp_ns(record: object) -> int | None`
+- Function L69: `_iso_from_nanos(timestamp_ns: int | None) -> str | None`
+- Function L75: `_data_window_ns(data: Sequence[object]) -> tuple[int | None, int | None]`
+- Function L89: `_coverage_ratio_for_window(*, start_ns: int | None, end_ns: int | None, simulated_through_ns: int | None) -> float | None`
+- Function L103: `build_backtest_run_state(*, data: Sequence[object], backtest_end_ns: int | None, forced_stop: bool, requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
+- Function L149: `apply_backtest_run_state(*, result: dict[str, Any], run_state: dict[str, Any]) -> dict[str, Any]`
+- Function L156: `print_backtest_result_warnings(*, results: Sequence[dict[str, Any]], market_key: str) -> None`
+- Function L199: `add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
+- Function L207: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = False, slippage_ticks: int = 1, entry_slippage_pct: float = 0.0, exit_slippage_pct: float = 0.0, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', return_summary_series: bool = False, book_type: BookType = BookType.L2_MBP, liquidity_consumption: bool = True, queue_position: bool = True, latency_model: Any | None = _DEFAULT_LATENCY_MODEL, nautilus_log_level: str = 'INFO', requested_start_ns: int | None = None, requested_end_ns: int | None = None) -> dict[str, Any]`
 
 ### `prediction_market_extensions/backtesting/_execution_config.py`
 - Imports: `__future__, dataclasses, math, nautilus_trader`
@@ -800,80 +842,133 @@ flowchart TD
 - Function L184: `display_html_artifacts(html_artifacts: Sequence[Path], *, repo_root: Path, iframe_height: int = 820) -> None`
 
 ### `prediction_market_extensions/backtesting/_optimizer.py`
-- Imports: `__future__, collections, contextlib, csv, dataclasses, datetime, itertools, json, multiprocessing, pathlib, pickle, prediction_market_extensions, random, statistics, tempfile, traceback, types, typing, warnings`
-- Function L256: `_validate_parameter_spec(name: str, spec) -> ParameterSpec`
-- Function L291: `_collect_search_placeholders(value) -> set[str]`
-- Function L304: `_replace_search_placeholders(value, params: Mapping[str, Any]) -> Any`
-- Function L320: `_parameter_candidates(parameter_grid: Mapping[str, Sequence[Any]]) -> list[ParameterValues]`
-- Function L335: `_sample_parameter_sets(config: ParameterSearchConfig) -> list[ParameterValues]`
-- Function L345: `_windowed_replay(*, base_replay: ReplaySpec, window: ParameterSearchWindow) -> ReplaySpec`
-- Function L361: `_windowed_replays(*, base_replays: Sequence[ReplaySpec], window: ParameterSearchWindow) -> tuple[ReplaySpec, ...]`
-- Function L367: `_build_backtest(*, config: ParameterSearchConfig, trial_id: int, window: ParameterSearchWindow, params: ParameterValues) -> PredictionMarketBacktest`
-- Function L388: `_coerce_parameter_values(*, config: ParameterSearchConfig, params: ParameterValues | Mapping[str, Any]) -> ParameterValues`
-- Function L396: `build_parameter_search_window_backtest(*, config: ParameterSearchConfig, window: ParameterSearchWindow, params: ParameterValues | Mapping[str, Any], trial_id: int = 1, name: str | None = None, return_summary_series: bool | None = None) -> PredictionMarketBacktest`
-- Function L420: `_build_backtest_kwargs(*, config: ParameterSearchConfig, trial_id: int, window: ParameterSearchWindow, params: ParameterValues) -> dict[str, Any]`
-- Function L446: `_default_evaluation_worker(worker_kwargs: dict[str, Any], result_path: str, send_conn) -> None`
-- Function L470: `_run_default_evaluator_in_subprocess(*, worker_kwargs: dict[str, Any]) -> object`
-- Function L520: `_coerce_results(value: object) -> list[dict[str, Any]]`
-- Function L535: `_series_values(series: object) -> list[float]`
-- Function L550: `_max_drawdown_currency(equity_series: object) -> float`
-- Function L563: `_joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float`
-- Function L631: `_as_float(value: object, *, default: float = 0.0) -> float`
-- Function L637: `_as_int(value: object, *, default: int = 0) -> int`
-- Function L645: `_score_result(*, pnl: float, max_drawdown_currency: float, fills: int, requested_coverage_ratio: float, terminated_early: bool, initial_cash: float, min_fills_per_window: int) -> float`
-- Function L663: `_evaluate_window(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues, window: ParameterSearchWindow) -> _WindowEvaluation`
-- Function L758: `_median_metric(values: Sequence[float]) -> float`
-- Function L762: `_build_leaderboard_row(*, trial_id: int, params: ParameterValues, train_evaluations: Sequence[_WindowEvaluation], holdout_evaluations: Sequence[_WindowEvaluation] = ()) -> ParameterSearchLeaderboardRow`
-- Function L813: `_train_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[float, int]`
-- Function L817: `_final_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[int, float, float, int]`
-- Function L825: `_params_dict(params: ParameterValues) -> dict[str, Any]`
-- Function L829: `_json_safe(value) -> Any`
-- Function L843: `_write_leaderboard_csv(*, rows: Sequence[ParameterSearchLeaderboardRow], output_path: Path) -> str`
-- Function L906: `_summary_payload(*, config: ParameterSearchConfig, summary: ParameterSearchSummary) -> dict[str, Any]`
-- Function L945: `_write_summary_json(*, config: ParameterSearchConfig, summary: ParameterSearchSummary, output_path: Path) -> str`
-- Function L958: `_format_score(value: float | None) -> str`
-- Function L964: `_print_top_candidates(*, rows: Sequence[ParameterSearchLeaderboardRow], holdout_enabled: bool) -> None`
-- Function L986: `_evaluate_train_windows(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues) -> tuple[_WindowEvaluation, ...]`
-- Function L1001: `_run_random_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
-- Function L1026: `_suggest_params_from_trial(trial, parameter_space: Mapping[str, ParameterSpec]) -> ParameterValues`
-- Function L1061: `_run_tpe_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
-- Function L1101: `run_parameter_search(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None = None) -> ParameterSearchSummary`
-- Class L52: `ParameterSearchWindow`
-- Class L59: `ParameterSearchConfig`
-  - Method L85: `optimizer_type(self) -> str`
-  - Method L88: `__post_init__(self) -> None`
-- Class L207: `ParameterSearchLeaderboardRow`
-- Class L225: `ParameterSearchSummary`
-  - Method L239: `optimizer_type(self) -> str`
-- Class L244: `_WindowEvaluation`
+- Imports: `__future__, collections, contextlib, csv, dataclasses, datetime, itertools, json, math, multiprocessing, pathlib, pickle, prediction_market_extensions, random, statistics, tempfile, traceback, types, typing, warnings`
+- Function L265: `_validate_parameter_spec(name: str, spec) -> ParameterSpec`
+- Function L341: `_numeric_bound(*, name: str, label: str, value) -> float`
+- Function L353: `_is_integral_bound(value) -> bool`
+- Function L363: `_normalize_discrete_values(*, name: str, values, label: str) -> tuple[Any, ...]`
+- Function L375: `_collect_search_placeholders(value) -> set[str]`
+- Function L388: `_replace_search_placeholders(value, params: Mapping[str, Any]) -> Any`
+- Function L404: `_candidate_identity(value) -> Any`
+- Function L437: `_candidate_key(params: ParameterValues) -> str`
+- Function L445: `_parameter_candidates(parameter_grid: Mapping[str, Sequence[Any]]) -> list[ParameterValues]`
+- Function L460: `_sample_parameter_sets(config: ParameterSearchConfig) -> list[ParameterValues]`
+- Function L470: `_windowed_replay(*, base_replay: ReplaySpec, window: ParameterSearchWindow) -> ReplaySpec`
+- Function L486: `_windowed_replays(*, base_replays: Sequence[ReplaySpec], window: ParameterSearchWindow) -> tuple[ReplaySpec, ...]`
+- Function L492: `_build_backtest(*, config: ParameterSearchConfig, trial_id: int, window: ParameterSearchWindow, params: ParameterValues) -> PredictionMarketBacktest`
+- Function L513: `_coerce_parameter_values(*, config: ParameterSearchConfig, params: ParameterValues | Mapping[str, Any]) -> ParameterValues`
+- Function L521: `build_parameter_search_window_backtest(*, config: ParameterSearchConfig, window: ParameterSearchWindow, params: ParameterValues | Mapping[str, Any], trial_id: int = 1, name: str | None = None, return_summary_series: bool | None = None) -> PredictionMarketBacktest`
+- Function L545: `_build_backtest_kwargs(*, config: ParameterSearchConfig, trial_id: int, window: ParameterSearchWindow, params: ParameterValues) -> dict[str, Any]`
+- Function L571: `_default_evaluation_worker(worker_kwargs: dict[str, Any], result_path: str, send_conn) -> None`
+- Function L595: `_run_default_evaluator_in_subprocess(*, worker_kwargs: dict[str, Any]) -> object`
+- Function L645: `_coerce_results(value: object) -> list[dict[str, Any]]`
+- Function L660: `_replay_result_key_from_replay(replay: ReplaySpec) -> tuple[str, str] | None`
+- Function L668: `_replay_result_key_from_result(result: Mapping[str, Any]) -> tuple[str, str] | None`
+- Function L682: `_format_replay_result_keys(keys: Sequence[tuple[str, str]]) -> str`
+- Function L686: `_validate_result_market_coverage(*, config: ParameterSearchConfig, results: Sequence[Mapping[str, Any]]) -> str | None`
+- Function L723: `_joint_portfolio_equity_series_from_results(results: Sequence[Mapping[str, Any]]) -> tuple[object | None, str | None]`
+- Function L751: `_coerce_finite_series_value(value: object, *, name: str) -> tuple[float | None, str | None]`
+- Function L763: `_series_values_checked(series: object, *, name: str) -> tuple[list[float], str | None]`
+- Function L788: `_series_values(series: object) -> list[float]`
+- Function L793: `_max_drawdown_currency(equity_series: object) -> float`
+- Function L806: `_joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float`
+- Function L876: `_as_float(value: object, *, default: float = 0.0) -> float`
+- Function L884: `_as_int(value: object, *, default: int = 0) -> int`
+- Function L894: `_finite_float_metric(value: object, *, name: str) -> tuple[float | None, str | None]`
+- Function L903: `_finite_int_metric(value: object, *, name: str) -> tuple[int | None, str | None]`
+- Function L922: `_score_result(*, pnl: float, max_drawdown_currency: float, fills: int, requested_coverage_ratio: float, terminated_early: bool, initial_cash: float, min_fills_per_window: int) -> float`
+- Function L940: `_evaluate_window(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues, window: ParameterSearchWindow) -> _WindowEvaluation`
+- Function L1164: `_median_metric(values: Sequence[float]) -> float`
+- Function L1168: `_phase_median_score(evaluations: Sequence[_WindowEvaluation], *, invalid_score: float) -> float`
+- Function L1178: `_build_leaderboard_row(*, trial_id: int, params: ParameterValues, train_evaluations: Sequence[_WindowEvaluation], holdout_evaluations: Sequence[_WindowEvaluation] = (), invalid_score: float = DEFAULT_INVALID_SCORE) -> ParameterSearchLeaderboardRow`
+- Function L1234: `_train_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[float, int]`
+- Function L1238: `_final_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[int, float, float, int]`
+- Function L1246: `_params_dict(params: ParameterValues) -> dict[str, Any]`
+- Function L1250: `_json_safe(value) -> Any`
+- Function L1270: `_write_leaderboard_csv(*, rows: Sequence[ParameterSearchLeaderboardRow], output_path: Path) -> str`
+- Function L1337: `_summary_payload(*, config: ParameterSearchConfig, summary: ParameterSearchSummary) -> dict[str, Any]`
+- Function L1376: `_write_summary_json(*, config: ParameterSearchConfig, summary: ParameterSearchSummary, output_path: Path) -> str`
+- Function L1389: `_format_score(value: float | None) -> str`
+- Function L1395: `_print_top_candidates(*, rows: Sequence[ParameterSearchLeaderboardRow], holdout_enabled: bool) -> None`
+- Function L1417: `_evaluate_train_windows(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues) -> tuple[_WindowEvaluation, ...]`
+- Function L1432: `_run_random_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
+- Function L1460: `_suggest_params_from_trial(trial, parameter_space: Mapping[str, ParameterSpec]) -> ParameterValues`
+- Function L1495: `_run_tpe_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
+- Function L1538: `run_parameter_search(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None = None) -> ParameterSearchSummary`
+- Class L54: `ParameterSearchWindow`
+- Class L61: `ParameterSearchConfig`
+  - Method L87: `optimizer_type(self) -> str`
+  - Method L90: `__post_init__(self) -> None`
+- Class L216: `ParameterSearchLeaderboardRow`
+- Class L234: `ParameterSearchSummary`
+  - Method L248: `optimizer_type(self) -> str`
+- Class L253: `_WindowEvaluation`
 
 ### `prediction_market_extensions/backtesting/_prediction_market_backtest.py`
 - Imports: `__future__, asyncio, collections, datetime, nautilus_trader, pandas, prediction_market_extensions, typing, warnings`
-- Function L73: `_record_ts_event(record) -> int | None`
-- Function L83: `_largest_record_gap_ns(records: Sequence[Any]) -> int | None`
-- Function L97: `_emit_engine_status(engine: BacktestEngine, message: str) -> None`
-- Function L109: `_serialize_engine_result_stats(engine_result) -> dict[str, Any]`
-- Function L513: `_LoadedMarketSim(*, spec: ReplaySpec, instrument, records: Sequence[Any], count: int, count_key: str, market_key: str, market_id: str, outcome: str, realized_outcome: float | None, prices: Sequence[float], metadata: Mapping[str, Any] | None, requested_start_ns: int | None, requested_end_ns: int | None) -> LoadedReplay`
-- Class L121: `PredictionMarketBacktest`
-  - Method L122: `__init__(self, *, name: str, data: MarketDataConfig, replays: Sequence[ReplaySpec], strategy_configs: Sequence[StrategyConfigSpec] = (), strategy_factory: StrategyFactory | None = None, initial_cash: float, probability_window: int, min_book_events: int = 0, min_price_range: float = 0.0, default_lookback_days: int | None = None, default_lookback_hours: float | None = None, default_start_time: pd.Timestamp | datetime | str | None = None, default_end_time: pd.Timestamp | datetime | str | None = None, nautilus_log_level: str = 'INFO', execution: ExecutionModelConfig | None = None, chart_resample_rule: str | None = None, return_summary_series: bool = False) -> None`
-  - Method L170: `_strategy_summary_label(self) -> str`
-  - Method L177: `run(self) -> list[dict[str, Any]]`
-  - Method L187: `run_backtest(self) -> list[dict[str, Any]]`
-  - Method L190: `async run_async(self) -> list[dict[str, Any]]`
-  - Method L263: `async run_backtest_async(self) -> list[dict[str, Any]]`
-  - Method L266: `_create_artifact_builder(self) -> PredictionMarketArtifactBuilder`
-  - Method L278: `_build_result(self, *, loaded_sim: LoadedReplay, fills_report: pd.DataFrame, positions_report: pd.DataFrame, market_artifacts: Mapping[str, Any] | None = None, joint_portfolio_artifacts: Mapping[str, Any] | None = None, run_state: dict[str, Any] | None = None) -> dict[str, Any]`
-  - Method L297: `_build_market_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay], fills_report: pd.DataFrame) -> dict[str, dict[str, Any]]`
-  - Method L308: `_build_joint_portfolio_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay]) -> dict[str, Any]`
-  - Method L315: `_normalize_replays(self, replays: Sequence[ReplaySpec]) -> tuple[ReplaySpec, ...]`
-  - Method L328: `_load_request(self) -> ReplayLoadRequest`
-  - Method L338: `async _load_sims_async(self) -> list[LoadedReplay]`
-  - Method L362: `_build_engine(self) -> BacktestEngine`
-  - Method L397: `_build_importable_strategy_configs(self, loaded_sims: Sequence[LoadedReplay]) -> list[Any]`
-  - Method L419: `_is_batch_strategy_config(self, strategy_spec: StrategyConfigSpec) -> bool`
-  - Method L428: `_contains_value(self, value, target: str) -> bool`
-  - Method L437: `_bind_strategy_spec(self, *, strategy_spec: StrategyConfigSpec, loaded_sim: LoadedReplay, all_instrument_ids: Sequence[InstrumentId]) -> StrategyConfigSpec`
-  - Method L465: `_bind_value(self, value, *, instrument_id: InstrumentId, all_instrument_ids: Sequence[InstrumentId], metadata: Mapping[str, Any]) -> Any`
+- Function L86: `_default_prediction_market_execution() -> ExecutionModelConfig`
+- Function L93: `_record_ts_event(record) -> int | None`
+- Function L103: `_largest_record_gap_ns(records: Sequence[Any]) -> int | None`
+- Function L117: `_emit_engine_status(engine: BacktestEngine, message: str) -> None`
+- Function L129: `_serialize_engine_result_stats(engine_result) -> dict[str, Any]`
+- Function L141: `_install_prediction_market_order_guard(strategy: Strategy, order_guard: PredictionMarketOrderGuard) -> Strategy`
+- Function L148: `_apply_order_guard_warnings(results: list[dict[str, Any]], order_guard: PredictionMarketOrderGuard) -> None`
+- Function L158: `_timestamp_ns_from_iso(value: object | None) -> int | None`
+- Function L174: `_iso_from_nanos(timestamp_ns: int) -> str`
+- Function L178: `_run_state_for_loaded_sim(*, data: Sequence[Any], backtest_end_ns: int | None, forced_stop: bool, loaded_sim: LoadedReplay) -> dict[str, Any]`
+- Function L615: `_LoadedMarketSim(*, spec: ReplaySpec, instrument, records: Sequence[Any], count: int, count_key: str, market_key: str, market_id: str, outcome: str, realized_outcome: float | None, prices: Sequence[float], metadata: Mapping[str, Any] | None, requested_start_ns: int | None, requested_end_ns: int | None) -> LoadedReplay`
+- Class L210: `PredictionMarketBacktest`
+  - Method L211: `__init__(self, *, name: str, data: MarketDataConfig, replays: Sequence[ReplaySpec], strategy_configs: Sequence[StrategyConfigSpec] = (), strategy_factory: StrategyFactory | None = None, initial_cash: float, probability_window: int, min_book_events: int = 0, min_price_range: float = 0.0, default_lookback_days: int | None = None, default_lookback_hours: float | None = None, default_start_time: pd.Timestamp | datetime | str | None = None, default_end_time: pd.Timestamp | datetime | str | None = None, nautilus_log_level: str = 'INFO', execution: ExecutionModelConfig | None = None, chart_resample_rule: str | None = None, return_summary_series: bool = False) -> None`
+  - Method L261: `_strategy_summary_label(self) -> str`
+  - Method L268: `run(self) -> list[dict[str, Any]]`
+  - Method L278: `run_backtest(self) -> list[dict[str, Any]]`
+  - Method L281: `async run_async(self) -> list[dict[str, Any]]`
+  - Method L365: `async run_backtest_async(self) -> list[dict[str, Any]]`
+  - Method L368: `_create_artifact_builder(self) -> PredictionMarketArtifactBuilder`
+  - Method L380: `_build_result(self, *, loaded_sim: LoadedReplay, fills_report: pd.DataFrame, positions_report: pd.DataFrame, market_artifacts: Mapping[str, Any] | None = None, joint_portfolio_artifacts: Mapping[str, Any] | None = None, run_state: dict[str, Any] | None = None) -> dict[str, Any]`
+  - Method L399: `_build_market_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay], fills_report: pd.DataFrame) -> dict[str, dict[str, Any]]`
+  - Method L410: `_build_joint_portfolio_artifacts(self, *, engine: BacktestEngine, loaded_sims: Sequence[LoadedReplay]) -> dict[str, Any]`
+  - Method L417: `_normalize_replays(self, replays: Sequence[ReplaySpec]) -> tuple[ReplaySpec, ...]`
+  - Method L430: `_load_request(self) -> ReplayLoadRequest`
+  - Method L440: `async _load_sims_async(self) -> list[LoadedReplay]`
+  - Method L464: `_build_engine(self) -> BacktestEngine`
+  - Method L499: `_build_importable_strategy_configs(self, loaded_sims: Sequence[LoadedReplay]) -> list[Any]`
+  - Method L521: `_is_batch_strategy_config(self, strategy_spec: StrategyConfigSpec) -> bool`
+  - Method L530: `_contains_value(self, value, target: str) -> bool`
+  - Method L539: `_bind_strategy_spec(self, *, strategy_spec: StrategyConfigSpec, loaded_sim: LoadedReplay, all_instrument_ids: Sequence[InstrumentId]) -> StrategyConfigSpec`
+  - Method L567: `_bind_value(self, value, *, instrument_id: InstrumentId, all_instrument_ids: Sequence[InstrumentId], metadata: Mapping[str, Any]) -> Any`
+
+### `prediction_market_extensions/backtesting/_prediction_market_order_guard.py`
+- Imports: `__future__, dataclasses, decimal, nautilus_trader, types`
+- Function L13: `_decimal_or_none(value: object) -> Decimal | None`
+- Function L31: `_call_or_value(value: object) -> object`
+- Function L40: `_order_side(order: object) -> OrderSide | None`
+- Function L56: `_order_quantity(order: object) -> Decimal | None`
+- Function L60: `_order_leaves_quantity(order: object) -> Decimal | None`
+- Function L67: `_order_price(order: object) -> Decimal | None`
+- Function L74: `_order_type(order: object) -> OrderType | None`
+- Function L79: `_client_order_id(order: object) -> str`
+- Function L83: `_event_order_is_closed(strategy: object, event: object) -> bool`
+- Function L97: `_prediction_market_instrument(instrument: object | None) -> bool`
+- Function L103: `_best_book_price(strategy: object, order: object, side: OrderSide) -> Decimal | None`
+- Function L128: `_buy_reference_price(strategy: object, order: object) -> Decimal`
+- Function L138: `_fee_rate(instrument: object | None, *, taker: bool) -> Decimal`
+- Function L148: `_buy_cash_cost(*, strategy: object, order: object, instrument: object | None, quantity: Decimal) -> Decimal`
+- Function L162: `_free_quote_balance(strategy: object, instrument: object) -> Decimal | None`
+- Function L173: `_long_position_qty(strategy: object, instrument_id: object) -> Decimal`
+- Class L189: `_Reservation`
+- Class L198: `PredictionMarketOrderGuard`
+  - Method L201: `__init__(self) -> None`
+  - Method L205: `install(self, strategy: object) -> None`
+  - Method L240: `_strategy_key(self, strategy: object) -> int`
+  - Method L243: `_reservation_key(self, strategy: object, order_or_client_order_id: object) -> _ReservationKey`
+  - Method L252: `_clear_strategy_reservations(self, strategy: object) -> None`
+  - Method L262: `_wrap_reset_event(self, strategy: object) -> None`
+  - Method L275: `_wrap_order_event(self, strategy: object, handler_name: str, *, release_on_closed: bool) -> None`
+  - Method L300: `_check_order(self, strategy: object, order: object) -> tuple[bool, str, _Reservation | None]`
+  - Method L376: `_deny_order(self, strategy: object, order: object, reason: str) -> None`
+  - Method L398: `_refresh_reservation(self, strategy: object, reservation_key: _ReservationKey, *, client_order_id: object, event: object | None = None) -> None`
+  - Method L445: `_reduce_reservation_from_fill(self, existing: _Reservation, *, event: object | None, side: OrderSide | None) -> None`
 
 ### `prediction_market_extensions/backtesting/_prediction_market_runner.py`
 - Imports: `__future__, collections, datetime, nautilus_trader, pandas, prediction_market_extensions, typing`
@@ -885,28 +980,36 @@ flowchart TD
 
 ### `prediction_market_extensions/backtesting/_result_policies.py`
 - Imports: `__future__, collections, dataclasses, pandas, prediction_market_extensions, typing`
-- Function L26: `_timestamp_ns(value: object | None) -> int | None`
-- Function L50: `_timestamp_utc(value: object | None) -> pd.Timestamp | None`
-- Function L75: `_coerce_float(value: object | None) -> float | None`
-- Function L85: `_pairs_to_series(pairs: object) -> pd.Series`
-- Function L109: `_series_to_pairs(series: pd.Series) -> list[tuple[str, float]]`
-- Function L117: `_series_value_at_or_before(series: pd.Series, timestamp: pd.Timestamp) -> float | None`
-- Function L126: `_fill_event_timestamp(event: Mapping[object, object]) -> pd.Timestamp | None`
-- Function L134: `_binary_mark_to_market_pnl_at_settlement(*, fill_events: object, price_series: object, timestamp: pd.Timestamp) -> tuple[float, float] | None`
-- Function L191: `_series_bounds(*series_values: object) -> tuple[pd.Timestamp | None, pd.Timestamp | None]`
-- Function L202: `_set_series_value_at_and_after(series: pd.Series, *, timestamp: pd.Timestamp, value: float) -> pd.Series`
-- Function L215: `_add_series_delta_at_and_after(series: pd.Series, *, timestamp: pd.Timestamp, delta: float) -> pd.Series`
-- Function L231: `_add_settlement_delta_to_equity_like_series(series: pd.Series, *, timestamp: pd.Timestamp, settlement_delta: float, post_settlement_delta: float) -> pd.Series`
-- Function L256: `_settlement_timestamp(result: Mapping[str, Any], *, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> pd.Timestamp | None`
-- Function L289: `_apply_settlement_to_summary_series(result: dict[str, Any], *, settlement_pnl: float, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> None`
-- Function L366: `append_result_warning(result: dict[str, Any], message: str) -> None`
-- Function L375: `apply_repo_research_disclosures(results: Results) -> Results`
-- Function L388: `apply_binary_settlement_pnl(result: dict[str, Any], *, settlement_pnl_fn: SettlementPnlFn = compute_binary_settlement_pnl, pnl_key: str = 'pnl', market_exit_pnl_key: str = 'market_exit_pnl', fill_events_key: str = 'fill_events', realized_outcome_key: str = 'realized_outcome', settlement_observable_ns_key: str = 'settlement_observable_ns', settlement_observable_time_key: str = 'settlement_observable_time', simulated_through_key: str = 'simulated_through') -> dict[str, Any]`
-- Function L449: `apply_joint_portfolio_settlement_pnl(results: Results) -> Results`
-- Class L384: `ResultPolicy(Protocol)`
-  - Method L385: `apply(self, results: Results) -> Results | None`
-- Class L521: `BinarySettlementPnlPolicy`
-  - Method L528: `apply(self, results: Results) -> Results`
+- Function L27: `_timestamp_ns(value: object | None) -> int | None`
+- Function L61: `_timestamp_utc(value: object | None) -> pd.Timestamp | None`
+- Function L86: `_coerce_float(value: object | None) -> float | None`
+- Function L96: `_pairs_to_series(pairs: object) -> pd.Series`
+- Function L120: `_series_to_pairs(series: pd.Series) -> list[tuple[str, float]]`
+- Function L128: `_series_value_at_or_before(series: pd.Series, timestamp: pd.Timestamp) -> float | None`
+- Function L137: `_fill_event_timestamp(event: Mapping[object, object]) -> pd.Timestamp | None`
+- Function L145: `_explicit_settlement_cutoff_timestamp(result: Mapping[str, Any], *, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> pd.Timestamp | None`
+- Function L163: `_settlement_observable_timestamp(result: Mapping[str, Any], *, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> pd.Timestamp | None`
+- Function L177: `_fill_events_at_or_before(fill_events: object, timestamp: pd.Timestamp | None) -> tuple[object, int]`
+- Function L201: `_fill_event_count(fill_events: object) -> int | None`
+- Function L207: `_mapping_fill_events(fill_events: object) -> list[Mapping[object, object]]`
+- Function L213: `_binary_mark_to_market_pnl_at_settlement(*, fill_events: object, price_series: object, timestamp: pd.Timestamp) -> tuple[float, float] | None`
+- Function L268: `_fill_inventory_bounds(fill_events: object) -> tuple[float, float] | None`
+- Function L297: `_set_realism_invalid(result: dict[str, Any], *, stop_reason: str, warning: str) -> None`
+- Function L311: `_apply_result_integrity_checks(result: dict[str, Any], *, fill_events_key: str) -> dict[str, Any]`
+- Function L350: `_series_bounds(*series_values: object) -> tuple[pd.Timestamp | None, pd.Timestamp | None]`
+- Function L361: `_set_series_value_at_and_after(series: pd.Series, *, timestamp: pd.Timestamp, value: float) -> pd.Series`
+- Function L374: `_add_series_delta_at_and_after(series: pd.Series, *, timestamp: pd.Timestamp, delta: float) -> pd.Series`
+- Function L390: `_add_settlement_delta_to_equity_like_series(series: pd.Series, *, timestamp: pd.Timestamp, settlement_delta: float, post_settlement_delta: float) -> pd.Series`
+- Function L415: `_settlement_timestamp(result: Mapping[str, Any], *, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> pd.Timestamp | None`
+- Function L451: `_apply_settlement_to_summary_series(result: dict[str, Any], *, settlement_pnl: float, fill_events_key: str, settlement_observable_ns_key: str, settlement_observable_time_key: str) -> None`
+- Function L542: `append_result_warning(result: dict[str, Any], message: str) -> None`
+- Function L551: `apply_repo_research_disclosures(results: Results) -> Results`
+- Function L564: `apply_binary_settlement_pnl(result: dict[str, Any], *, settlement_pnl_fn: SettlementPnlFn = compute_binary_settlement_pnl, pnl_key: str = 'pnl', market_exit_pnl_key: str = 'market_exit_pnl', fill_events_key: str = 'fill_events', realized_outcome_key: str = 'realized_outcome', settlement_observable_ns_key: str = 'settlement_observable_ns', settlement_observable_time_key: str = 'settlement_observable_time', simulated_through_key: str = 'simulated_through', planned_end_key: str = 'planned_end') -> dict[str, Any]`
+- Function L690: `apply_joint_portfolio_settlement_pnl(results: Results) -> Results`
+- Class L560: `ResultPolicy(Protocol)`
+  - Method L561: `apply(self, results: Results) -> Results | None`
+- Class L762: `BinarySettlementPnlPolicy`
+  - Method L769: `apply(self, results: Results) -> Results`
 
 ### `prediction_market_extensions/backtesting/_strategy_configs.py`
 - Imports: `__future__, collections, copy, nautilus_trader, typing`
@@ -982,22 +1085,22 @@ flowchart TD
 ### `prediction_market_extensions/backtesting/data_sources/pmxt.py`
 - Imports: `__future__, collections, contextlib, contextvars, dataclasses, os, pathlib, prediction_market_extensions, pyarrow, threading, time, urllib`
 - Function L80: `_current_loader_config() -> PMXTLoaderConfig | None`
-- Function L615: `_normalize_mode(value: str | None) -> str`
-- Function L629: `_env_value(name: str) -> str | None`
-- Function L637: `_env_enabled(name: str) -> bool`
-- Function L644: `_resolve_prefetch_workers_override(*, default_when_unset: int | None) -> int | None`
-- Function L654: `_resolve_source_priority_override() -> tuple[str, ...]`
-- Function L674: `_resolve_existing_remote_url() -> str | None`
-- Function L679: `_resolve_existing_remote_urls() -> tuple[str, ...]`
-- Function L695: `_resolve_required_directory(env_name: str, *, label: str) -> Path`
-- Function L708: `_strip_prefixed_local_source(source: str, *, prefixes: Sequence[str]) -> str | None`
-- Function L718: `_strip_prefixed_remote_source(source: str, *, prefixes: Sequence[str]) -> str | None`
-- Function L728: `_classify_explicit_pmxt_sources(sources: Sequence[str]) -> tuple[str | None, tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[tuple[str, str], ...]]`
-- Function L804: `_explicit_source_summary(*, ordered_sources: Sequence[str], ordered_entries: Sequence[tuple[str, str]] = ()) -> str`
-- Function L822: `resolve_pmxt_loader_config(*, sources: Sequence[str] | None = None) -> tuple[PMXTDataSourceSelection, PMXTLoaderConfig]`
-- Function L960: `_loader_config_to_env_updates(config: PMXTLoaderConfig) -> dict[str, str | None]`
-- Function L974: `resolve_pmxt_data_source_selection(*, sources: Sequence[str] | None = None) -> tuple[PMXTDataSourceSelection, dict[str, str | None]]`
-- Function L984: `configured_pmxt_data_source(*, sources: Sequence[str] | None = None) -> Iterator[PMXTDataSourceSelection]`
+- Function L731: `_normalize_mode(value: str | None) -> str`
+- Function L745: `_env_value(name: str) -> str | None`
+- Function L753: `_env_enabled(name: str) -> bool`
+- Function L760: `_resolve_prefetch_workers_override(*, default_when_unset: int | None) -> int | None`
+- Function L770: `_resolve_source_priority_override() -> tuple[str, ...]`
+- Function L790: `_resolve_existing_remote_url() -> str | None`
+- Function L795: `_resolve_existing_remote_urls() -> tuple[str, ...]`
+- Function L811: `_resolve_required_directory(env_name: str, *, label: str) -> Path`
+- Function L824: `_strip_prefixed_local_source(source: str, *, prefixes: Sequence[str]) -> str | None`
+- Function L834: `_strip_prefixed_remote_source(source: str, *, prefixes: Sequence[str]) -> str | None`
+- Function L844: `_classify_explicit_pmxt_sources(sources: Sequence[str]) -> tuple[str | None, tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[tuple[str, str], ...]]`
+- Function L920: `_explicit_source_summary(*, ordered_sources: Sequence[str], ordered_entries: Sequence[tuple[str, str]] = ()) -> str`
+- Function L938: `resolve_pmxt_loader_config(*, sources: Sequence[str] | None = None) -> tuple[PMXTDataSourceSelection, PMXTLoaderConfig]`
+- Function L1076: `_loader_config_to_env_updates(config: PMXTLoaderConfig) -> dict[str, str | None]`
+- Function L1090: `resolve_pmxt_data_source_selection(*, sources: Sequence[str] | None = None) -> tuple[PMXTDataSourceSelection, dict[str, str | None]]`
+- Function L1100: `configured_pmxt_data_source(*, sources: Sequence[str] | None = None) -> Iterator[PMXTDataSourceSelection]`
 - Class L61: `PMXTLoaderConfig`
   - Method L71: `remote_base_url(self) -> str | None`
 - Class L84: `RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader)`
@@ -1009,24 +1112,28 @@ flowchart TD
   - Method L163: `_archive_urls_for_hour(self, hour) -> Any`
   - Method L171: `_raw_path_for_hour(self, hour) -> Path | None`
   - Method L184: `_raw_paths_for_hour_at_root(self, raw_root: Path, hour) -> tuple[Path, ...]`
-  - Method L187: `_load_local_raw_market_batches_from_root(self, raw_root: Path, hour, *, batch_size: int) -> Any`
-  - Method L215: `_load_local_raw_market_batches(self, hour, *, batch_size: int) -> Any`
-  - Method L225: `_load_local_archive_market_batches(self, hour, *, batch_size: int) -> Any`
-  - Method L231: `_load_remote_market_batches(self, hour, *, batch_size: int) -> Any`
-  - Method L252: `_archive_url_for_base_url(self, base_url: str, hour) -> str`
-  - Method L255: `_load_remote_market_batches_from_base_url(self, base_url: str, hour, *, batch_size: int) -> Any`
-  - Method L268: `_resolve_source_priority(cls) -> tuple[str, ...]`
-  - Method L292: `_resolve_prefetch_workers(cls) -> int`
-  - Method L299: `_scoped_source_entry(self, kind: str, target: str) -> Any`
-  - Method L325: `_load_entry_batches(self, kind: str, hour, *, batch_size: int) -> Any`
-  - Method L346: `_load_ordered_entry_batches(self, kind: str, target: str, hour, *, batch_size: int) -> Any`
-  - Method L368: `_write_cache_if_enabled(self, hour, table) -> None`
-  - Method L373: `_load_market_table(self, hour, *, batch_size: int) -> Any`
-  - Method L431: `_load_market_batches(self, hour, *, batch_size: int) -> Any`
-  - Method L485: `_download_to_file_with_progress(self, url: str, destination: Path) -> int | None`
-  - Method L538: `_download_payload_with_progress(self, url: str) -> bytes | None`
-  - Method L578: `_progress_total_bytes(self, source: str) -> int | None`
-- Class L610: `PMXTDataSourceSelection`
+  - Method L187: `_local_source_fingerprint_for_hour(self, raw_root: Path, hour) -> dict[str, object] | None`
+  - Method L195: `_remote_source_fingerprint_for_hour(self, base_url: str, hour) -> dict[str, object]`
+  - Method L223: `_source_fingerprint_for_entry(self, kind: str, target: str, hour) -> dict[str, object] | None`
+  - Method L232: `_source_cache_fingerprint_for_hour(self, hour) -> Any`
+  - Method L263: `_load_local_raw_market_batches_from_root(self, raw_root: Path, hour, *, batch_size: int) -> Any`
+  - Method L291: `_load_local_raw_market_batches(self, hour, *, batch_size: int) -> Any`
+  - Method L301: `_load_local_archive_market_batches(self, hour, *, batch_size: int) -> Any`
+  - Method L307: `_load_remote_market_batches(self, hour, *, batch_size: int) -> Any`
+  - Method L328: `_archive_url_for_base_url(self, base_url: str, hour) -> str`
+  - Method L331: `_load_remote_market_batches_from_base_url(self, base_url: str, hour, *, batch_size: int) -> Any`
+  - Method L344: `_resolve_source_priority(cls) -> tuple[str, ...]`
+  - Method L368: `_resolve_prefetch_workers(cls) -> int`
+  - Method L375: `_scoped_source_entry(self, kind: str, target: str) -> Any`
+  - Method L401: `_load_entry_batches(self, kind: str, hour, *, batch_size: int) -> Any`
+  - Method L422: `_load_ordered_entry_batches(self, kind: str, target: str, hour, *, batch_size: int) -> Any`
+  - Method L444: `_write_cache_if_enabled(self, hour, table, *, source: dict[str, object] | None) -> None`
+  - Method L459: `_load_market_table(self, hour, *, batch_size: int) -> Any`
+  - Method L532: `_load_market_batches(self, hour, *, batch_size: int) -> Any`
+  - Method L601: `_download_to_file_with_progress(self, url: str, destination: Path) -> int | None`
+  - Method L654: `_download_payload_with_progress(self, url: str) -> bytes | None`
+  - Method L694: `_progress_total_bytes(self, source: str) -> int | None`
+- Class L726: `PMXTDataSourceSelection`
 
 ### `prediction_market_extensions/backtesting/data_sources/polymarket_native.py`
 - Imports: `__future__, collections, contextlib, contextvars, dataclasses, msgspec, os, prediction_market_extensions, typing, urllib, warnings`
@@ -1068,119 +1175,136 @@ flowchart TD
 - Class L16: `MarketDataSupport`
 
 ### `prediction_market_extensions/backtesting/data_sources/replay_adapters.py`
-- Imports: `__future__, collections, contextlib, dataclasses, datetime, importlib, nautilus_trader, os, pandas, pathlib, prediction_market_extensions, time, typing`
-- Function L50: `_resolve_backtest_compat_symbol(name: str, default) -> Any`
-- Function L60: `_loader_realized_outcome(loader) -> float | None`
-- Function L68: `_normalize_timestamp(value: object | None, *, default_now: bool = False) -> pd.Timestamp`
-- Function L84: `_loaded_window(records: tuple[object, ...]) -> ReplayWindow | None`
-- Function L100: `_requested_window(start: pd.Timestamp, end: pd.Timestamp) -> ReplayWindow`
-- Function L104: `_price_range(prices: tuple[float, ...]) -> float`
-- Function L110: `_best_book_midpoint(book: OrderBook) -> float | None`
-- Function L118: `_book_event_count_and_midpoints(*, instrument, records: tuple[object, ...], deltas_type: type[Any]) -> tuple[int, tuple[float, ...]]`
-- Function L135: `_validate_replay_window(*, market_label: str, count_label: str, count: int, min_record_count: int, prices: tuple[float, ...], min_price_range: float) -> bool`
-- Function L155: `_cache_home() -> Path`
-- Function L160: `_trade_cache_path(*, loader, date: pd.Timestamp) -> Path | None`
-- Function L175: `_trade_record_sort_key(record: TradeTick) -> tuple[int, int]`
-- Function L179: `_serialize_trade_ticks(trades: tuple[TradeTick, ...]) -> pd.DataFrame`
-- Function L194: `_deserialize_trade_ticks(*, loader, frame: pd.DataFrame) -> tuple[TradeTick, ...]`
-- Function L219: `_write_trade_cache(*, path: Path, trades: tuple[TradeTick, ...]) -> None`
-- Function L227: `_trade_day_label(day: pd.Timestamp) -> str`
-- Function L231: `_print_trade_progress_header(*, market_label: str, start: pd.Timestamp, end: pd.Timestamp) -> None`
-- Function L240: `_print_trade_progress_line(*, day: pd.Timestamp, elapsed_secs: float, rows: int, source: str) -> None`
-- Function L250: `async _load_trade_ticks(loader, *, start: pd.Timestamp, end: pd.Timestamp, market_label: str) -> tuple[TradeTick, ...]`
-- Function L291: `_record_sort_key(record: object) -> tuple[int, int, int]`
-- Function L298: `_merge_records(*, book_records: tuple[OrderBookDeltas, ...], trade_records: tuple[TradeTick, ...]) -> tuple[object, ...]`
-- Class L319: `_BaseReplayAdapter(HistoricalReplayAdapter)`
-  - Method L329: `key(self) -> ReplayAdapterKey`
-  - Method L333: `replay_spec_type(self) -> type[Any]`
-  - Method L336: `configure_sources(self, *, sources: tuple[str, ...] | list[str]) -> AbstractContextManager[Any]`
-  - Method L342: `engine_profile(self) -> ReplayEngineProfile`
-  - Method L345: `build_single_market_replay(self, *, field_values: Mapping[str, Any]) -> Any`
-  - Method L357: `_build_loaded_replay(self, *, replay, instrument, records: tuple[Any, ...], count: int, count_key: str, market_key: str, market_id: str, prices: tuple[float, ...], outcome: str, realized_outcome: float | None, metadata: dict[str, Any], requested_window: ReplayWindow) -> LoadedReplay`
-- Class L393: `PolymarketPMXTBookReplayAdapter(_BaseReplayAdapter)`
-  - Method L394: `__init__(self) -> None`
-  - Method L421: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
-- Class L504: `PolymarketTelonexBookReplayAdapter(_BaseReplayAdapter)`
-  - Method L505: `__init__(self) -> None`
-  - Method L535: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
+- Imports: `__future__, collections, contextlib, dataclasses, datetime, importlib, nautilus_trader, os, pandas, pathlib, prediction_market_extensions, time, typing, warnings`
+- Function L51: `_resolve_backtest_compat_symbol(name: str, default) -> Any`
+- Function L61: `_loader_realized_outcome(loader) -> float | None`
+- Function L69: `_normalize_timestamp(value: object | None, *, default_now: bool = False) -> pd.Timestamp`
+- Function L85: `_loaded_window(records: tuple[object, ...]) -> ReplayWindow | None`
+- Function L101: `_instrument_expiration_ns(instrument) -> int | None`
+- Function L110: `_clip_records_at_instrument_expiration(*, instrument, records: tuple[object, ...], market_label: str) -> tuple[tuple[object, ...], dict[str, Any]]`
+- Function L141: `_book_is_crossed(book: OrderBook) -> bool`
+- Function L147: `_drop_crossed_l2_book_records(*, instrument, records: tuple[object, ...], deltas_type: type[Any], market_label: str) -> tuple[tuple[object, ...], dict[str, Any]]`
+- Function L210: `_requested_window(start: pd.Timestamp, end: pd.Timestamp) -> ReplayWindow`
+- Function L214: `_price_range(prices: tuple[float, ...]) -> float`
+- Function L220: `_best_book_midpoint(book: OrderBook) -> float | None`
+- Function L228: `_book_event_count_and_midpoints(*, instrument, records: tuple[object, ...], deltas_type: type[Any]) -> tuple[int, tuple[float, ...]]`
+- Function L245: `_validate_replay_window(*, market_label: str, count_label: str, count: int, min_record_count: int, prices: tuple[float, ...], min_price_range: float) -> bool`
+- Function L265: `_cache_home() -> Path`
+- Function L270: `_trade_cache_path(*, loader, date: pd.Timestamp) -> Path | None`
+- Function L285: `_trade_record_sort_key(record: TradeTick) -> tuple[int, int]`
+- Function L289: `_serialize_trade_ticks(trades: tuple[TradeTick, ...]) -> pd.DataFrame`
+- Function L304: `_deserialize_trade_ticks(*, loader, frame: pd.DataFrame) -> tuple[TradeTick, ...]`
+- Function L329: `_write_trade_cache(*, path: Path, trades: tuple[TradeTick, ...]) -> None`
+- Function L337: `_trade_day_label(day: pd.Timestamp) -> str`
+- Function L341: `_print_trade_progress_header(*, market_label: str, start: pd.Timestamp, end: pd.Timestamp) -> None`
+- Function L350: `_print_trade_progress_line(*, day: pd.Timestamp, elapsed_secs: float, rows: int, source: str) -> None`
+- Function L360: `async _load_trade_ticks(loader, *, start: pd.Timestamp, end: pd.Timestamp, market_label: str) -> tuple[TradeTick, ...]`
+- Function L401: `_record_sort_key(record: object) -> tuple[int, int, int]`
+- Function L408: `_merge_records(*, book_records: tuple[OrderBookDeltas, ...], trade_records: tuple[TradeTick, ...]) -> tuple[object, ...]`
+- Class L429: `_BaseReplayAdapter(HistoricalReplayAdapter)`
+  - Method L439: `key(self) -> ReplayAdapterKey`
+  - Method L443: `replay_spec_type(self) -> type[Any]`
+  - Method L446: `configure_sources(self, *, sources: tuple[str, ...] | list[str]) -> AbstractContextManager[Any]`
+  - Method L452: `engine_profile(self) -> ReplayEngineProfile`
+  - Method L455: `build_single_market_replay(self, *, field_values: Mapping[str, Any]) -> Any`
+  - Method L467: `_build_loaded_replay(self, *, replay, instrument, records: tuple[Any, ...], count: int, count_key: str, market_key: str, market_id: str, prices: tuple[float, ...], outcome: str, realized_outcome: float | None, metadata: dict[str, Any], requested_window: ReplayWindow) -> LoadedReplay`
+- Class L503: `PolymarketPMXTBookReplayAdapter(_BaseReplayAdapter)`
+  - Method L504: `__init__(self) -> None`
+  - Method L531: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
+- Class L631: `PolymarketTelonexBookReplayAdapter(_BaseReplayAdapter)`
+  - Method L632: `__init__(self) -> None`
+  - Method L662: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
 
 ### `prediction_market_extensions/backtesting/data_sources/telonex.py`
-- Imports: `__future__, collections, concurrent, contextlib, contextvars, dataclasses, datetime, duckdb, hashlib, io, nautilus_trader, numpy, os, pandas, pathlib, prediction_market_extensions, pyarrow, re, threading, urllib, warnings`
-- Function L113: `_current_loader_config() -> TelonexLoaderConfig | None`
-- Function L117: `_env_value(name: str) -> str | None`
-- Function L127: `_resolve_channel(channel: str | None = None) -> str`
-- Function L131: `_default_cache_root() -> Path`
-- Function L137: `_resolve_api_cache_root() -> Path | None`
-- Function L147: `_normalize_api_base_url(value: str | None) -> str`
-- Function L156: `_expand_source_vars(source: str) -> str`
-- Function L166: `_classify_telonex_sources(sources: Sequence[str]) -> tuple[TelonexSourceEntry, ...]`
-- Function L209: `_default_telonex_sources_from_env() -> tuple[TelonexSourceEntry, ...]`
-- Function L230: `_source_summary(entries: Sequence[TelonexSourceEntry]) -> str`
-- Function L241: `resolve_telonex_loader_config(*, sources: Sequence[str] | None = None, channel: str | None = None) -> tuple[TelonexDataSourceSelection, TelonexLoaderConfig]`
-- Function L261: `resolve_telonex_data_source_selection(*, sources: Sequence[str] | None = None) -> tuple[TelonexDataSourceSelection, dict[str, str | None]]`
-- Function L269: `configured_telonex_data_source(*, sources: Sequence[str] | None = None, channel: str | None = None) -> Iterator[TelonexDataSourceSelection]`
-- Class L83: `TelonexSourceEntry`
-- Class L90: `TelonexLoaderConfig`
-- Class L96: `TelonexDataSourceSelection`
-- Class L102: `_TelonexDayResult`
-- Class L280: `RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader)`
-  - Method L281: `__init__(self, *args, **kwargs) -> None`
-  - Method L286: `_ensure_blob_scan_caches(self) -> None`
-  - Method L312: `_download_progress(self, url: str, downloaded_bytes: int, total_bytes: int | None, finished: bool) -> None`
-  - Method L319: `_day_progress(self, date: str, event: str, source: str, rows: int) -> None`
-  - Method L325: `_resolve_api_cache_root(cls) -> Path | None`
-  - Method L329: `_resolve_prefetch_workers(cls) -> int`
-  - Method L338: `_config(self) -> TelonexLoaderConfig`
-  - Method L345: `_date_range(start: pd.Timestamp, end: pd.Timestamp) -> list[str]`
-  - Method L356: `_outcome_segments(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
-  - Method L363: `_local_blob_root(root: Path) -> Path | None`
-  - Method L377: `_outcome_segment_candidates(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
-  - Method L384: `_month_partition_dirs(*, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[Path, ...]`
-  - Method L395: `_readable_blob_part_paths(self, *, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool]`
-  - Method L432: `_scan_readable_blob_part_paths(self, partition_dir: Path) -> tuple[tuple[str, ...], bool]`
-  - Method L465: `_manifest_blob_part_paths(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool] | None`
-  - Method L534: `_load_blob_range(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
-  - Method L739: `_cached_ts_ns_for_frame(self, frame: pd.DataFrame, column_name: str) -> np.ndarray | None`
-  - Method L758: `_local_consolidated_candidates(cls, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
-  - Method L783: `_local_daily_candidates(cls, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
-  - Method L816: `_local_consolidated_path(self, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L836: `_local_path_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L859: `_safe_read_parquet(path: Path) -> pd.DataFrame | None`
-  - Method L869: `_load_local_range(self, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L889: `_load_local_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L912: `_api_url(*, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L932: `_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L961: `_load_api_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L990: `_write_api_cache_day(self, *, payload: bytes, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
-  - Method L1027: `_fast_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L1049: `_load_fast_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L1078: `_write_fast_cache_day(self, *, frame: pd.DataFrame, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
-  - Method L1151: `_load_api_day_cached(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L1226: `_deltas_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
-  - Method L1258: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas] | None, str]`
-  - Method L1299: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> None`
-  - Method L1343: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
-  - Method L1378: `_deltas_records_from_columns(self, data: dict[str, list[object]]) -> list[OrderBookDeltas]`
-  - Method L1425: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
-  - Method L1452: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
-  - Method L1544: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
-  - Method L1556: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
-  - Method L1561: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
-  - Method L1575: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
-  - Method L1582: `_book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]`
-  - Method L1617: `_book_levels_from_arrays(*, prices: object, sizes: object, side: str) -> tuple[PolymarketBookLevel, ...]`
-  - Method L1634: `_book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]`
-  - Method L1637: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
-  - Method L1653: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
-  - Method L1702: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> list[OrderBookDeltas]`
-  - Method L1792: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
-  - Method L1840: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
-  - Method L1907: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L1947: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L1989: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L2008: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None]) -> _TelonexDayResult`
-  - Method L2108: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool) -> Iterator[_TelonexDayResult]`
-  - Method L2174: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
+- Imports: `__future__, collections, concurrent, contextlib, contextvars, dataclasses, datetime, decimal, duckdb, hashlib, io, json, nautilus_trader, numpy, os, pandas, pathlib, prediction_market_extensions, pyarrow, re, threading, urllib, warnings`
+- Function L116: `_current_loader_config() -> TelonexLoaderConfig | None`
+- Function L120: `_env_value(name: str) -> str | None`
+- Function L130: `_resolve_channel(channel: str | None = None) -> str`
+- Function L134: `_default_cache_root() -> Path`
+- Function L140: `_resolve_api_cache_root() -> Path | None`
+- Function L150: `_normalize_api_base_url(value: str | None) -> str`
+- Function L159: `_expand_source_vars(source: str) -> str`
+- Function L169: `_classify_telonex_sources(sources: Sequence[str]) -> tuple[TelonexSourceEntry, ...]`
+- Function L212: `_default_telonex_sources_from_env() -> tuple[TelonexSourceEntry, ...]`
+- Function L233: `_source_summary(entries: Sequence[TelonexSourceEntry]) -> str`
+- Function L244: `resolve_telonex_loader_config(*, sources: Sequence[str] | None = None, channel: str | None = None) -> tuple[TelonexDataSourceSelection, TelonexLoaderConfig]`
+- Function L264: `resolve_telonex_data_source_selection(*, sources: Sequence[str] | None = None) -> tuple[TelonexDataSourceSelection, dict[str, str | None]]`
+- Function L272: `configured_telonex_data_source(*, sources: Sequence[str] | None = None, channel: str | None = None) -> Iterator[TelonexDataSourceSelection]`
+- Class L86: `TelonexSourceEntry`
+- Class L93: `TelonexLoaderConfig`
+- Class L99: `TelonexDataSourceSelection`
+- Class L105: `_TelonexDayResult`
+- Class L283: `RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader)`
+  - Method L284: `__init__(self, *args, **kwargs) -> None`
+  - Method L289: `_ensure_blob_scan_caches(self) -> None`
+  - Method L315: `_download_progress(self, url: str, downloaded_bytes: int, total_bytes: int | None, finished: bool) -> None`
+  - Method L322: `_day_progress(self, date: str, event: str, source: str, rows: int) -> None`
+  - Method L328: `_resolve_api_cache_root(cls) -> Path | None`
+  - Method L332: `_resolve_prefetch_workers(cls) -> int`
+  - Method L341: `_config(self) -> TelonexLoaderConfig`
+  - Method L348: `_date_range(start: pd.Timestamp, end: pd.Timestamp) -> list[str]`
+  - Method L359: `_outcome_segments(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
+  - Method L366: `_local_blob_root(root: Path) -> Path | None`
+  - Method L380: `_outcome_segment_candidates(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
+  - Method L387: `_month_partition_dirs(*, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[Path, ...]`
+  - Method L398: `_readable_blob_part_paths(self, *, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool]`
+  - Method L435: `_scan_readable_blob_part_paths(self, partition_dir: Path) -> tuple[tuple[str, ...], bool]`
+  - Method L468: `_manifest_blob_part_paths(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool] | None`
+  - Method L537: `_load_blob_range(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
+  - Method L752: `_cached_ts_ns_for_frame(self, frame: pd.DataFrame, column_name: str) -> np.ndarray | None`
+  - Method L771: `_local_consolidated_candidates(cls, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
+  - Method L796: `_local_daily_candidates(cls, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
+  - Method L829: `_local_consolidated_path(self, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L849: `_local_path_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L872: `_safe_read_parquet(path: Path) -> pd.DataFrame | None`
+  - Method L882: `_load_local_range(self, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L902: `_load_local_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L925: `_api_url(*, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L945: `_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L974: `_load_api_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L1003: `_write_api_cache_day(self, *, payload: bytes, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
+  - Method L1040: `_fast_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L1063: `_fast_api_cache_metadata_path(fast_path: Path) -> Path`
+  - Method L1066: `_fast_api_cache_metadata_payload(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1091: `_fast_api_cache_metadata_matches(self, *, fast_path: Path, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> bool`
+  - Method L1119: `_load_fast_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L1163: `_write_fast_cache_day(self, *, frame: pd.DataFrame, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
+  - Method L1259: `_load_api_day_cached(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L1334: `_deltas_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
+  - Method L1367: `_deltas_cache_metadata_path(cache_path: Path) -> Path`
+  - Method L1371: `_local_file_fingerprint(path: Path) -> dict[str, object] | None`
+  - Method L1384: `_local_blob_source_fingerprint_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1457: `_telonex_source_fingerprint_for_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1518: `_deltas_cache_source_fingerprint(self, *, config: TelonexLoaderConfig, date: str, market_slug: str, token_index: int, outcome: str | None) -> dict[str, object] | None`
+  - Method L1540: `_deltas_cache_metadata_payload(self, *, source: Mapping[str, object] | None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, object] | None`
+  - Method L1569: `_deltas_cache_metadata_matches(self, *, cache_path: Path, expected_metadata: Mapping[str, object] | None) -> bool`
+  - Method L1581: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, expected_metadata: Mapping[str, object] | None) -> tuple[list[OrderBookDeltas] | None, str]`
+  - Method L1628: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, metadata: Mapping[str, object] | None) -> None`
+  - Method L1688: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
+  - Method L1723: `_deltas_records_from_columns(self, data: dict[str, list[object]]) -> list[OrderBookDeltas]`
+  - Method L1770: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
+  - Method L1797: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
+  - Method L1889: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
+  - Method L1900: `_scaled_column_to_ns(column: pd.Series, multiplier: int) -> np.ndarray`
+  - Method L1915: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
+  - Method L1920: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
+  - Method L1934: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
+  - Method L1941: `_book_levels_from_value(value: object, *, side: str) -> tuple[PolymarketBookLevel, ...]`
+  - Method L1976: `_book_levels_from_arrays(*, prices: object, sizes: object, side: str) -> tuple[PolymarketBookLevel, ...]`
+  - Method L1993: `_book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]`
+  - Method L1997: `_book_levels_are_crossed(*, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel]) -> bool`
+  - Method L2006: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
+  - Method L2025: `_retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
+  - Method L2040: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
+  - Method L2089: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> list[OrderBookDeltas]`
+  - Method L2200: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
+  - Method L2248: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
+  - Method L2347: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2387: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L2429: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L2448: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None]) -> _TelonexDayResult`
+  - Method L2589: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool) -> Iterator[_TelonexDayResult]`
+  - Method L2655: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
 
 ### `prediction_market_extensions/backtesting/data_sources/vendors.py`
 - Imports: `__future__, dataclasses`
@@ -1415,16 +1539,17 @@ flowchart TD
   - Method L226: `_rounded_quantity(self, instrument_id: InstrumentId, size: Decimal) -> Any`
   - Method L242: `_pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
   - Method L245: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
-  - Method L323: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], quantities: list[object], visible_size: float, net_unit_cost: float, edge: float) -> None`
-  - Method L362: `_event_order_is_closed(self, event) -> bool`
-  - Method L377: `_mark_order_event(self, event) -> None`
-  - Method L385: `on_order_filled(self, event) -> None`
-  - Method L388: `on_order_rejected(self, event) -> None`
-  - Method L391: `on_order_denied(self, event) -> None`
-  - Method L394: `on_order_canceled(self, event) -> None`
-  - Method L397: `on_order_expired(self, event) -> None`
-  - Method L400: `on_stop(self) -> None`
-  - Method L409: `on_reset(self) -> None`
+  - Method L328: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], quantities: list[object], visible_size: float, net_unit_cost: float, edge: float) -> None`
+  - Method L369: `_event_order_is_closed(self, event) -> bool`
+  - Method L384: `_mark_order_event(self, event) -> None`
+  - Method L392: `_rollback_empty_failed_pair_entry(self, event) -> None`
+  - Method L402: `on_order_filled(self, event) -> None`
+  - Method L405: `on_order_rejected(self, event) -> None`
+  - Method L409: `on_order_denied(self, event) -> None`
+  - Method L413: `on_order_canceled(self, event) -> None`
+  - Method L417: `on_order_expired(self, event) -> None`
+  - Method L421: `on_stop(self) -> None`
+  - Method L430: `on_reset(self) -> None`
 
 ### `strategies/breakout.py`
 - Imports: `__future__, collections, decimal, math, nautilus_trader, strategies, typing`

--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-04-27T23:09:41+00:00
-Modules: 104 | Classes: 154 | Functions/methods: 1314
+Generated: 2026-04-28T02:15:14+00:00
+Modules: 107 | Classes: 159 | Functions/methods: 1354
 
 ## Backtesting Data Flow
 
@@ -56,6 +56,17 @@ flowchart TD
 - Function L28: `_btc_5m_windows() -> tuple[tuple[str, str, str], ...]`
 - Function L40: `_btc_5m_replays() -> Any`
 - Function L56: `run() -> None`
+
+### `backtests/polymarket_profile_replay_verification.py`
+- Imports: `__future__, decimal, os, typing`
+- Function L51: `_env_int(name: str, default: int) -> int`
+- Function L61: `_env_float(name: str, default: float) -> float`
+- Function L71: `_load_profile_trades() -> Any`
+- Function L88: `_initial_cash_for_profile_trades(groups) -> float`
+- Function L97: `_build_experiment(groups, *, profile_user: str, lead_seconds: float) -> Any`
+- Function L186: `_simulated_net_quantity(fill_events: object) -> float`
+- Function L199: `_print_profile_comparison(results: list[dict[str, Any]], groups) -> None`
+- Function L232: `run() -> None`
 
 ### `backtests/polymarket_telonex_book_joint_portfolio_runner.py`
 - Imports: `__future__, decimal`
@@ -525,55 +536,55 @@ flowchart TD
 - Function L448: `_record_active_cutoff(active_cutoffs: dict[str, pd.Timestamp], label: str, result: Mapping[str, Any]) -> None`
 - Function L461: `_result_brier_cutoff(result: Mapping[str, Any]) -> pd.Timestamp | None`
 - Function L469: `_truncate_brier_series_at_cutoff(result: Mapping[str, Any], *series_values: pd.Series) -> tuple[pd.Series, ...]`
-- Function L478: `_active_range_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
-- Function L490: `_fill_event_timestamp(event: Mapping[str, Any]) -> pd.Timestamp | None`
-- Function L503: `_fill_event_position_delta(event: Mapping[str, Any]) -> float | None`
-- Function L516: `_normalize_fill_action_value(value: object, *, default_for_token_side: str | None) -> str | None`
-- Function L533: `_is_missing_fill_value(value: object) -> bool`
-- Function L546: `_fill_event_action(event: Mapping[str, Any], *, default_missing: str | None) -> str | None`
-- Function L583: `_result_active_position_intervals(result: Mapping[str, Any]) -> list[tuple[pd.Timestamp, pd.Timestamp | None]] | None`
-- Function L633: `_position_interval_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp | None, fallback_end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
-- Function L653: `_overlay_range_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
-- Function L665: `_parse_float_like(value, default: float = 0.0) -> float`
-- Function L687: `_first_non_missing_fill_value(source, *keys: str) -> Any`
-- Function L698: `_fill_value_text(value) -> str`
-- Function L704: `_result_has_position_activity(result: Mapping[str, Any]) -> bool`
-- Function L723: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
-- Function L818: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
-- Function L864: `_aggregate_brier_frames(results: Sequence[dict[str, Any]], *, market_key: str | None) -> dict[str, pd.DataFrame]`
-- Function L897: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
-- Function L922: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
-- Function L926: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
-- Function L932: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
-- Function L939: `_yes_price_fill_marker_budget(max_points: int) -> int`
-- Function L945: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
-- Function L956: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
-- Function L1003: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
-- Function L1017: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
-- Function L1038: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], market_key: str | None, resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
-- Function L1084: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
-- Function L1099: `_add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
-- Function L1107: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = False, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L2_MBP, liquidity_consumption: bool = True, queue_position: bool = True, latency_model: Any | None = _DEFAULT_LATENCY_MODEL, nautilus_log_level: str = 'INFO') -> dict[str, Any]`
-- Function L1273: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
-- Function L1327: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1632: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
-- Function L1927: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
-- Function L1989: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
-- Function L2024: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
-- Function L2050: `_summary_total_equity_series(results: Sequence[Mapping[str, Any]]) -> list[tuple[str, float]]`
-- Function L2118: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
-- Function L2136: `_summary_returns_from_pairs(pairs: object, *, initial_capital: float | None = None) -> dict[int, float]`
-- Function L2145: `_summary_returns_from_series(series: pd.Series, *, initial_capital: float | None = None) -> dict[int, float]`
-- Function L2171: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
-- Function L2188: `_summary_total_return_pct(pairs: object, *, initial_capital: float | None = None) -> float | None`
-- Function L2197: `_summary_total_return_pct_from_series(series: pd.Series, *, initial_capital: float | None = None) -> float | None`
-- Function L2216: `_safe_stat(func, returns: dict[int, float]) -> float | None`
-- Function L2224: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
-- Function L2229: `_coerce_float(value: object) -> float | None`
-- Function L2237: `_format_summary_float(value: object, decimals: int) -> str`
-- Function L2244: `_format_summary_pct(value: object) -> str`
-- Function L2251: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
-- Function L2314: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
+- Function L496: `_active_range_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
+- Function L508: `_fill_event_timestamp(event: Mapping[str, Any]) -> pd.Timestamp | None`
+- Function L521: `_fill_event_position_delta(event: Mapping[str, Any]) -> float | None`
+- Function L534: `_normalize_fill_action_value(value: object, *, default_for_token_side: str | None) -> str | None`
+- Function L551: `_is_missing_fill_value(value: object) -> bool`
+- Function L564: `_fill_event_action(event: Mapping[str, Any], *, default_missing: str | None) -> str | None`
+- Function L601: `_result_active_position_intervals(result: Mapping[str, Any]) -> list[tuple[pd.Timestamp, pd.Timestamp | None]] | None`
+- Function L651: `_position_interval_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp | None, fallback_end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
+- Function L671: `_overlay_range_mask(timeline: pd.DatetimeIndex, *, start: pd.Timestamp, end: pd.Timestamp, cutoff: pd.Timestamp | None) -> Any`
+- Function L683: `_parse_float_like(value, default: float = 0.0) -> float`
+- Function L705: `_first_non_missing_fill_value(source, *keys: str) -> Any`
+- Function L716: `_fill_value_text(value) -> str`
+- Function L722: `_result_has_position_activity(result: Mapping[str, Any]) -> bool`
+- Function L741: `_serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]`
+- Function L836: `_deserialize_fill_events(*, market_id: str, fill_events: Sequence[dict[str, Any]], models_module) -> list[Any]`
+- Function L882: `_aggregate_brier_frames(results: Sequence[dict[str, Any]], *, market_key: str | None) -> dict[str, pd.DataFrame]`
+- Function L915: `_aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> str | None`
+- Function L940: `_summary_panels_need_market_prices(plot_panels: Sequence[str]) -> bool`
+- Function L944: `_summary_panels_need_fill_events(plot_panels: Sequence[str]) -> bool`
+- Function L950: `_summary_panels_need_overlay_series(plot_panels: Sequence[str]) -> bool`
+- Function L957: `_yes_price_fill_marker_budget(max_points: int) -> int`
+- Function L963: `_summary_yes_price_fill_marker_limit(fill_count: int, max_points: int) -> int | None`
+- Function L974: `_configure_summary_report_downsampling(plotting_module, *, adaptive: bool = True, max_points: int = 5000) -> None`
+- Function L1021: `_build_summary_brier_panel(brier_frames: dict[str, pd.DataFrame], *, axis_label: str, max_points_per_market: int) -> Any | None`
+- Function L1035: `_build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -> pd.DataFrame`
+- Function L1056: `_build_summary_brier_extra_panels(*, results: Sequence[dict[str, Any]], market_key: str | None, resolved_plot_panels: Sequence[str], max_points_per_market: int) -> dict[str, Any]`
+- Function L1102: `_apply_summary_layout_overrides(layout, *, initial_cash: float, max_yes_price_fill_markers: int | None) -> Any`
+- Function L1117: `_add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None`
+- Function L1125: `run_market_backtest(*, market_id: str, instrument, data: Sequence[object], strategy: Strategy, strategy_name: str, output_prefix: str, platform: str, venue: Venue, base_currency: Currency, fee_model, fill_model: Any | None = None, apply_default_fill_model: bool = False, initial_cash: float, probability_window: int, price_attr: str, count_key: str, data_count: int | None = None, chart_resample_rule: str | None = None, market_key: str = 'market', open_browser: bool = False, return_summary_series: bool = False, book_type: BookType = BookType.L2_MBP, liquidity_consumption: bool = True, queue_position: bool = True, latency_model: Any | None = _DEFAULT_LATENCY_MODEL, nautilus_log_level: str = 'INFO') -> dict[str, Any]`
+- Function L1291: `save_combined_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str) -> str | None`
+- Function L1345: `save_aggregate_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1650: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
+- Function L1945: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
+- Function L2007: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
+- Function L2042: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
+- Function L2068: `_summary_total_equity_series(results: Sequence[Mapping[str, Any]]) -> list[tuple[str, float]]`
+- Function L2136: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
+- Function L2154: `_summary_returns_from_pairs(pairs: object, *, initial_capital: float | None = None) -> dict[int, float]`
+- Function L2163: `_summary_returns_from_series(series: pd.Series, *, initial_capital: float | None = None) -> dict[int, float]`
+- Function L2189: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
+- Function L2206: `_summary_total_return_pct(pairs: object, *, initial_capital: float | None = None) -> float | None`
+- Function L2215: `_summary_total_return_pct_from_series(series: pd.Series, *, initial_capital: float | None = None) -> float | None`
+- Function L2234: `_safe_stat(func, returns: dict[int, float]) -> float | None`
+- Function L2242: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
+- Function L2247: `_coerce_float(value: object) -> float | None`
+- Function L2255: `_format_summary_float(value: object, decimals: int) -> str`
+- Function L2262: `_format_summary_pct(value: object) -> str`
+- Function L2269: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
+- Function L2332: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
 
 ### `prediction_market_extensions/analysis/__init__.py`
 - Imports: none
@@ -1296,15 +1307,15 @@ flowchart TD
   - Method L2006: `_snapshot_to_deltas(self, *, bids: Sequence[PolymarketBookLevel], asks: Sequence[PolymarketBookLevel], ts_event: int) -> OrderBookDeltas | None`
   - Method L2025: `_retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas`
   - Method L2040: `_diff_to_deltas(self, *, previous_bids: dict[str, str], previous_asks: dict[str, str], current_bids: dict[str, str], current_asks: dict[str, str], ts_event: int) -> OrderBookDeltas | None`
-  - Method L2089: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> list[OrderBookDeltas]`
-  - Method L2200: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
-  - Method L2248: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
-  - Method L2347: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L2387: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L2429: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L2448: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None]) -> _TelonexDayResult`
-  - Method L2589: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool) -> Iterator[_TelonexDayResult]`
-  - Method L2655: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
+  - Method L2089: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True, invalid_snapshot_warning: bool = True, invalid_snapshot_counter: Callable[[int], None] | None = None) -> list[OrderBookDeltas]`
+  - Method L2205: `_try_load_range_from_local(self, *, entry: TelonexSourceEntry, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
+  - Method L2253: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
+  - Method L2352: `_try_load_day_from_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2392: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L2434: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L2453: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None], invalid_snapshot_counter: Callable[[int], None] | None = None) -> _TelonexDayResult`
+  - Method L2597: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, invalid_snapshot_counter: Callable[[int], None] | None = None) -> Iterator[_TelonexDayResult]`
+  - Method L2666: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
 
 ### `prediction_market_extensions/backtesting/data_sources/vendors.py`
 - Imports: `__future__, dataclasses`
@@ -1335,6 +1346,29 @@ flowchart TD
 - Function L89: `run_reported_backtest(*, backtest: PredictionMarketBacktest, report: MarketReportConfig, empty_message: str | None = None) -> list[dict[str, object]]`
 - Function L105: `_resolve_report_market_key(*, results: Sequence[dict[str, object]], configured_key: str) -> str`
 - Class L32: `MarketReportConfig`
+
+### `prediction_market_extensions/backtesting/profile_replay.py`
+- Imports: `__future__, collections, dataclasses, decimal, json, pandas, prediction_market_extensions, re, urllib`
+- Function L63: `profile_replay_key(*, slug: str, outcome_index: int) -> str`
+- Function L67: `_decimal_from_payload(value: object, *, field: str) -> Decimal`
+- Function L77: `_timestamp_from_payload(value: object) -> pd.Timestamp`
+- Function L87: `normalize_profile_trade(payload: Mapping[str, object]) -> ProfileTrade`
+- Function L121: `normalize_profile_trades(payloads: Iterable[Mapping[str, object]]) -> tuple[ProfileTrade, ...]`
+- Function L131: `fetch_profile_trades(*, user: str, limit: int = 500, taker_only: bool = False, base_url: str = POLYMARKET_PROFILE_TRADES_URL, timeout_seconds: float = 30.0) -> tuple[ProfileTrade, ...]`
+- Function L157: `_inventory_never_negative(trades: Sequence[ProfileTrade]) -> bool`
+- Function L169: `select_profile_trade_groups(trades: Sequence[ProfileTrade], *, max_groups: int, allowed_slug_prefixes: Sequence[str] = DEFAULT_PROFILE_REPLAY_PREFIXES, require_complete_inventory: bool = True) -> tuple[ProfileTradeGroup, ...]`
+- Function L196: `infer_profile_replay_window(group: ProfileTradeGroup, *, lead_time_seconds: float, start_buffer_seconds: float, end_buffer_seconds: float) -> tuple[pd.Timestamp, pd.Timestamp]`
+- Function L222: `profile_trades_by_key(groups: Sequence[ProfileTradeGroup]) -> dict[str, list[dict[str, object]]]`
+- Function L240: `build_profile_replays(groups: Sequence[ProfileTradeGroup], *, profile_user: str, lead_time_seconds: float, start_buffer_seconds: float = 120.0, end_buffer_seconds: float = 1800.0) -> tuple[BookReplay, ...]`
+- Function L274: `profile_actual_pnl(trades: Sequence[ProfileTrade], *, realized_outcome: float | int | None) -> dict[str, float | None]`
+- Function L312: `append_profile_replay_diagnostics(results: Sequence[Mapping[str, object]], groups: Sequence[ProfileTradeGroup]) -> list[dict[str, object]]`
+- Class L24: `ProfileTrade`
+  - Method L36: `key(self) -> str`
+  - Method L40: `timestamp_ns(self) -> int`
+- Class L45: `ProfileTradeGroup`
+  - Method L51: `key(self) -> str`
+  - Method L55: `outcome(self) -> str`
+  - Method L59: `title(self) -> str`
 
 ### `scripts/__init__.py`
 - Imports: none
@@ -1747,6 +1781,26 @@ flowchart TD
 - Class L170: `BookPanicFadeStrategy(_PanicFadeBase)`
   - Method L171: `_subscribe(self) -> None`
   - Method L177: `on_order_book(self, order_book) -> None`
+
+### `strategies/profile_replay.py`
+- Imports: `__future__, collections, dataclasses, decimal, nautilus_trader, prediction_market_extensions, typing`
+- Function L44: `_payload_float(payload: Mapping[str, Any], field: str) -> float`
+- Function L51: `_payload_timestamp_ns(payload: Mapping[str, Any]) -> int`
+- Function L61: `_decimal_or_none(value: object) -> Decimal | None`
+- Function L70: `_scheduled_orders_from_config(config: BookProfileReplayConfig) -> tuple[_ScheduledProfileOrder, ...]`
+- Class L20: `_ScheduledProfileOrder`
+- Class L29: `BookProfileReplayConfig(StrategyConfig)`
+  - Method L35: `__post_init__(self) -> None`
+- Class L112: `BookProfileReplayStrategy(Strategy)`
+  - Method L121: `__init__(self, config: BookProfileReplayConfig) -> None`
+  - Method L128: `on_start(self) -> None`
+  - Method L139: `on_order_book_deltas(self, deltas) -> None`
+  - Method L146: `on_order_book(self, order_book) -> None`
+  - Method L149: `_submit_due_orders(self, *, ts_event_ns: int) -> None`
+  - Method L157: `_sell_quantity_cap(self) -> float`
+  - Method L175: `_submit_scheduled_order(self, scheduled_order: _ScheduledProfileOrder) -> None`
+  - Method L210: `on_stop(self) -> None`
+  - Method L213: `on_reset(self) -> None`
 
 ### `strategies/rsi_reversion.py`
 - Imports: `__future__, decimal, nautilus_trader, strategies, typing`

--- a/NOTICE
+++ b/NOTICE
@@ -28,6 +28,7 @@ provenance notices with file-specific change dates:
 - `backtests/polymarket_book_joint_portfolio_runner.py`
 - `backtests/polymarket_btc_5m_late_favorite_taker_hold.py`
 - `backtests/polymarket_btc_5m_pair_arbitrage.py`
+- `backtests/polymarket_profile_replay_verification.py`
 - `backtests/polymarket_telonex_book_joint_portfolio_runner.py`
 - `prediction_market_extensions/adapters/kalshi/data.py`
 - `prediction_market_extensions/adapters/kalshi/fee_model.py`

--- a/NOTICE
+++ b/NOTICE
@@ -23,6 +23,7 @@ prediction-market example, adapter, or plotting code and carry file-level LGPL
 provenance notices with file-specific change dates:
 
 
+- `backtests/polymarket_book_buy_sell_random.py`
 - `backtests/polymarket_book_ema_crossover.py`
 - `backtests/polymarket_book_ema_optimizer.py`
 - `backtests/polymarket_book_joint_portfolio_runner.py`
@@ -59,6 +60,7 @@ provenance notices with file-specific change dates:
 - `strategies/__init__.py`
 - `strategies/binary_pair_arbitrage.py`
 - `strategies/breakout.py`
+- `strategies/buy_sell_random.py`
 - `strategies/core.py`
 - `strategies/deep_value.py`
 - `strategies/ema_crossover.py`

--- a/backtests/polymarket_book_buy_sell_random.py
+++ b/backtests/polymarket_book_buy_sell_random.py
@@ -1,0 +1,120 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Added in this repository on 2026-04-28.
+# See the repository NOTICE file for provenance and licensing scope.
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+if __package__ in {None, ""}:
+    from _script_helpers import ensure_repo_root
+else:
+    from ._script_helpers import ensure_repo_root
+
+ensure_repo_root(__file__)
+
+
+def run() -> None:
+    from prediction_market_extensions.backtesting._execution_config import (
+        ExecutionModelConfig,
+        StaticLatencyConfig,
+    )
+    from prediction_market_extensions.backtesting._experiments import (
+        build_replay_experiment,
+        run_experiment,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_backtest import (
+        MarketReportConfig,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_runner import (
+        MarketDataConfig,
+    )
+    from prediction_market_extensions.backtesting._replay_specs import BookReplay
+    from prediction_market_extensions.backtesting._timing_harness import timing_harness
+    from prediction_market_extensions.backtesting.data_sources import Book, PMXT, Polymarket
+
+    @timing_harness
+    def _run() -> None:
+        run_experiment(
+            build_replay_experiment(
+                name="polymarket_book_buy_sell_random",
+                description="Random three-day buy/sell cadence on PMXT L2 book data",
+                data=MarketDataConfig(
+                    platform=Polymarket,
+                    data_type=Book,
+                    vendor=PMXT,
+                    sources=(
+                        "local:/Volumes/LaCie/pmxt_data",
+                        "archive:r2v2.pmxt.dev",
+                        "archive:r2.pmxt.dev",
+                    ),
+                ),
+                replays=(
+                    BookReplay(
+                        market_slug="human-moon-landing-in-2026",
+                        token_index=0,
+                        start_time="2026-03-01T00:00:00Z",
+                        end_time="2026-04-11T23:59:59Z",
+                    ),
+                ),
+                strategy_configs=[
+                    {
+                        "strategy_path": "strategies:BookBuySellRandomStrategy",
+                        "config_path": "strategies:BookBuySellRandomConfig",
+                        "config": {
+                            "trade_size": Decimal(5),
+                            "interval_seconds": 3.0 * 24.0 * 60.0 * 60.0,
+                            "random_seed": 7,
+                            "max_entry_price": 1.0,
+                            "max_spread": 1.0,
+                            "min_visible_size": 0.0,
+                        },
+                    }
+                ],
+                initial_cash=100.0,
+                probability_window=30,
+                min_book_events=500,
+                min_price_range=0.005,
+                execution=ExecutionModelConfig(
+                    queue_position=True,
+                    latency_model=StaticLatencyConfig(
+                        base_latency_ms=75.0,
+                        insert_latency_ms=10.0,
+                        update_latency_ms=5.0,
+                        cancel_latency_ms=5.0,
+                    ),
+                ),
+                report=MarketReportConfig(
+                    count_key="book_events",
+                    count_label="Book Events",
+                    pnl_label="PnL (USDC)",
+                    summary_report=True,
+                    summary_report_path="output/polymarket_book_buy_sell_random_summary.html",
+                    summary_plot_panels=(
+                        "total_equity",
+                        "equity",
+                        "market_pnl",
+                        "periodic_pnl",
+                        "yes_price",
+                        "allocation",
+                        "total_drawdown",
+                        "drawdown",
+                        "total_rolling_sharpe",
+                        "rolling_sharpe",
+                        "total_cash_equity",
+                        "cash_equity",
+                        "monthly_returns",
+                        "total_brier_advantage",
+                        "brier_advantage",
+                    ),
+                ),
+                empty_message="No PMXT buy/sell random sims met the book requirements.",
+            )
+        )
+
+    _run()
+
+
+if __name__ == "__main__":
+    run()

--- a/backtests/polymarket_profile_replay_verification.py
+++ b/backtests/polymarket_profile_replay_verification.py
@@ -68,6 +68,22 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_timestamp(*names: str):
+    import pandas as pd
+
+    for name in names:
+        raw = os.getenv(name)
+        if raw is None or not raw.strip():
+            continue
+        timestamp = pd.Timestamp(raw)
+        if pd.isna(timestamp):
+            continue
+        if timestamp.tzinfo is None:
+            return timestamp.tz_localize("UTC")
+        return timestamp.tz_convert("UTC")
+    return None
+
+
 def _load_profile_trades():
     from prediction_market_extensions.backtesting.profile_replay import (
         fetch_profile_trades,
@@ -242,6 +258,14 @@ def run() -> None:
         groups = select_profile_trade_groups(
             trades,
             max_groups=_env_int("POLYMARKET_PROFILE_REPLAY_MAX_GROUPS", PROFILE_MAX_GROUPS),
+            min_latest_trade_time=_env_timestamp(
+                "POLYMARKET_PROFILE_REPLAY_MIN_LATEST_TRADE_TIME",
+                "POLYMARKET_PROFILE_REPLAY_AFTER",
+            ),
+            max_latest_trade_time=_env_timestamp(
+                "POLYMARKET_PROFILE_REPLAY_MAX_LATEST_TRADE_TIME",
+                "POLYMARKET_PROFILE_REPLAY_BEFORE",
+            ),
         )
         if not groups:
             print("No complete profile trade groups were selected for replay verification.")

--- a/backtests/polymarket_profile_replay_verification.py
+++ b/backtests/polymarket_profile_replay_verification.py
@@ -1,0 +1,267 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Modified in this repository on 2026-04-27.
+# See the repository NOTICE file for provenance and licensing scope.
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from typing import Any
+
+if __package__ in {None, ""}:
+    from _script_helpers import ensure_repo_root
+else:
+    from ._script_helpers import ensure_repo_root
+
+ensure_repo_root(__file__)
+
+
+PROFILE_USER = "0xe29aff6a6ae1e1d6a3a1c4c904f2957afa98cda0"
+PROFILE_TRADE_LIMIT = 500
+PROFILE_MAX_GROUPS = 4
+PROFILE_LEAD_SECONDS = 1.0
+
+SNAPSHOT_PROFILE_TRADES: tuple[dict[str, object], ...] = (
+    {
+        "side": "BUY",
+        "size": 15.687741,
+        "price": 0.619999986359999,
+        "timestamp": 1777241444,
+        "slug": "btc-updown-5m-1777241400",
+        "outcome": "Down",
+        "outcomeIndex": 1,
+        "title": "Bitcoin Up or Down - April 26, 6:10PM-6:15PM ET",
+        "transactionHash": "0xfa98fd1afc6f01599ab5eadf990eaf462f0a79dd74f2b7bce90c591df36c12db",
+    },
+    {
+        "side": "SELL",
+        "size": 15.68,
+        "price": 0.65,
+        "timestamp": 1777241522,
+        "slug": "btc-updown-5m-1777241400",
+        "outcome": "Down",
+        "outcomeIndex": 1,
+        "title": "Bitcoin Up or Down - April 26, 6:10PM-6:15PM ET",
+        "transactionHash": "0x738a5dcfd2ceb43b7828c7d0ae1765f3c7f1c54a00284de89897f49dcce029f7",
+    },
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _load_profile_trades():
+    from prediction_market_extensions.backtesting.profile_replay import (
+        fetch_profile_trades,
+        normalize_profile_trades,
+    )
+
+    source = os.getenv("POLYMARKET_PROFILE_REPLAY_SOURCE", "live").strip().casefold()
+    if source in {"snapshot", "static", "offline"}:
+        return normalize_profile_trades(SNAPSHOT_PROFILE_TRADES)
+
+    return fetch_profile_trades(
+        user=os.getenv("POLYMARKET_PROFILE_REPLAY_USER", PROFILE_USER),
+        limit=_env_int("POLYMARKET_PROFILE_REPLAY_LIMIT", PROFILE_TRADE_LIMIT),
+        taker_only=False,
+    )
+
+
+def _initial_cash_for_profile_trades(groups) -> float:  # type: ignore[no-untyped-def]
+    buy_notional = Decimal("0")
+    for group in groups:
+        for trade in group.trades:
+            if trade.side == "BUY":
+                buy_notional += trade.price * trade.size
+    return max(1000.0, float(buy_notional * Decimal("3") + Decimal("100")))
+
+
+def _build_experiment(groups, *, profile_user: str, lead_seconds: float):  # type: ignore[no-untyped-def]
+    from prediction_market_extensions.backtesting._execution_config import (
+        ExecutionModelConfig,
+        StaticLatencyConfig,
+    )
+    from prediction_market_extensions.backtesting._experiments import build_replay_experiment
+    from prediction_market_extensions.backtesting._prediction_market_backtest import (
+        MarketReportConfig,
+    )
+    from prediction_market_extensions.backtesting._prediction_market_runner import (
+        MarketDataConfig,
+    )
+    from prediction_market_extensions.backtesting.data_sources import Book, PMXT, Polymarket
+    from prediction_market_extensions.backtesting.profile_replay import (
+        build_profile_replays,
+        profile_trades_by_key,
+    )
+
+    trades_by_key = profile_trades_by_key(groups)
+    return build_replay_experiment(
+        name="polymarket_profile_replay_verification",
+        description=(
+            "Formal profile-emulation verification using public Polymarket trades and PMXT L2 books"
+        ),
+        data=MarketDataConfig(
+            platform=Polymarket,
+            data_type=Book,
+            vendor=PMXT,
+            sources=(
+                "local:/Volumes/LaCie/pmxt_data",
+                "archive:r2v2.pmxt.dev",
+                "archive:r2.pmxt.dev",
+            ),
+        ),
+        replays=build_profile_replays(
+            groups,
+            profile_user=profile_user,
+            lead_time_seconds=lead_seconds,
+        ),
+        strategy_configs=[
+            {
+                "strategy_path": "strategies:BookProfileReplayStrategy",
+                "config_path": "strategies:BookProfileReplayConfig",
+                "config": {
+                    "selection_key": "__SIM_METADATA__:profile_replay_key",
+                    "trades_by_key": trades_by_key,
+                    "lead_time_seconds": lead_seconds,
+                },
+            }
+        ],
+        initial_cash=_initial_cash_for_profile_trades(groups),
+        probability_window=30,
+        min_book_events=1,
+        min_price_range=0.0,
+        execution=ExecutionModelConfig(
+            queue_position=True,
+            latency_model=StaticLatencyConfig(
+                base_latency_ms=75.0,
+                insert_latency_ms=10.0,
+                update_latency_ms=5.0,
+                cancel_latency_ms=5.0,
+            ),
+        ),
+        report=MarketReportConfig(
+            count_key="book_events",
+            count_label="Book Events",
+            pnl_label="PnL (USDC)",
+            market_key="sim_label",
+            summary_report=True,
+            summary_report_path="output/polymarket_profile_replay_verification_summary.html",
+            summary_plot_panels=(
+                "total_equity",
+                "equity",
+                "market_pnl",
+                "periodic_pnl",
+                "yes_price",
+                "allocation",
+                "drawdown",
+                "total_drawdown",
+                "cash_equity",
+                "total_cash_equity",
+            ),
+        ),
+        empty_message="No profile replay verification windows met the PMXT book requirements.",
+        partial_message=("Completed {completed} of {total} profile replay verification windows."),
+        return_summary_series=True,
+    )
+
+
+def _simulated_net_quantity(fill_events: object) -> float:
+    if not isinstance(fill_events, list | tuple):
+        return 0.0
+    total = 0.0
+    for event in fill_events:
+        if not isinstance(event, dict):
+            continue
+        quantity = float(event.get("quantity") or 0.0)
+        action = str(event.get("action") or "").lower()
+        total += quantity if action == "buy" else -quantity
+    return total
+
+
+def _print_profile_comparison(results: list[dict[str, Any]], groups) -> None:  # type: ignore[no-untyped-def]
+    from prediction_market_extensions.backtesting.profile_replay import (
+        append_profile_replay_diagnostics,
+    )
+
+    enriched = append_profile_replay_diagnostics(results, groups)
+    print("\nProfile replay verification")
+    print(
+        "market/outcome".ljust(42),
+        "trades".rjust(6),
+        "fills".rjust(6),
+        "target_qty".rjust(11),
+        "sim_qty".rjust(11),
+        "actual_pnl".rjust(12),
+        "bt_pnl".rjust(12),
+        "error".rjust(12),
+    )
+    for result in enriched:
+        key = str(result.get("profile_replay_key") or result.get("sim_label") or "")
+        actual_pnl = result.get("profile_actual_pnl")
+        error = result.get("profile_pnl_error")
+        print(
+            key[:42].ljust(42),
+            str(result.get("profile_trade_count", "")).rjust(6),
+            str(result.get("fills", "")).rjust(6),
+            f"{float(result.get('profile_buy_quantity') or 0.0):11.4f}",
+            f"{_simulated_net_quantity(result.get('fill_events')):11.4f}",
+            "n/a".rjust(12) if actual_pnl is None else f"{float(actual_pnl):12.4f}",
+            f"{float(result.get('pnl') or 0.0):12.4f}",
+            "n/a".rjust(12) if error is None else f"{float(error):12.4f}",
+        )
+
+
+def run() -> None:
+    from prediction_market_extensions.backtesting import _experiments
+    from prediction_market_extensions.backtesting._timing_harness import timing_harness
+    from prediction_market_extensions.backtesting.profile_replay import select_profile_trade_groups
+
+    @timing_harness
+    def _run() -> None:
+        profile_user = os.getenv("POLYMARKET_PROFILE_REPLAY_USER", PROFILE_USER)
+        lead_seconds = _env_float("POLYMARKET_PROFILE_REPLAY_LEAD_SECONDS", PROFILE_LEAD_SECONDS)
+        trades = _load_profile_trades()
+        groups = select_profile_trade_groups(
+            trades,
+            max_groups=_env_int("POLYMARKET_PROFILE_REPLAY_MAX_GROUPS", PROFILE_MAX_GROUPS),
+        )
+        if not groups:
+            print("No complete profile trade groups were selected for replay verification.")
+            return
+
+        print(
+            f"Selected {len(groups)} profile trade group(s) from {len(trades)} "
+            f"public trades for {profile_user}; submitting {lead_seconds:g}s before each trade."
+        )
+        experiment = _build_experiment(
+            groups,
+            profile_user=profile_user,
+            lead_seconds=lead_seconds,
+        )
+        results = _experiments.run_experiment(experiment)
+        if isinstance(results, list):
+            _print_profile_comparison(results, groups)
+
+    _run()
+
+
+if __name__ == "__main__":
+    run()

--- a/prediction_market_extensions/adapters/polymarket/fee_model.py
+++ b/prediction_market_extensions/adapters/polymarket/fee_model.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from nautilus_trader.backtest.models import FeeModel
 from nautilus_trader.core.rust.model import OrderType
+from nautilus_trader.model.enums import LiquiditySide
 from nautilus_trader.model.objects import Money
 
 from prediction_market_extensions.adapters.polymarket.parsing import calculate_commission
@@ -173,6 +174,29 @@ def calculate_maker_rebate(
     return float(rebate.quantize(_REBATE_QUANTUM, rounding=ROUND_HALF_UP))
 
 
+def _order_liquidity_side(order: object) -> LiquiditySide | None:
+    try:
+        liquidity_side = getattr(order, "liquidity_side")
+    except AttributeError:
+        return None
+    if callable(liquidity_side):
+        liquidity_side = liquidity_side()
+
+    if isinstance(liquidity_side, LiquiditySide):
+        return liquidity_side
+
+    name = getattr(liquidity_side, "name", None)
+    if isinstance(name, str):
+        normalized = name.strip().upper()
+        if normalized in LiquiditySide.__members__:
+            return LiquiditySide[normalized]
+
+    try:
+        return LiquiditySide(int(liquidity_side))
+    except (TypeError, ValueError):
+        return None
+
+
 class PolymarketFeeModel(FeeModel):
     """
     Polymarket fee model for backtesting.
@@ -233,10 +257,8 @@ class PolymarketFeeModel(FeeModel):
         fill_quantity = Decimal(str(fill_qty))
         fill_price = Decimal(str(fill_px))
 
-        if order.order_type == OrderType.LIMIT:
-            # The fee callback does not expose realized maker/taker liquidity.
-            # Repo-owned Polymarket book backtests use passive-posting limit
-            # orders, so treat their limit fills as maker-side rebates.
+        liquidity_side = _order_liquidity_side(order)
+        if order.order_type == OrderType.LIMIT and liquidity_side == LiquiditySide.MAKER:
             if not self._maker_rebates_enabled:
                 return Money(Decimal("0"), instrument.quote_currency)
 

--- a/prediction_market_extensions/adapters/polymarket/pmxt.py
+++ b/prediction_market_extensions/adapters/polymarket/pmxt.py
@@ -11,7 +11,8 @@ import shutil
 import tempfile
 import time
 import warnings
-from collections.abc import Callable, Iterator
+import json
+from collections.abc import Callable, Iterator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager, suppress
 from decimal import Decimal
@@ -35,7 +36,7 @@ from nautilus_trader.adapters.polymarket.schemas.book import (
     PolymarketQuotes,
 )
 from nautilus_trader.model.book import OrderBook
-from nautilus_trader.model.data import OrderBookDeltas
+from nautilus_trader.model.data import OrderBookDelta, OrderBookDeltas
 from nautilus_trader.model.enums import BookType
 
 
@@ -89,6 +90,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
     _PMXT_DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024
     _PMXT_TEMP_DOWNLOAD_ROOT = Path(tempfile.gettempdir()) / "nautilus_trader" / "pmxt-downloads"
     _PMXT_TEMP_DOWNLOAD_STALE_SECONDS = 24 * 60 * 60
+    _PMXT_FILTERED_CACHE_METADATA_VERSION = 2
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
@@ -219,6 +221,62 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             self._pmxt_cache_dir, self.condition_id, self.token_id, hour
         )
 
+    @staticmethod
+    def _cache_metadata_path(cache_path: Path) -> Path:
+        return cache_path.with_name(f"{cache_path.name}.metadata.json")
+
+    @staticmethod
+    def _local_file_fingerprint(path: Path) -> dict[str, object] | None:
+        try:
+            stat = path.expanduser().resolve().stat()
+        except OSError:
+            return None
+        return {
+            "kind": "local",
+            "path": str(path.expanduser().resolve()),
+            "size": int(stat.st_size),
+            "mtime_ns": int(stat.st_mtime_ns),
+            "ctime_ns": int(stat.st_ctime_ns),
+        }
+
+    def _source_cache_fingerprint_for_hour(self, hour: pd.Timestamp) -> dict[str, object] | None:
+        for archive_path in self._local_archive_paths_for_hour(hour):
+            fingerprint = self._local_file_fingerprint(archive_path)
+            if fingerprint is not None:
+                return fingerprint
+        try:
+            return {"kind": "remote", "url": self._archive_url_for_hour(hour)}
+        except Exception:
+            return None
+
+    def _cache_metadata_for_hour(self, hour: pd.Timestamp) -> dict[str, object] | None:
+        source = self._source_cache_fingerprint_for_hour(hour)
+        return self._cache_metadata_payload(hour, source=source)
+
+    def _cache_metadata_payload(
+        self, hour: pd.Timestamp, *, source: Mapping[str, object] | None
+    ) -> dict[str, object] | None:
+        if source is None or self.condition_id is None or self.token_id is None:
+            return None
+        return {
+            "version": self._PMXT_FILTERED_CACHE_METADATA_VERSION,
+            "condition_id": self.condition_id,
+            "token_id": self.token_id,
+            "hour": hour.tz_convert(UTC).isoformat(),
+            "source": dict(source),
+        }
+
+    def _cache_metadata_matches(self, hour: pd.Timestamp, cache_path: Path) -> bool:
+        expected = self._cache_metadata_for_hour(hour)
+        if expected is None:
+            return False
+        metadata_path = self._cache_metadata_path(cache_path)
+        try:
+            actual = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        return actual == expected
+
     @classmethod
     def _local_archive_candidate_paths_for_hour(
         cls, archive_dir: Path, hour: pd.Timestamp
@@ -283,6 +341,8 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         cache_path = self._cache_path_for_hour(hour)
         if cache_path is None or not cache_path.exists():
             return None
+        if not self._cache_metadata_matches(hour, cache_path):
+            return None
 
         try:
             dataset = ds.dataset(str(cache_path), format="parquet")
@@ -295,6 +355,8 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         cache_path = self._cache_path_for_hour(hour)
         if cache_path is None or not cache_path.exists():
             return None
+        if not self._cache_metadata_matches(hour, cache_path):
+            return None
 
         try:
             dataset = ds.dataset(str(cache_path), format="parquet")
@@ -304,18 +366,37 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             cache_path.unlink(missing_ok=True)
             return None
 
-    def _write_market_cache(self, hour: pd.Timestamp, table: pa.Table) -> None:
+    def _write_market_cache(
+        self,
+        hour: pd.Timestamp,
+        table: pa.Table,
+        *,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
         cache_path = self._cache_path_for_hour(hour)
         if cache_path is None:
             return
+        cache_metadata = dict(metadata) if metadata is not None else None
 
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = cache_path.with_name(f"{cache_path.name}.tmp.{os.getpid()}")
+        metadata_path = self._cache_metadata_path(cache_path)
+        metadata_tmp_path = metadata_path.with_name(f"{metadata_path.name}.tmp.{os.getpid()}")
         try:
             pq.write_table(table, tmp_path)
+            if cache_metadata is not None:
+                metadata_tmp_path.write_text(
+                    json.dumps(cache_metadata, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
             os.replace(tmp_path, cache_path)
+            if cache_metadata is not None:
+                os.replace(metadata_tmp_path, metadata_path)
+            else:
+                metadata_path.unlink(missing_ok=True)
         finally:
             tmp_path.unlink(missing_ok=True)
+            metadata_tmp_path.unlink(missing_ok=True)
 
     def _scan_raw_market_batches(
         self,
@@ -457,7 +538,9 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             )
             if self._pmxt_cache_dir is not None:
                 with suppress(OSError, pa.ArrowException):
-                    self._write_market_cache(hour, table)
+                    self._write_market_cache(
+                        hour, table, metadata=self._cache_metadata_for_hour(hour)
+                    )
             return table
 
         remote_table = self._load_remote_market_table(hour, batch_size=batch_size)
@@ -465,7 +548,9 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             remote_table = self._filter_table_to_token(remote_table)
             if self._pmxt_cache_dir is not None:
                 with suppress(OSError, pa.ArrowException):
-                    self._write_market_cache(hour, remote_table)
+                    self._write_market_cache(
+                        hour, remote_table, metadata=self._cache_metadata_for_hour(hour)
+                    )
             return remote_table
 
         return None
@@ -482,7 +567,9 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             if self._pmxt_cache_dir is not None:
                 table = pa.Table.from_batches(batches) if batches else self._empty_market_table()
                 with suppress(OSError, pa.ArrowException):
-                    self._write_market_cache(hour, table)
+                    self._write_market_cache(
+                        hour, table, metadata=self._cache_metadata_for_hour(hour)
+                    )
             return batches
 
         batches = self._load_remote_market_batches(hour, batch_size=batch_size)
@@ -490,7 +577,9 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
             if self._pmxt_cache_dir is not None:
                 table = pa.Table.from_batches(batches) if batches else self._empty_market_table()
                 with suppress(OSError, pa.ArrowException):
-                    self._write_market_cache(hour, table)
+                    self._write_market_cache(
+                        hour, table, metadata=self._cache_metadata_for_hour(hour)
+                    )
             return batches
 
         return None
@@ -780,7 +869,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
 
     @staticmethod
     def _timestamp_to_ms_string(timestamp_secs: float) -> str:
-        return f"{timestamp_secs * 1000:.6f}"
+        return format(Decimal(str(timestamp_secs)) * Decimal("1000"), "f")
 
     @staticmethod
     def _decode_book_snapshot(payload_text: str) -> _PMXTBookSnapshotPayload:
@@ -837,6 +926,22 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         ts_init = int(getattr(record, "ts_init", ts_event))
         return (ts_event, ts_init)
 
+    @staticmethod
+    def _retimestamp_deltas(deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas:
+        exact_deltas = [
+            OrderBookDelta(
+                instrument_id=delta.instrument_id,
+                action=delta.action,
+                order=delta.order,
+                flags=delta.flags,
+                sequence=delta.sequence,
+                ts_event=ts_event,
+                ts_init=ts_event,
+            )
+            for delta in deltas.deltas
+        ]
+        return OrderBookDeltas(deltas.instrument_id, exact_deltas)
+
     def _payload_sort_key(self, update_type: str, payload_text: str) -> tuple[int, int]:
         if update_type == "book_snapshot":
             timestamp = self._decode_book_snapshot(payload_text).timestamp
@@ -872,6 +977,10 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         )
         if deltas is None:
             return local_book, has_snapshot
+        deltas = self._retimestamp_deltas(
+            deltas,
+            ts_event=self._timestamp_to_ns(payload.timestamp),
+        )
 
         event_ns = deltas.ts_event
         local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
@@ -908,6 +1017,10 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         quotes = self._to_price_change(payload)
         deltas = quotes.parse_to_deltas(
             instrument=instrument, ts_init=self._timestamp_to_ns(payload.timestamp)
+        )
+        deltas = self._retimestamp_deltas(
+            deltas,
+            ts_event=self._timestamp_to_ns(payload.timestamp),
         )
         local_book.apply_deltas(deltas)
 
@@ -953,6 +1066,8 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
         events: list[OrderBookDeltas] = []
         hours = self._archive_hours(start_ts, end_ts)
         last_payload_key: tuple[int, int] | None = None
+        emitted_snapshot = False
+        seen_price_change_payloads: set[str] = set()
         gap_hours: list[pd.Timestamp] = []
         self._pmxt_last_load_gap_hours = ()
 
@@ -966,6 +1081,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
                 # potentially stale state.
                 gap_hours.append(hour)
                 has_snapshot = False
+                emitted_snapshot = False
                 local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
                 continue
             if not batches:
@@ -984,6 +1100,7 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
                 if last_payload_key is not None and payload_key < last_payload_key:
                     continue
                 if update_type == "book_snapshot":
+                    event_count_before = len(events)
                     local_book, has_snapshot = self._process_book_snapshot(
                         payload_text,
                         token_id=token_id,
@@ -995,10 +1112,19 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
                         end_ns=end_ns,
                         include_order_book=include_order_book,
                     )
+                    if len(events) > event_count_before and bool(
+                        getattr(events[-1], "is_snapshot", False)
+                    ):
+                        emitted_snapshot = True
                     last_payload_key = payload_key
                     continue
 
                 if update_type == "price_change":
+                    if has_snapshot and payload_text in seen_price_change_payloads:
+                        continue
+                    if has_snapshot:
+                        seen_price_change_payloads.add(payload_text)
+                    event_count_before = len(events)
                     local_book = self._process_price_change(
                         payload_text,
                         token_id=token_id,
@@ -1010,6 +1136,21 @@ class PolymarketPMXTDataLoader(PolymarketDataLoader):
                         end_ns=end_ns,
                         include_order_book=include_order_book,
                     )
+                    if len(events) > event_count_before:
+                        if not emitted_snapshot:
+                            first_delta = events.pop()
+                            try:
+                                events.append(
+                                    local_book.to_deltas_c(
+                                        int(first_delta.ts_event),
+                                        int(getattr(first_delta, "ts_init", first_delta.ts_event)),
+                                    )
+                                )
+                                emitted_snapshot = True
+                            except Exception:
+                                events.append(first_delta)
+                        else:
+                            emitted_snapshot = True
                     last_payload_key = payload_key
 
         events.sort(key=self._event_sort_key)

--- a/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
+++ b/prediction_market_extensions/adapters/prediction_market/backtest_utils.py
@@ -358,6 +358,11 @@ def compute_binary_settlement_pnl(
 ) -> float | None:
     """
     Compute binary-market PnL by marking any remaining position to settlement.
+
+    ``resolved_outcome`` is token-level for the instrument being settled:
+    ``1.0`` means the traded token pays out, ``0.0`` means it expires
+    worthless. Fill ``side`` values are retained for display compatibility and
+    do not invert the payout.
     """
     if resolved_outcome is None:
         return None
@@ -367,7 +372,6 @@ def compute_binary_settlement_pnl(
     cash = 0.0
     open_qty = 0.0
     commissions = 0.0
-    contract_side = "yes"
     saw_fill = False
 
     for event in fill_events:
@@ -377,9 +381,6 @@ def compute_binary_settlement_pnl(
         commission = _parse_numeric(event.get("commission"), default=0.0)
         if quantity <= 0.0 or price is None:
             continue
-        event_side = str(event.get("side") or "").strip().casefold()
-        if event_side in {"yes", "no"}:
-            contract_side = event_side
         saw_fill = True
 
         commissions += commission
@@ -392,9 +393,7 @@ def compute_binary_settlement_pnl(
 
     if not saw_fill:
         return None
-    settlement_value = (
-        float(resolved_outcome) if contract_side == "yes" else 1.0 - float(resolved_outcome)
-    )
+    settlement_value = float(resolved_outcome)
     return cash + (settlement_value * open_qty) - commissions
 
 

--- a/prediction_market_extensions/adapters/prediction_market/fill_model.py
+++ b/prediction_market_extensions/adapters/prediction_market/fill_model.py
@@ -69,12 +69,12 @@ def _order_quantity(order) -> float | None:
 
 
 def _is_entry_order(order) -> bool:
+    if getattr(order, "reduce_only", False):
+        return False
     intent = parse_order_intent(getattr(order, "tags", None))
     if intent == "entry":
         return True
     if intent == "exit":
-        return False
-    if getattr(order, "reduce_only", False):
         return False
     return order.side == OrderSideEnum.BUY
 

--- a/prediction_market_extensions/adapters/prediction_market/info_sanitization.py
+++ b/prediction_market_extensions/adapters/prediction_market/info_sanitization.py
@@ -77,34 +77,30 @@ def extract_resolution_metadata(info: Mapping[str, Any] | None) -> dict[str, Any
 def sanitize_info_for_simulation(info: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return a copy of `info` with resolution-revealing fields stripped.
 
-    Top-level resolution keys are removed. Per-token entries are shallow-copied
-    so per-token resolution flags can be redacted without mutating the caller's
-    original payload.
+    Resolution keys are removed recursively so nested event/token payloads
+    cannot leak the result through `instrument.info`.
     """
     if not info:
         return {}
 
-    sanitized: dict[str, Any] = {
-        key: value for key, value in info.items() if key not in _RESOLUTION_TOP_LEVEL_KEYS
+    return _sanitize_mapping(info)
+
+
+def _sanitize_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _sanitize_mapping(value)
+    if isinstance(value, list):
+        return [_sanitize_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_value(item) for item in value)
+    return value
+
+
+def _sanitize_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    redacted_keys = _RESOLUTION_TOP_LEVEL_KEYS | _RESOLUTION_TOKEN_KEYS
+    return {
+        key: _sanitize_value(item) for key, item in value.items() if str(key) not in redacted_keys
     }
-
-    raw_tokens = sanitized.get("tokens")
-    if isinstance(raw_tokens, list):
-        scrubbed_tokens: list[Any] = []
-        for entry in raw_tokens:
-            if isinstance(entry, Mapping):
-                scrubbed_tokens.append(
-                    {
-                        key: value
-                        for key, value in entry.items()
-                        if key not in _RESOLUTION_TOKEN_KEYS
-                    }
-                )
-            else:
-                scrubbed_tokens.append(entry)
-        sanitized["tokens"] = scrubbed_tokens
-
-    return sanitized
 
 
 __all__ = [

--- a/prediction_market_extensions/adapters/prediction_market/research.py
+++ b/prediction_market_extensions/adapters/prediction_market/research.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import re
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
@@ -36,6 +37,7 @@ from nautilus_trader.model.objects import Currency, Money
 from nautilus_trader.risk.config import RiskEngineConfig
 from nautilus_trader.trading.strategy import Strategy
 
+from prediction_market_extensions import install_commission_patch
 from prediction_market_extensions.adapters.prediction_market.backtest_utils import (
     _timestamp_to_naive_utc_datetime,
     build_brier_inputs,
@@ -64,9 +66,28 @@ from prediction_market_extensions.analysis.legacy_backtesting.models import (
 from prediction_market_extensions.analysis.legacy_plot_adapter import (
     save_legacy_backtest_layout,
 )
+from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
+from prediction_market_extensions.backtesting._prediction_market_order_guard import (
+    PredictionMarketOrderGuard,
+)
 from prediction_market_extensions.backtesting._result_policies import (
     apply_binary_settlement_pnl,
 )
+
+_DEFAULT_LATENCY_MODEL = object()
+_DEFAULT_PREDICTION_MARKET_LATENCY = StaticLatencyConfig(
+    base_latency_ms=75.0,
+    insert_latency_ms=10.0,
+    update_latency_ms=5.0,
+    cancel_latency_ms=5.0,
+)
+
+
+def _default_prediction_market_latency_model() -> Any:
+    latency_model = _DEFAULT_PREDICTION_MARKET_LATENCY.build_latency_model()
+    if latency_model is None:
+        raise AssertionError("default prediction-market latency model must be non-zero")
+    return latency_model
 
 
 def _extract_account_pnl_series(engine: BacktestEngine) -> pd.Series:
@@ -235,8 +256,152 @@ def _pairs_to_series(pairs: Sequence[tuple[str, float]] | Sequence[tuple[Any, fl
     return series.groupby(series.index).last().sort_index()
 
 
+def _series_value_at_or_before(series: pd.Series, timestamp: pd.Timestamp) -> float | None:
+    if series.empty:
+        return None
+    prior = series.loc[series.index <= timestamp]
+    if prior.empty:
+        return float(series.iloc[0])
+    return float(prior.iloc[-1])
+
+
+def _result_initial_capital(
+    result: Mapping[str, Any],
+    *,
+    equity_series: pd.Series,
+    cash_series: pd.Series,
+    pnl_series: pd.Series,
+) -> float | None:
+    explicit = _coerce_float(result.get("initial_cash"))
+    if explicit is not None:
+        return explicit
+
+    if not equity_series.empty:
+        initial = float(equity_series.iloc[0])
+        pnl_at_start = _series_value_at_or_before(pnl_series, pd.Timestamp(equity_series.index[0]))
+        if pnl_at_start is not None:
+            return initial - pnl_at_start
+        return initial
+
+    if not cash_series.empty:
+        initial = float(cash_series.iloc[0])
+        pnl_at_start = _series_value_at_or_before(pnl_series, pd.Timestamp(cash_series.index[0]))
+        if pnl_at_start is not None:
+            return initial - pnl_at_start
+        return initial
+
+    return None
+
+
+def _initial_capital_from_pnl_series(
+    *, equity_series: pd.Series, pnl_series: pd.Series
+) -> float | None:
+    if equity_series.empty:
+        return None
+    pnl_at_start = _series_value_at_or_before(pnl_series, pd.Timestamp(equity_series.index[0]))
+    if pnl_at_start is None:
+        return None
+    return float(equity_series.iloc[0]) - pnl_at_start
+
+
+def _joint_portfolio_initial_capital(
+    result: Mapping[str, Any], *, equity_series: pd.Series
+) -> float | None:
+    explicit = _coerce_float(result.get("joint_portfolio_initial_cash"))
+    if explicit is not None:
+        return explicit
+    pnl_series = _pairs_to_series(result.get("joint_portfolio_pnl_series") or [])
+    return _initial_capital_from_pnl_series(
+        equity_series=equity_series,
+        pnl_series=pnl_series,
+    )
+
+
+def _return_fraction(*, initial_capital: float, final_equity: float) -> float:
+    if not math.isfinite(initial_capital) or initial_capital <= 0.0:
+        return float("nan")
+    return (float(final_equity) - float(initial_capital)) / float(initial_capital)
+
+
+def _series_with_initial_capital_basis(
+    series: pd.Series,
+    *,
+    initial_capital: float | None,
+) -> pd.Series:
+    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric.empty or initial_capital is None or not math.isfinite(float(initial_capital)):
+        return numeric
+
+    first = float(numeric.iloc[0])
+    initial = float(initial_capital)
+    if abs(first - initial) <= 1e-12:
+        return numeric
+
+    first_ts = pd.Timestamp(numeric.index[0])
+    if pd.isna(first_ts) or first_ts.value <= 0:
+        return numeric
+
+    basis = pd.Series(
+        [initial],
+        index=pd.DatetimeIndex([first_ts - pd.Timedelta(nanoseconds=1)]),
+        dtype=float,
+    )
+    return pd.concat([basis, numeric]).groupby(level=0).last().sort_index()
+
+
 def _to_legacy_datetime(timestamp: pd.Timestamp) -> datetime:
     return _timestamp_to_naive_utc_datetime(pd.Timestamp(timestamp))
+
+
+def _result_base_label(result: Mapping[str, Any], market_key: str | None) -> str:
+    if market_key is not None:
+        value = result.get(market_key)
+        if value not in (None, ""):
+            return str(value)
+
+    for key in ("slug", "market", "instrument_id"):
+        value = result.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return "unknown"
+
+
+def _result_label_disambiguator(result: Mapping[str, Any]) -> str | None:
+    for key in ("outcome", "realized_outcome", "instrument_id", "token_id", "token_index"):
+        value = result.get(key)
+        if value in (None, ""):
+            continue
+        return str(value)
+    return None
+
+
+def _unique_result_labels(results: Sequence[dict[str, Any]], market_key: str | None) -> list[str]:
+    base_labels = [_result_base_label(result, market_key) for result in results]
+    base_counts = Counter(base_labels)
+    base_seen: Counter[str] = Counter()
+    used_labels: set[str] = set()
+    labels: list[str] = []
+
+    for result, base_label in zip(results, base_labels, strict=True):
+        base_seen[base_label] += 1
+        label = base_label
+        if base_counts[base_label] > 1 or label in used_labels:
+            disambiguator = _result_label_disambiguator(result)
+            if disambiguator is not None and disambiguator != base_label:
+                label = f"{base_label} ({disambiguator})"
+            else:
+                label = f"{base_label} #{base_seen[base_label]}"
+
+        suffix = 2
+        unique_label = label
+        while unique_label in used_labels:
+            unique_label = f"{label} #{suffix}"
+            suffix += 1
+
+        labels.append(unique_label)
+        used_labels.add(unique_label)
+
+    return labels
 
 
 def _series_to_iso_pairs(series: pd.Series) -> list[tuple[str, float]]:
@@ -271,11 +436,256 @@ def _extend_active_range(
     active_ranges[label] = (min(current_start, start), max(current_end, end))
 
 
-def _parse_float_like(value: Any, default: float = 0.0) -> float:
+def _result_settlement_active_cutoff(result: Mapping[str, Any]) -> pd.Timestamp | None:
+    if not bool(result.get("settlement_pnl_applied")):
+        return None
+    timestamp = pd.to_datetime(result.get("settlement_series_time"), utc=True, errors="coerce")
+    if pd.isna(timestamp):
+        return None
+    return pd.Timestamp(timestamp)
+
+
+def _record_active_cutoff(
+    active_cutoffs: dict[str, pd.Timestamp],
+    label: str,
+    result: Mapping[str, Any],
+) -> None:
+    cutoff = _result_settlement_active_cutoff(result)
+    if cutoff is None:
+        return
+    active_cutoffs[label] = (
+        min(active_cutoffs[label], cutoff) if label in active_cutoffs else cutoff
+    )
+
+
+def _result_brier_cutoff(result: Mapping[str, Any]) -> pd.Timestamp | None:
+    for key in ("settlement_series_time", "settlement_observable_time", "market_close_time_ns"):
+        timestamp = pd.to_datetime(result.get(key), utc=True, errors="coerce")
+        if not pd.isna(timestamp):
+            return pd.Timestamp(timestamp)
+    return None
+
+
+def _truncate_brier_series_at_cutoff(
+    result: Mapping[str, Any], *series_values: pd.Series
+) -> tuple[pd.Series, ...]:
+    cutoff = _result_brier_cutoff(result)
+    if cutoff is None:
+        return series_values
+
+    truncated: list[pd.Series] = []
+    for series in series_values:
+        if series.empty:
+            truncated.append(series)
+            continue
+        if not isinstance(series.index, pd.DatetimeIndex):
+            index = pd.to_datetime(series.index, utc=True, errors="coerce")
+            valid_mask = ~pd.isna(index)
+            if not bool(valid_mask.any()):
+                truncated.append(pd.Series(dtype=float))
+                continue
+            series = pd.Series(
+                series.to_numpy()[valid_mask],
+                index=pd.DatetimeIndex(index[valid_mask]),
+                dtype=float,
+            )
+        truncated.append(series.loc[series.index < cutoff])
+    return tuple(truncated)
+
+
+def _active_range_mask(
+    timeline: pd.DatetimeIndex,
+    *,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    cutoff: pd.Timestamp | None,
+) -> Any:
+    if cutoff is None:
+        return (timeline >= start) & (timeline <= end)
+    return (timeline >= start) & (timeline < cutoff)
+
+
+def _fill_event_timestamp(event: Mapping[str, Any]) -> pd.Timestamp | None:
+    for key in ("timestamp", "ts_last", "ts_event", "ts_init"):
+        timestamp = pd.to_datetime(event.get(key), utc=True, errors="coerce")
+        if isinstance(timestamp, pd.DatetimeIndex):
+            if len(timestamp) == 0:
+                continue
+            timestamp = timestamp[0]
+        if pd.isna(timestamp):
+            continue
+        return pd.Timestamp(timestamp)
+    return None
+
+
+def _fill_event_position_delta(event: Mapping[str, Any]) -> float | None:
+    quantity = _parse_float_like(event.get("quantity"), default=0.0)
+    if quantity <= 0.0:
+        return None
+
+    action = _fill_event_action(event, default_missing=None)
+    if action == "buy":
+        return quantity
+    if action == "sell":
+        return -quantity
+    return None
+
+
+def _normalize_fill_action_value(
+    value: object,
+    *,
+    default_for_token_side: str | None,
+) -> str | None:
+    if _is_missing_fill_value(value):
+        return None
+    text = str(value or "").strip().lower()
+    if text in {"buy", "bought"}:
+        return "buy"
+    if text in {"sell", "sold"}:
+        return "sell"
+    if text in {"yes", "no"}:
+        return default_for_token_side
+    return None
+
+
+def _is_missing_fill_value(value: object) -> bool:
     if value is None:
+        return True
+    try:
+        missing = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    try:
+        return bool(missing)
+    except (TypeError, ValueError):
+        return False
+
+
+def _fill_event_action(
+    event: Mapping[str, Any],
+    *,
+    default_missing: str | None,
+) -> str | None:
+    for key in ("action", "order_side"):
+        normalized = _normalize_fill_action_value(
+            event.get(key),
+            default_for_token_side=None,
+        )
+        if normalized is not None:
+            return normalized
+
+    # Tolerate raw venue/Data API rows where `side` is BUY/SELL, while keeping
+    # YES/NO as the token side under the fill_events schema.
+    normalized_side = _normalize_fill_action_value(
+        event.get("side"),
+        default_for_token_side=None,
+    )
+    if normalized_side is not None:
+        return normalized_side
+
+    for key in ("action", "order_side"):
+        normalized = _normalize_fill_action_value(
+            event.get(key),
+            default_for_token_side="buy",
+        )
+        if normalized is not None:
+            return normalized
+
+    if _is_missing_fill_value(event.get("action")) and _is_missing_fill_value(
+        event.get("order_side")
+    ):
+        return default_missing
+    return None
+
+
+def _result_active_position_intervals(
+    result: Mapping[str, Any],
+) -> list[tuple[pd.Timestamp, pd.Timestamp | None]] | None:
+    fill_events = result.get("fill_events")
+    if not isinstance(fill_events, Sequence) or isinstance(fill_events, str | bytes):
+        return None
+
+    deltas_by_time: dict[pd.Timestamp, float] = {}
+    parsed_event = False
+    for event in fill_events:
+        if not isinstance(event, Mapping):
+            continue
+        timestamp = _fill_event_timestamp(event)
+        delta = _fill_event_position_delta(event)
+        if timestamp is None or delta is None:
+            continue
+        parsed_event = True
+        deltas_by_time[timestamp] = deltas_by_time.get(timestamp, 0.0) + delta
+
+    if not parsed_event:
+        return None
+
+    intervals: list[tuple[pd.Timestamp, pd.Timestamp | None]] = []
+    position = 0.0
+    interval_start: pd.Timestamp | None = None
+    epsilon = 1e-12
+
+    for timestamp in sorted(deltas_by_time):
+        previous_position = position
+        position += deltas_by_time[timestamp]
+        was_open = abs(previous_position) > epsilon
+        is_open = abs(position) > epsilon
+
+        if not was_open and is_open:
+            interval_start = timestamp
+        elif was_open and not is_open:
+            if interval_start is not None:
+                intervals.append((interval_start, timestamp))
+            interval_start = None
+        elif was_open and is_open and previous_position * position < 0:
+            if interval_start is not None:
+                intervals.append((interval_start, timestamp))
+            interval_start = timestamp
+
+    if interval_start is not None and abs(position) > epsilon:
+        intervals.append((interval_start, None))
+
+    return intervals
+
+
+def _position_interval_mask(
+    timeline: pd.DatetimeIndex,
+    *,
+    start: pd.Timestamp,
+    end: pd.Timestamp | None,
+    fallback_end: pd.Timestamp,
+    cutoff: pd.Timestamp | None,
+) -> Any:
+    effective_end = fallback_end if end is None else end
+    inclusive_end = end is None and cutoff is None
+    if cutoff is not None and cutoff <= effective_end:
+        effective_end = cutoff
+        inclusive_end = False
+
+    mask = timeline >= start
+    if inclusive_end:
+        return mask & (timeline <= effective_end)
+    return mask & (timeline < effective_end)
+
+
+def _overlay_range_mask(
+    timeline: pd.DatetimeIndex,
+    *,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    cutoff: pd.Timestamp | None,
+) -> Any:
+    if cutoff is None:
+        return (timeline >= start) & (timeline <= end)
+    return (timeline >= start) & (timeline <= cutoff)
+
+
+def _parse_float_like(value: Any, default: float = 0.0) -> float:
+    if _is_missing_fill_value(value):
         return default
     if isinstance(value, int | float):
-        return float(value)
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else default
 
     text = str(value).strip().replace("_", "").replace("\u2212", "-")
     if not text:
@@ -286,9 +696,46 @@ def _parse_float_like(value: Any, default: float = 0.0) -> float:
         return default
 
     try:
-        return float(match.group(0))
+        parsed = float(match.group(0))
     except ValueError:
         return default
+    return parsed if math.isfinite(parsed) else default
+
+
+def _first_non_missing_fill_value(source: Any, *keys: str) -> Any:
+    for key in keys:
+        try:
+            value = source.get(key)
+        except AttributeError:
+            continue
+        if not _is_missing_fill_value(value):
+            return value
+    return None
+
+
+def _fill_value_text(value: Any) -> str:
+    if _is_missing_fill_value(value):
+        return ""
+    return str(value).strip()
+
+
+def _result_has_position_activity(result: Mapping[str, Any]) -> bool:
+    fills_count = result.get("fills")
+    if fills_count is not None:
+        try:
+            if int(fills_count) > 0:
+                return True
+        except (TypeError, ValueError):
+            pass
+
+    fill_events = result.get("fill_events")
+    if not isinstance(fill_events, Sequence) or isinstance(fill_events, str | bytes):
+        return False
+
+    return any(
+        isinstance(event, Mapping) and _parse_float_like(event.get("quantity"), default=0.0) > 0.0
+        for event in fill_events
+    )
 
 
 def _serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]:
@@ -314,52 +761,70 @@ def _serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> lis
     events: list[dict[str, Any]] = []
     for idx, (_, row) in enumerate(frame.iterrows(), start=1):
         quantity = _parse_float_like(
-            row.get("filled_qty", row.get("last_qty", row.get("quantity")))
+            _first_non_missing_fill_value(row, "last_qty", "filled_qty", "quantity")
         )
         if quantity <= 0.0:
             continue
 
         timestamp = pd.to_datetime(
-            row.get("ts_last", row.get("ts_event", row.get("ts_init"))), utc=True, errors="coerce"
+            _first_non_missing_fill_value(row, "ts_last", "ts_event", "ts_init"),
+            utc=True,
+            errors="coerce",
         )
         if pd.isna(timestamp):
             continue
         assert isinstance(timestamp, pd.Timestamp)
 
-        side_source = str(
-            row.get("instrument_side")
-            or row.get("instrument_id")
-            or row.get("symbol")
-            or row.get("market_id")
-            or market_id
+        raw_side = _fill_value_text(row.get("side")).lower()
+        action = _fill_event_action(
+            {
+                "action": row.get("action"),
+                "order_side": row.get("order_side"),
+                "side": row.get("side"),
+            },
+            default_missing="buy",
         )
+        if action is None:
+            continue
+
+        side_source_value = _first_non_missing_fill_value(row, "instrument_side")
+        if side_source_value is None and raw_side in {"yes", "no"}:
+            side_source_value = raw_side
+        if side_source_value is None:
+            side_source_value = _first_non_missing_fill_value(
+                row, "instrument_id", "symbol", "market_id"
+            )
+        side_source = str(side_source_value if side_source_value is not None else market_id)
+        side_source_upper = side_source.upper()
         normalized_side = (
             "no"
             if (
-                side_source.upper().endswith("NO")
-                or "-NO" in side_source.upper()
-                or ".NO." in side_source.upper()
-                or "_NO" in side_source.upper()
+                side_source_upper.endswith("NO")
+                or "-NO" in side_source_upper
+                or ".NO." in side_source_upper
+                or "_NO" in side_source_upper
             )
             else inferred_side
         )
 
+        order_id_value = _first_non_missing_fill_value(
+            row, "client_order_id", "venue_order_id", "order_id"
+        )
+        order_id = _fill_value_text(order_id_value) or f"fill-{idx}"
+
         events.append(
             {
-                "order_id": str(
-                    row.get("client_order_id")
-                    or row.get("venue_order_id")
-                    or row.get("order_id")
-                    or f"fill-{idx}"
-                ),
+                "order_id": order_id,
                 "market_id": market_id,
-                "action": str(row.get("side") or row.get("order_side") or "BUY").strip().lower(),
+                "action": action,
                 "side": normalized_side,
-                "price": _parse_float_like(row.get("avg_px", row.get("last_px", row.get("price")))),
+                "price": _parse_float_like(
+                    _first_non_missing_fill_value(row, "last_px", "avg_px", "price")
+                ),
                 "quantity": quantity,
                 "timestamp": timestamp.isoformat(),
                 "commission": _parse_float_like(
-                    row.get("commissions", row.get("commission", row.get("fees")))
+                    _first_non_missing_fill_value(row, "commission", "commissions", "fees")
                 ),
             }
         )
@@ -375,35 +840,38 @@ def _deserialize_fill_events(
     market_side = legacy_plot_adapter._infer_market_side(models_module, market_id)
 
     for idx, event in enumerate(fill_events, start=1):
-        timestamp = pd.to_datetime(event.get("timestamp"), utc=True, errors="coerce")
-        if pd.isna(timestamp):
+        timestamp = _fill_event_timestamp(event)
+        if timestamp is None:
             continue
-        assert isinstance(timestamp, pd.Timestamp)
 
-        quantity = float(event.get("quantity") or 0.0)
+        quantity = _parse_float_like(event.get("quantity"), default=0.0)
         if quantity <= 0.0:
             continue
 
-        action = str(event.get("action") or "buy").strip().lower()
-        event_side = str(event.get("side") or "").strip().lower()
+        action = _fill_event_action(event, default_missing="buy")
+        if action is None:
+            continue
+
+        event_side = _fill_value_text(event.get("side")).lower()
         if event_side == "no":
             fill_side = models_module.Side.NO
         elif event_side == "yes":
             fill_side = models_module.Side.YES
         else:
             fill_side = market_side
+        order_id = _fill_value_text(event.get("order_id")) or f"fill-{idx}"
         fills.append(
             models_module.Fill(
-                order_id=str(event.get("order_id") or f"fill-{idx}"),
+                order_id=order_id,
                 market_id=market_id,
                 action=models_module.OrderAction.BUY
                 if action == "buy"
                 else models_module.OrderAction.SELL,
                 side=fill_side,
-                price=float(event.get("price") or 0.0),
+                price=_parse_float_like(event.get("price"), default=0.0),
                 quantity=quantity,
                 timestamp=_to_legacy_datetime(timestamp),
-                commission=float(event.get("commission") or 0.0),
+                commission=_parse_float_like(event.get("commission"), default=0.0),
             )
         )
 
@@ -411,14 +879,19 @@ def _deserialize_fill_events(
     return fills
 
 
-def _aggregate_brier_frames(results: Sequence[dict[str, Any]]) -> dict[str, pd.DataFrame]:
+def _aggregate_brier_frames(
+    results: Sequence[dict[str, Any]], *, market_key: str | None
+) -> dict[str, pd.DataFrame]:
     frames: dict[str, pd.DataFrame] = {}
+    labels = _unique_result_labels(results, market_key)
 
-    for result in results:
-        market_id = str(result.get("slug") or result.get("market") or "unknown")
+    for result, market_id in zip(results, labels, strict=True):
         user_series = _pairs_to_series(result.get("user_probability_series") or [])
         market_series = _pairs_to_series(result.get("market_probability_series") or [])
         outcome_series = _pairs_to_series(result.get("outcome_series") or [])
+        user_series, market_series, outcome_series = _truncate_brier_series_at_cutoff(
+            result, user_series, market_series, outcome_series
+        )
         if user_series.empty or market_series.empty or outcome_series.empty:
             continue
 
@@ -451,6 +924,9 @@ def _aggregate_brier_unavailable_reason(results: Sequence[dict[str, Any]]) -> st
             market_series = _pairs_to_series(result.get("market_probability_series") or [])
         if outcome_series.empty:
             outcome_series = _pairs_to_series(result.get("outcome_series") or [])
+        user_series, market_series, outcome_series = _truncate_brier_series_at_cutoff(
+            result, user_series, market_series, outcome_series
+        )
         if not user_series.empty and not market_series.empty and not outcome_series.empty:
             break
 
@@ -580,6 +1056,7 @@ def _build_total_summary_brier_frame(brier_frames: Mapping[str, pd.DataFrame]) -
 def _build_summary_brier_extra_panels(
     *,
     results: Sequence[dict[str, Any]],
+    market_key: str | None,
     resolved_plot_panels: Sequence[str],
     max_points_per_market: int,
 ) -> dict[str, Any]:
@@ -590,7 +1067,7 @@ def _build_summary_brier_extra_panels(
     ):
         return extra_panels
 
-    brier_frames = _aggregate_brier_frames(results)
+    brier_frames = _aggregate_brier_frames(results, market_key=market_key)
     if brier_frames:
         if PANEL_TOTAL_BRIER_ADVANTAGE in resolved_plot_panels:
             total_frame = _build_total_summary_brier_frame(brier_frames)
@@ -637,6 +1114,14 @@ def _apply_summary_layout_overrides(
         return apply_fn(layout, initial_cash=float(initial_cash))
 
 
+def _add_engine_data_by_type(engine: BacktestEngine, records: Sequence[Any]) -> None:
+    records_by_type: dict[type[Any], list[Any]] = {}
+    for record in records:
+        records_by_type.setdefault(type(record), []).append(record)
+    for typed_records in records_by_type.values():
+        engine.add_data(typed_records)
+
+
 def run_market_backtest(
     *,
     market_id: str,
@@ -650,7 +1135,7 @@ def run_market_backtest(
     base_currency: Currency,
     fee_model: Any,
     fill_model: Any | None = None,
-    apply_default_fill_model: bool = True,
+    apply_default_fill_model: bool = False,
     initial_cash: float,
     probability_window: int,
     price_attr: str,
@@ -660,28 +1145,35 @@ def run_market_backtest(
     market_key: str = "market",
     open_browser: bool = False,
     return_summary_series: bool = False,
-    book_type: BookType = BookType.L1_MBP,
-    liquidity_consumption: bool = False,
-    queue_position: bool = False,
-    latency_model: Any | None = None,
+    book_type: BookType = BookType.L2_MBP,
+    liquidity_consumption: bool = True,
+    queue_position: bool = True,
+    latency_model: Any | None = _DEFAULT_LATENCY_MODEL,
+    nautilus_log_level: str = "INFO",
 ) -> dict[str, Any]:
     """
     Run one prediction-market backtest and emit a legacy chart.
 
-    Prediction-market market orders are taker-style orders against a central
-    limit order book. Historical backtests here replay trades/bars without full
-    book depth, so we apply a deterministic one-tick adverse fill model by
-    default to approximate slippage. Callers can override this with a custom
-    ``fill_model`` if needed.
+    The repository is L2-book native, so this legacy helper defaults to
+    passive ``L2_MBP`` book execution with queue position and a static latency
+    model. Older synthetic taker fills remain available by passing
+    ``apply_default_fill_model=True`` or a custom ``fill_model``.
     """
+    install_commission_patch()
+    if latency_model is _DEFAULT_LATENCY_MODEL:
+        latency_model = _default_prediction_market_latency_model()
+    elif isinstance(latency_model, StaticLatencyConfig):
+        latency_model = latency_model.build_latency_model()
+
     if fill_model is None and apply_default_fill_model:
         fill_model = PredictionMarketTakerFillModel()
 
+    data_records = data if isinstance(data, list) else list(data)
     engine = BacktestEngine(
         config=BacktestEngineConfig(
             trader_id=TraderId("BACKTESTER-001"),
-            logging=LoggingConfig(log_level="WARNING"),
-            risk_engine=RiskEngineConfig(bypass=True),
+            logging=LoggingConfig(log_level=nautilus_log_level),
+            risk_engine=RiskEngineConfig(),
         )
     )
     engine.add_venue(
@@ -696,19 +1188,24 @@ def run_market_backtest(
         book_type=book_type,
         liquidity_consumption=liquidity_consumption,
         queue_position=queue_position,
+        bar_execution=False,
+        trade_execution=True,
     )
     engine.add_instrument(instrument)
-    engine.add_data(data if isinstance(data, list) else list(data))
+    _add_engine_data_by_type(engine, data_records)
+    order_guard = PredictionMarketOrderGuard()
+    order_guard.install(strategy)
     engine.add_strategy(strategy)
     engine.run()
 
     fills = engine.trader.generate_order_fills_report()
     positions = engine.trader.generate_positions_report()
     pnl = extract_realized_pnl(positions)
-    price_points = extract_price_points(data, price_attr=price_attr)
+    price_points = extract_price_points(data_records, price_attr=price_attr)
     realized_outcome = infer_realized_outcome(instrument)
     fill_events = _serialize_fill_events(market_id=market_id, fills_report=fills)
     result_warnings: list[str] = []
+    result_warnings.extend(order_guard.warnings)
     user_probabilities, market_probabilities, outcomes = build_brier_inputs(
         points=price_points,
         window=probability_window,
@@ -762,9 +1259,10 @@ def run_market_backtest(
 
     result = {
         market_key: market_id,
-        count_key: int(data_count) if data_count is not None else len(data),
+        count_key: int(data_count) if data_count is not None else len(data_records),
         "fills": len(fills),
         "pnl": pnl,
+        "initial_cash": float(initial_cash),
         "realized_outcome": realized_outcome,
         "fill_events": fill_events,
         "warnings": result_warnings,
@@ -875,10 +1373,25 @@ def save_aggregate_backtest_report(
     equity_series_by_market: dict[str, pd.Series] = {}
     cash_series_by_market: dict[str, pd.Series] = {}
     active_ranges: dict[str, tuple[pd.Timestamp, pd.Timestamp]] = {}
+    active_cutoffs: dict[str, pd.Timestamp] = {}
+    active_position_intervals: dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None]]] = {}
+    active_position_labels: set[str] = set()
+    initial_capital_by_label: dict[str, float] = {}
     timeline_points: set[pd.Timestamp] = set()
+    labels = _unique_result_labels(results, market_key)
 
-    for result in results:
-        label = str(result.get(market_key) or "unknown")
+    for result, label in zip(results, labels, strict=True):
+        _record_active_cutoff(active_cutoffs, label, result)
+        position_intervals = _result_active_position_intervals(result)
+        if position_intervals is None:
+            if _result_has_position_activity(result):
+                active_position_labels.add(label)
+        else:
+            active_position_intervals[label] = position_intervals
+            for interval_start, interval_end in position_intervals:
+                timeline_points.add(interval_start)
+                if interval_end is not None:
+                    timeline_points.add(interval_end)
         final_pnl = float(result.get("pnl") or 0.0)
 
         price_series = _pairs_to_series(result.get("price_series") or [])
@@ -911,7 +1424,14 @@ def save_aggregate_backtest_report(
 
         if equity_series.empty:
             if not pnl_series.empty:
-                start_equity = float(cash_series.iloc[0]) if not cash_series.empty else 100.0
+                explicit_initial_cash = _coerce_float(result.get("initial_cash"))
+                start_equity = (
+                    explicit_initial_cash
+                    if explicit_initial_cash is not None
+                    else float(cash_series.iloc[0])
+                    if not cash_series.empty
+                    else 100.0
+                )
                 equity_series = pnl_series.astype(float) + start_equity
             elif not price_series.empty:
                 equity_series = pd.Series(
@@ -939,6 +1459,15 @@ def save_aggregate_backtest_report(
                     dtype=float,
                 )
 
+        initial_capital = _result_initial_capital(
+            result,
+            equity_series=equity_series,
+            cash_series=cash_series,
+            pnl_series=pnl_series,
+        )
+        if initial_capital is not None:
+            initial_capital_by_label[label] = initial_capital
+
         if not equity_series.empty:
             equity_series_by_market[label] = equity_series.astype(float)
             timeline_points.update(equity_series.index.to_list())
@@ -958,6 +1487,8 @@ def save_aggregate_backtest_report(
     else:
         now = pd.Timestamp.now(tz="UTC")
         timeline = pd.DatetimeIndex([now])
+    if initial_capital_by_label and len(timeline) > 0 and timeline[0].value > 0:
+        timeline = pd.DatetimeIndex([timeline[0] - pd.Timedelta(nanoseconds=1)]).union(timeline)
 
     aggregate_equity = pd.Series(0.0, index=timeline, dtype=float)
     aggregate_cash = pd.Series(0.0, index=timeline, dtype=float)
@@ -987,26 +1518,48 @@ def save_aggregate_backtest_report(
         full_equity = _align_series_to_timeline(
             equity_series,
             timeline,
-            before=float(equity_series.iloc[0]),
+            before=initial_capital_by_label.get(label, float(equity_series.iloc[0])),
             after=float(equity_series.iloc[-1]),
         )
         full_cash = _align_series_to_timeline(
             cash_series,
             timeline,
-            before=float(cash_series.iloc[0]),
+            before=initial_capital_by_label.get(label, float(cash_series.iloc[0])),
             after=float(cash_series.iloc[-1]),
         )
 
         aggregate_equity = aggregate_equity.add(full_equity, fill_value=0.0)
         aggregate_cash = aggregate_cash.add(full_cash, fill_value=0.0)
 
-        active_mask = (timeline >= start) & (timeline <= end)
-        active_count.loc[active_mask] = active_count.loc[active_mask] + 1
+        if label in active_position_intervals:
+            for interval_start, interval_end in active_position_intervals[label]:
+                active_mask = _position_interval_mask(
+                    timeline,
+                    start=interval_start,
+                    end=interval_end,
+                    fallback_end=end,
+                    cutoff=active_cutoffs.get(label),
+                )
+                active_count.loc[active_mask] = active_count.loc[active_mask] + 1
+        elif label in active_position_labels:
+            active_mask = _active_range_mask(
+                timeline,
+                start=start,
+                end=end,
+                cutoff=active_cutoffs.get(label),
+            )
+            active_count.loc[active_mask] = active_count.loc[active_mask] + 1
 
+        overlay_mask = _overlay_range_mask(
+            timeline,
+            start=start,
+            end=end,
+            cutoff=active_cutoffs.get(label),
+        )
         clipped_equity = full_equity.copy()
         clipped_cash = full_cash.copy()
-        clipped_equity.loc[~active_mask] = float("nan")
-        clipped_cash.loc[~active_mask] = float("nan")
+        clipped_equity.loc[~overlay_mask] = float("nan")
+        clipped_cash.loc[~overlay_mask] = float("nan")
         overlay_equity[label] = clipped_equity
         overlay_cash[label] = clipped_cash
 
@@ -1034,7 +1587,10 @@ def save_aggregate_backtest_report(
     max_drawdown = float(drawdowns.max()) if not drawdowns.empty else 0.0
     metrics = {
         "final_pnl": final_equity - initial_cash,
-        "total_return": 0.0 if initial_cash == 0 else (final_equity - initial_cash) / initial_cash,
+        "total_return": _return_fraction(
+            initial_capital=initial_cash,
+            final_equity=final_equity,
+        ),
         "max_drawdown": max_drawdown,
     }
 
@@ -1067,6 +1623,7 @@ def save_aggregate_backtest_report(
     output_abs.parent.mkdir(parents=True, exist_ok=True)
     extra_panels = _build_summary_brier_extra_panels(
         results=results,
+        market_key=market_key,
         resolved_plot_panels=resolved_plot_panels,
         max_points_per_market=max_points_per_market,
     )
@@ -1121,18 +1678,32 @@ def save_joint_portfolio_backtest_report(
     equity_series_by_market: dict[str, pd.Series] = {}
     cash_series_by_market: dict[str, pd.Series] = {}
     active_ranges: dict[str, tuple[pd.Timestamp, pd.Timestamp]] = {}
+    active_cutoffs: dict[str, pd.Timestamp] = {}
+    active_position_intervals: dict[str, list[tuple[pd.Timestamp, pd.Timestamp | None]]] = {}
+    active_position_labels: set[str] = set()
     timeline_points: set[pd.Timestamp] = set()
+    labels = _unique_result_labels(results, market_key)
 
     portfolio_equity = pd.Series(dtype=float)
     portfolio_cash = pd.Series(dtype=float)
 
-    for result in results:
+    for result, label in zip(results, labels, strict=True):
+        _record_active_cutoff(active_cutoffs, label, result)
+        position_intervals = _result_active_position_intervals(result)
+        if position_intervals is None:
+            if _result_has_position_activity(result):
+                active_position_labels.add(label)
+        else:
+            active_position_intervals[label] = position_intervals
+            for interval_start, interval_end in position_intervals:
+                timeline_points.add(interval_start)
+                if interval_end is not None:
+                    timeline_points.add(interval_end)
         if portfolio_equity.empty:
             portfolio_equity = _pairs_to_series(result.get("joint_portfolio_equity_series") or [])
         if portfolio_cash.empty:
             portfolio_cash = _pairs_to_series(result.get("joint_portfolio_cash_series") or [])
 
-        label = str(result.get(market_key) or "unknown")
         price_series = _pairs_to_series(result.get("price_series") or [])
         if not price_series.empty:
             if include_market_prices:
@@ -1184,29 +1755,59 @@ def save_joint_portfolio_backtest_report(
             dtype=float,
         )
 
+    joint_initial_capital = _joint_portfolio_initial_capital(
+        results[0], equity_series=portfolio_equity
+    )
+
     timeline_points.update(portfolio_equity.index.to_list())
     timeline_points.update(portfolio_cash.index.to_list())
     timeline = (
         pd.DatetimeIndex(sorted(timeline_points)) if timeline_points else portfolio_equity.index
     )
+    if joint_initial_capital is not None and len(timeline) > 0 and timeline[0].value > 0:
+        timeline = pd.DatetimeIndex([timeline[0] - pd.Timedelta(nanoseconds=1)]).union(timeline)
 
     aligned_equity = _align_series_to_timeline(
         portfolio_equity,
         timeline,
-        before=float(portfolio_equity.iloc[0]),
+        before=(
+            float(portfolio_equity.iloc[0])
+            if joint_initial_capital is None
+            else float(joint_initial_capital)
+        ),
         after=float(portfolio_equity.iloc[-1]),
     )
     aligned_cash = _align_series_to_timeline(
         portfolio_cash,
         timeline,
-        before=float(portfolio_cash.iloc[0]),
+        before=(
+            float(portfolio_cash.iloc[0])
+            if joint_initial_capital is None
+            else float(joint_initial_capital)
+        ),
         after=float(portfolio_cash.iloc[-1]),
     )
 
     active_count = pd.Series(0, index=timeline, dtype=int)
-    for start, end in active_ranges.values():
-        active_mask = (timeline >= start) & (timeline <= end)
-        active_count.loc[active_mask] = active_count.loc[active_mask] + 1
+    for label, (start, end) in active_ranges.items():
+        if label in active_position_intervals:
+            for interval_start, interval_end in active_position_intervals[label]:
+                active_mask = _position_interval_mask(
+                    timeline,
+                    start=interval_start,
+                    end=interval_end,
+                    fallback_end=end,
+                    cutoff=active_cutoffs.get(label),
+                )
+                active_count.loc[active_mask] = active_count.loc[active_mask] + 1
+        elif label in active_position_labels:
+            active_mask = _active_range_mask(
+                timeline,
+                start=start,
+                end=end,
+                cutoff=active_cutoffs.get(label),
+            )
+            active_count.loc[active_mask] = active_count.loc[active_mask] + 1
 
     overlay_equity: dict[str, pd.Series] = {}
     overlay_cash: dict[str, pd.Series] = {}
@@ -1244,7 +1845,12 @@ def save_joint_portfolio_backtest_report(
                 before=float(cash_series.iloc[0]),
                 after=float(cash_series.iloc[-1]),
             )
-            active_mask = (timeline >= start) & (timeline <= end)
+            active_mask = _overlay_range_mask(
+                timeline,
+                start=start,
+                end=end,
+                cutoff=active_cutoffs.get(label),
+            )
             clipped_equity = full_equity.copy()
             clipped_cash = full_cash.copy()
             clipped_equity.loc[~active_mask] = float("nan")
@@ -1273,7 +1879,10 @@ def save_joint_portfolio_backtest_report(
     max_drawdown = float(drawdowns.max()) if not drawdowns.empty else 0.0
     metrics = {
         "final_pnl": final_equity - initial_cash,
-        "total_return": 0.0 if initial_cash == 0 else (final_equity - initial_cash) / initial_cash,
+        "total_return": _return_fraction(
+            initial_capital=initial_cash,
+            final_equity=final_equity,
+        ),
         "max_drawdown": max_drawdown,
     }
 
@@ -1291,8 +1900,8 @@ def save_joint_portfolio_backtest_report(
         num_markets_resolved=len(results),
         market_prices=market_prices if include_market_prices else {},
         market_pnls={
-            str(item.get(market_key) or "unknown"): float(item.get("pnl") or 0.0)
-            for item in results
+            label: float(item.get("pnl") or 0.0)
+            for item, label in zip(results, labels, strict=True)
         },
         overlay_series=(
             {"equity": overlay_equity, "cash": overlay_cash} if include_overlay_series else {}
@@ -1309,6 +1918,7 @@ def save_joint_portfolio_backtest_report(
     output_abs.parent.mkdir(parents=True, exist_ok=True)
     extra_panels = _build_summary_brier_extra_panels(
         results=results,
+        market_key=market_key,
         resolved_plot_panels=resolved_plot_panels,
         max_points_per_market=max_points_per_market,
     )
@@ -1348,11 +1958,10 @@ def print_backtest_summary(
         print(empty_message)
         return
 
+    labels = _unique_result_labels(results, market_key)
     rows = [_summary_stats_for_result(result) for result in results]
     total_row = _summary_stats_total(rows=rows, results=results)
-    col_w = (
-        max(len("Market"), len("TOTAL"), *(len(str(result[market_key])) for result in results)) + 2
-    )
+    col_w = max(len("Market"), len("TOTAL"), *(len(label) for label in labels)) + 2
     count_w = max(8, len(count_label))
     header = (
         f"{'Market':<{col_w}} {count_label:>{count_w}} {'Fills':>6} {'Qty':>10} "
@@ -1362,9 +1971,9 @@ def print_backtest_summary(
     sep = "─" * len(header)
 
     print(f"\n{sep}\n{header}\n{sep}")
-    for result, row in zip(results, rows, strict=True):
+    for result, row, label in zip(results, rows, labels, strict=True):
         print(
-            f"{result[market_key]:<{col_w}} {result[count_key]:>{count_w}} "
+            f"{label:<{col_w}} {result[count_key]:>{count_w}} "
             f"{result['fills']:>6} {_format_summary_float(row['fill_qty'], 2):>10} "
             f"{_format_summary_float(row['avg_fill_price'], 4):>7} "
             f"{_format_summary_float(row['fill_notional'], 2):>10} "
@@ -1397,14 +2006,31 @@ def print_backtest_summary(
 
 def _summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]:
     fill_qty, fill_notional, avg_fill_price = _summary_fill_stats(result.get("fill_events") or ())
-    returns = _summary_returns_from_pairs(result.get("equity_series"))
+    equity_series = _pairs_to_series(result.get("equity_series") or [])
+    cash_series = _pairs_to_series(result.get("cash_series") or [])
+    pnl_series = _pairs_to_series(result.get("pnl_series") or [])
+    initial_capital = _result_initial_capital(
+        result,
+        equity_series=equity_series,
+        cash_series=cash_series,
+        pnl_series=pnl_series,
+    )
+    if equity_series.empty:
+        if not cash_series.empty:
+            equity_series = cash_series.astype(float)
+        elif not pnl_series.empty and initial_capital is not None:
+            equity_series = pnl_series.astype(float) + float(initial_capital)
+    returns = _summary_returns_from_series(equity_series, initial_capital=initial_capital)
     stats = _summary_return_stats(returns)
     coverage = _coerce_float(result.get("requested_coverage_ratio"))
     return {
         "fill_qty": fill_qty,
         "fill_notional": fill_notional,
         "avg_fill_price": avg_fill_price,
-        "return_pct": _summary_total_return_pct(result.get("equity_series")),
+        "return_pct": _summary_total_return_pct_from_series(
+            equity_series,
+            initial_capital=initial_capital,
+        ),
         "max_drawdown_pct": stats["max_drawdown_pct"],
         "sharpe": stats["sharpe"],
         "sortino": stats["sortino"],
@@ -1419,7 +2045,7 @@ def _summary_stats_total(
     fill_qty = sum(float(row.get("fill_qty") or 0.0) for row in rows)
     fill_notional = sum(float(row.get("fill_notional") or 0.0) for row in rows)
     avg_fill_price = fill_notional / fill_qty if fill_qty > 0.0 else None
-    equity_series = results[0].get("joint_portfolio_equity_series") if results else None
+    equity_series = _summary_total_equity_series(results)
     stats = _summary_return_stats(_summary_returns_from_pairs(equity_series))
     coverage_values = [
         float(row["coverage_pct"])
@@ -1437,6 +2063,74 @@ def _summary_stats_total(
         "profit_factor": stats["profit_factor"],
         "coverage_pct": sum(coverage_values) / len(coverage_values) if coverage_values else None,
     }
+
+
+def _summary_total_equity_series(results: Sequence[Mapping[str, Any]]) -> list[tuple[str, float]]:
+    if not results:
+        return []
+
+    joint_equity_series = results[0].get("joint_portfolio_equity_series")
+    if joint_equity_series:
+        series = _pairs_to_series(
+            joint_equity_series if isinstance(joint_equity_series, Sequence) else []
+        )
+        initial_capital = _joint_portfolio_initial_capital(
+            results[0],
+            equity_series=series,
+        )
+        series = _series_with_initial_capital_basis(
+            series,
+            initial_capital=initial_capital,
+        )
+        return _series_to_iso_pairs(series)
+
+    frame_infos: list[tuple[pd.Series, float]] = []
+    for result in results:
+        if not isinstance(result, Mapping):
+            continue
+        equity_series = _pairs_to_series(result.get("equity_series") or [])
+        cash_series = _pairs_to_series(result.get("cash_series") or [])
+        pnl_series = _pairs_to_series(result.get("pnl_series") or [])
+        initial_capital = _result_initial_capital(
+            result,
+            equity_series=equity_series,
+            cash_series=cash_series,
+            pnl_series=pnl_series,
+        )
+        if equity_series.empty:
+            if not cash_series.empty:
+                equity_series = cash_series.astype(float)
+            elif not pnl_series.empty and initial_capital is not None:
+                equity_series = pnl_series.astype(float) + float(initial_capital)
+            else:
+                continue
+        frame_infos.append(
+            (
+                equity_series,
+                float(equity_series.iloc[0]) if initial_capital is None else initial_capital,
+            )
+        )
+
+    if not frame_infos:
+        return []
+
+    timeline = frame_infos[0][0].index
+    for frame, _ in frame_infos[1:]:
+        timeline = timeline.union(frame.index)
+    timeline = timeline.sort_values()
+    if len(timeline) > 0 and timeline[0].value > 0:
+        timeline = pd.DatetimeIndex([timeline[0] - pd.Timedelta(nanoseconds=1)]).union(timeline)
+
+    total = pd.Series(0.0, index=timeline, dtype=float)
+    for frame, initial_capital in frame_infos:
+        aligned = _align_series_to_timeline(
+            frame.astype(float),
+            timeline,
+            before=float(initial_capital),
+            after=float(frame.iloc[-1]),
+        )
+        total = total.add(aligned, fill_value=0.0)
+    return _series_to_iso_pairs(total)
 
 
 def _summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]:
@@ -1457,13 +2151,27 @@ def _summary_fill_stats(fill_events: object) -> tuple[float, float, float | None
     return qty, notional, notional / qty if qty > 0.0 else None
 
 
-def _summary_returns_from_pairs(pairs: object) -> dict[int, float]:
+def _summary_returns_from_pairs(
+    pairs: object,
+    *,
+    initial_capital: float | None = None,
+) -> dict[int, float]:
     series = _pairs_to_series(pairs if isinstance(pairs, Sequence) else [])
+    return _summary_returns_from_series(series, initial_capital=initial_capital)
+
+
+def _summary_returns_from_series(
+    series: pd.Series,
+    *,
+    initial_capital: float | None = None,
+) -> dict[int, float]:
     if series.empty:
         return {}
 
-    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    numeric = _series_with_initial_capital_basis(series, initial_capital=initial_capital)
     if len(numeric) < 2:
+        return {}
+    if float(numeric.iloc[0]) <= 0.0:
         return {}
 
     returns = numeric.pct_change().replace([float("inf"), -float("inf")], pd.NA).dropna()
@@ -1495,18 +2203,30 @@ def _summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]:
     }
 
 
-def _summary_total_return_pct(pairs: object) -> float | None:
+def _summary_total_return_pct(
+    pairs: object,
+    *,
+    initial_capital: float | None = None,
+) -> float | None:
     series = _pairs_to_series(pairs if isinstance(pairs, Sequence) else [])
+    return _summary_total_return_pct_from_series(series, initial_capital=initial_capital)
+
+
+def _summary_total_return_pct_from_series(
+    series: pd.Series,
+    *,
+    initial_capital: float | None = None,
+) -> float | None:
     if series.empty:
         return None
 
-    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    numeric = _series_with_initial_capital_basis(series, initial_capital=initial_capital)
     if len(numeric) < 2:
         return None
 
     first = float(numeric.iloc[0])
     last = float(numeric.iloc[-1])
-    if abs(first) < 1e-12:
+    if first <= 0.0:
         return None
     return (last / first - 1.0) * 100.0
 

--- a/prediction_market_extensions/adapters/prediction_market/research.py
+++ b/prediction_market_extensions/adapters/prediction_market/research.py
@@ -738,7 +738,34 @@ def _result_has_position_activity(result: Mapping[str, Any]) -> bool:
     )
 
 
-def _serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> list[dict[str, Any]]:
+def _fill_event_side_hint(
+    *, outcome: object | None = None, token_index: object | None = None
+) -> str | None:
+    if not _is_missing_fill_value(outcome):
+        normalized = str(outcome).strip().casefold()
+        if normalized in {"no", "down", "lower", "below", "under"}:
+            return "no"
+        if normalized in {"yes", "up", "higher", "above", "over"}:
+            return "yes"
+
+    if not _is_missing_fill_value(token_index):
+        try:
+            index = int(token_index)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        if index == 0:
+            return "yes"
+        if index == 1:
+            return "no"
+    return None
+
+
+def _serialize_fill_events(
+    *,
+    market_id: str,
+    fills_report: pd.DataFrame,
+    default_side: str | None = None,
+) -> list[dict[str, Any]]:
     if fills_report.empty:
         return []
 
@@ -747,6 +774,11 @@ def _serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> lis
         frame = frame.reset_index()
 
     market_id_upper = str(market_id).upper()
+    normalized_default_side = (
+        str(default_side).strip().lower()
+        if default_side is not None and str(default_side).strip().lower() in {"yes", "no"}
+        else None
+    )
     inferred_side = (
         "no"
         if (
@@ -755,7 +787,7 @@ def _serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> lis
             or ".NO." in market_id_upper
             or "_NO" in market_id_upper
         )
-        else "yes"
+        else normalized_default_side or "yes"
     )
 
     events: list[dict[str, Any]] = []
@@ -836,6 +868,9 @@ def _serialize_fill_events(*, market_id: str, fills_report: pd.DataFrame) -> lis
 def _deserialize_fill_events(
     *, market_id: str, fill_events: Sequence[dict[str, Any]], models_module: Any
 ) -> list[Any]:
+    if not fill_events:
+        return []
+
     fills: list[Any] = []
     market_side = legacy_plot_adapter._infer_market_side(models_module, market_id)
 
@@ -1394,29 +1429,35 @@ def save_aggregate_backtest_report(
                     timeline_points.add(interval_end)
         final_pnl = float(result.get("pnl") or 0.0)
 
-        price_series = _pairs_to_series(result.get("price_series") or [])
-        if not price_series.empty:
-            if include_market_prices:
-                market_prices[label] = [
-                    (_to_legacy_datetime(ts), float(value)) for ts, value in price_series.items()
-                ]
-            _extend_active_range(
-                active_ranges, label, price_series.index[0], price_series.index[-1]
-            )
-            timeline_points.update(price_series.index.to_list())
-
+        result_fills: list[Any] = []
         if include_fill_events:
-            fills.extend(
-                _deserialize_fill_events(
-                    market_id=label,
-                    fill_events=result.get("fill_events") or [],
-                    models_module=models_module,
-                )
+            result_fills = _deserialize_fill_events(
+                market_id=label,
+                fill_events=result.get("fill_events") or [],
+                models_module=models_module,
             )
+            fills.extend(result_fills)
             for event in result.get("fill_events") or []:
                 timestamp = pd.to_datetime(event.get("timestamp"), utc=True, errors="coerce")
                 if not pd.isna(timestamp):
                     timeline_points.add(timestamp)
+
+        price_series = _pairs_to_series(result.get("price_series") or [])
+        if not price_series.empty:
+            price_points = [
+                (_to_legacy_datetime(ts), float(value)) for ts, value in price_series.items()
+            ]
+            if result_fills:
+                price_points = legacy_plot_adapter._market_prices_with_fill_points(
+                    {label: price_points}, result_fills
+                ).get(label, price_points)
+                price_series = _pairs_to_series(price_points)
+            if include_market_prices:
+                market_prices[label] = price_points
+            _extend_active_range(
+                active_ranges, label, price_series.index[0], price_series.index[-1]
+            )
+            timeline_points.update(price_series.index.to_list())
 
         equity_series = _pairs_to_series(result.get("equity_series") or [])
         cash_series = _pairs_to_series(result.get("cash_series") or [])
@@ -1704,12 +1745,31 @@ def save_joint_portfolio_backtest_report(
         if portfolio_cash.empty:
             portfolio_cash = _pairs_to_series(result.get("joint_portfolio_cash_series") or [])
 
+        result_fills: list[Any] = []
+        if include_fill_events:
+            result_fills = _deserialize_fill_events(
+                market_id=label,
+                fill_events=result.get("fill_events") or [],
+                models_module=models_module,
+            )
+            fills.extend(result_fills)
+            for event in result.get("fill_events") or []:
+                timestamp = pd.to_datetime(event.get("timestamp"), utc=True, errors="coerce")
+                if not pd.isna(timestamp):
+                    timeline_points.add(timestamp)
+
         price_series = _pairs_to_series(result.get("price_series") or [])
         if not price_series.empty:
+            price_points = [
+                (_to_legacy_datetime(ts), float(value)) for ts, value in price_series.items()
+            ]
+            if result_fills:
+                price_points = legacy_plot_adapter._market_prices_with_fill_points(
+                    {label: price_points}, result_fills
+                ).get(label, price_points)
+                price_series = _pairs_to_series(price_points)
             if include_market_prices:
-                market_prices[label] = [
-                    (_to_legacy_datetime(ts), float(value)) for ts, value in price_series.items()
-                ]
+                market_prices[label] = price_points
             _extend_active_range(
                 active_ranges, label, price_series.index[0], price_series.index[-1]
             )
@@ -1730,19 +1790,6 @@ def save_joint_portfolio_backtest_report(
                 _extend_active_range(
                     active_ranges, label, cash_series.index[0], cash_series.index[-1]
                 )
-
-        if include_fill_events:
-            fills.extend(
-                _deserialize_fill_events(
-                    market_id=label,
-                    fill_events=result.get("fill_events") or [],
-                    models_module=models_module,
-                )
-            )
-            for event in result.get("fill_events") or []:
-                timestamp = pd.to_datetime(event.get("timestamp"), utc=True, errors="coerce")
-                if not pd.isna(timestamp):
-                    timeline_points.add(timestamp)
 
     if portfolio_equity.empty and portfolio_cash.empty:
         return None

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -304,7 +304,7 @@ def _build_dataframes(
     eq = eq.sort_values("datetime").reset_index(drop=True)
 
     initial = result.initial_cash
-    if initial:
+    if initial > 0.0:
         eq["equity_pct"] = eq["equity"] / initial
         eq["return_pct"] = (eq["equity"] - initial) / initial
     else:
@@ -429,6 +429,13 @@ def _finite_idxmax(series: pd.Series) -> int | None:
     return int(finite.idxmax())
 
 
+def _finite_idxmin(series: pd.Series) -> int | None:
+    finite = series.replace([np.inf, -np.inf], np.nan).dropna()
+    if finite.empty:
+        return None
+    return int(finite.idxmin())
+
+
 def _downsample(
     eq: pd.DataFrame,
     fills_df: pd.DataFrame,
@@ -460,23 +467,50 @@ def _downsample(
         drawdown_peak = _finite_idxmax(eq["drawdown_pct"])
         if drawdown_peak is not None:
             must_keep.add(drawdown_peak)
+    if "num_positions" in eq.columns:
+        position_counts = pd.to_numeric(eq["num_positions"], errors="coerce")
+        changed = position_counts.ne(position_counts.shift())
+        if len(changed):
+            changed.iloc[0] = False
+        must_keep.update(int(idx) for idx in np.flatnonzero(changed.to_numpy()))
+    if not market_df.empty:
+        for column in market_df.columns:
+            values = pd.to_numeric(market_df[column], errors="coerce")
+            market_peak = _finite_idxmax(values)
+            if market_peak is not None:
+                must_keep.add(market_peak)
+            market_trough = _finite_idxmin(values)
+            if market_trough is not None:
+                must_keep.add(market_trough)
+    if alloc_df is not None and not alloc_df.empty:
+        for column in alloc_df.columns:
+            values = pd.to_numeric(alloc_df[column], errors="coerce")
+            allocation_peak = _finite_idxmax(values)
+            if allocation_peak is not None:
+                must_keep.add(allocation_peak)
+            allocation_trough = _finite_idxmin(values)
+            if allocation_trough is not None:
+                must_keep.add(allocation_trough)
     # Always keep first and last
     must_keep.add(0)
     must_keep.add(n - 1)
 
-    # Stride-based selection for the rest
-    budget = max(100, max_points - len(must_keep))
-    stride = max(1, n // budget)
-    strided = set(range(0, n, stride))
-
-    selected = sorted(must_keep | strided)
-    if len(selected) > max_points:
-        # If must_keep pushed us over, thin the strided points
-        must_list = sorted(must_keep)
-        remaining_budget = max_points - len(must_list)
-        stride2 = max(1, len(strided) // remaining_budget) if remaining_budget > 0 else n
-        thinned_strided = set(sorted(strided)[::stride2])
-        selected = sorted(must_keep | thinned_strided)
+    remaining_budget = max_points - len(must_keep)
+    if remaining_budget <= 0:
+        selected = sorted(must_keep)
+    else:
+        optional_indices = sorted(set(range(n)) - must_keep)
+        if len(optional_indices) > remaining_budget:
+            sampled_positions = np.linspace(
+                0,
+                len(optional_indices) - 1,
+                remaining_budget,
+                dtype=int,
+            )
+            optional_keep = {optional_indices[int(idx)] for idx in sampled_positions}
+        else:
+            optional_keep = set(optional_indices)
+        selected = sorted(must_keep | optional_keep)
 
     idx_arr = np.array(selected)
 
@@ -535,14 +569,10 @@ def _build_allocation_data(
         bar_idx = int(f["bar"])
         if mid not in pos_changes:
             pos_changes[mid] = np.zeros(n_bars)
-        if f["action"] == "buy" and f["side"] == "yes":
+        if f["action"] == "buy":
             pos_changes[mid][bar_idx] += f["quantity"]
-        elif (f["action"] == "sell" and f["side"] == "yes") or (
-            f["action"] == "buy" and f["side"] == "no"
-        ):
+        elif f["action"] == "sell":
             pos_changes[mid][bar_idx] -= f["quantity"]
-        elif f["action"] == "sell" and f["side"] == "no":
-            pos_changes[mid][bar_idx] += f["quantity"]
 
     pos_qty: dict[str, np.ndarray] = {}
     for mid, deltas in pos_changes.items():
@@ -597,12 +627,21 @@ def _build_allocation_data(
             fp = fill_price_map.get(mid, 0.5)
             price_on_bar[mid] = np.full(n_bars, fp)
 
+    flat_equity_mask: np.ndarray | None = None
+    if {"cash", "equity"}.issubset(eq.columns):
+        equity_values = pd.to_numeric(eq["equity"], errors="coerce").to_numpy(dtype=float)
+        cash_values = pd.to_numeric(eq["cash"], errors="coerce").to_numpy(dtype=float)
+        flat_equity_mask = np.isclose(equity_values, cash_values, rtol=0.0, atol=1e-9)
+
     # Zero out position qty after the market's price feed ends.
     # This handles market resolution: once there is no more price data,
     # the position was settled and should not contribute to allocation.
     for mid in pos_qty:
         last_ts = market_last_ts.get(mid)
         if last_ts is not None:
+            if flat_equity_mask is not None:
+                settled_on_bar = (eq_dts >= last_ts) & flat_equity_mask
+                pos_qty[mid][settled_on_bar] = 0.0
             # Zero out all bars after the last price observation
             cutoff = np.searchsorted(eq_dts, last_ts, side="right")
             if 0 < cutoff < n_bars:
@@ -622,12 +661,11 @@ def _build_allocation_data(
         if pr is None:
             continue
         safe_pr = np.nan_to_num(pr, nan=0.0)
-        val = np.where(qty >= 0, qty * safe_pr, np.abs(qty) * (1.0 - safe_pr))
-        val = np.maximum(val, 0.0)
+        val = qty * safe_pr
         pos_values[mid] = val
 
     # 4. Keep all positions (or top-N with "Other" bucket) ----------------
-    peak = {mid: float(np.max(v)) for mid, v in pos_values.items()}
+    peak = {mid: float(np.max(np.abs(v))) for mid, v in pos_values.items()}
     ranked = sorted(peak, key=peak.get, reverse=True)  # type: ignore[arg-type]
 
     # Keep individual columns for top markets, aggregate the rest into
@@ -649,7 +687,7 @@ def _build_allocation_data(
         col_data[label] = pos_values[mid]
     if other_ids:
         col_data["Other"] = np.sum([pos_values[m] for m in other_ids], axis=0)
-    col_data["Cash"] = np.maximum(eq["cash"].values, 0.0)
+    col_data["Cash"] = eq["cash"].values
     return pd.DataFrame(col_data, index=eq.index)
 
 
@@ -1221,11 +1259,36 @@ return this.labels[index] || "";
             )
             if relevant_fills.empty:
                 relevant_fills = fills_df
-            pnl_vals = np.where(
-                relevant_fills["action"] == "sell",
-                relevant_fills["price"] * relevant_fills["quantity"],
-                -relevant_fills["price"] * relevant_fills["quantity"],
-            )
+            market_pnls = getattr(result, "market_pnls", {}) or {}
+            if market_pnls:
+                market_pnls_by_id = {
+                    str(market_id): float(pnl) for market_id, pnl in market_pnls.items()
+                }
+                pnl_rows: list[pd.Series] = []
+                pnl_values: list[float] = []
+                for market_id, group in relevant_fills.groupby("market_id", sort=False):
+                    key = str(market_id)
+                    if key in market_pnls_by_id:
+                        pnl_rows.append(group.sort_values("bar").iloc[-1].copy())
+                        pnl_values.append(market_pnls_by_id[key])
+                        continue
+                    for _, row in group.iterrows():
+                        pnl_rows.append(row.copy())
+                        cashflow = float(row["price"]) * float(row["quantity"])
+                        pnl_values.append(cashflow if row["action"] == "sell" else -cashflow)
+                relevant_fills = (
+                    pd.DataFrame(pnl_rows).reset_index(drop=True)
+                    if pnl_rows
+                    else relevant_fills.iloc[0:0].copy()
+                )
+                pnl_vals = np.array(pnl_values, dtype=float)
+            else:
+                cashflow_vals = np.where(
+                    relevant_fills["action"] == "sell",
+                    relevant_fills["price"] * relevant_fills["quantity"],
+                    -relevant_fills["price"] * relevant_fills["quantity"],
+                )
+                pnl_vals = cashflow_vals
             positive = (pnl_vals > 0).astype(int).astype(str)
             sz = np.abs(pnl_vals).astype(float)
             if sz.max() > sz.min():
@@ -1368,16 +1431,32 @@ return this.labels[index] || "";
 
         dts = pd.to_datetime(eq["datetime"])
         eqv = eq["equity"].values.copy()
-        monthly = pd.DataFrame({"datetime": dts, "equity": eqv})
-        monthly["year"] = monthly["datetime"].dt.year.astype(str)
-        monthly["month"] = monthly["datetime"].dt.month
+        equity_by_time = pd.Series(eqv, index=pd.DatetimeIndex(dts)).sort_index()
+        equity_by_time = pd.to_numeric(equity_by_time, errors="coerce").dropna()
+        if equity_by_time.empty:
+            return None
 
-        # Compute return for each calendar month
-        first_last = monthly.groupby(["year", "month"]).agg(
-            eq_start=("equity", "first"), eq_end=("equity", "last")
+        month_start = equity_by_time.resample("ME").first().dropna()
+        month_end = equity_by_time.resample("ME").last().dropna()
+        if month_end.empty:
+            return None
+
+        returns = month_end.pct_change(fill_method=None)
+        first_month = month_end.index[0]
+        first_start = float(month_start.loc[first_month])
+        returns.loc[first_month] = (
+            0.0
+            if abs(first_start) < 1e-12
+            else (float(month_end.loc[first_month]) / first_start) - 1.0
         )
-        first_last["ret"] = (first_last["eq_end"] - first_last["eq_start"]) / first_last["eq_start"]  # type: ignore[reportIndexIssue]
-        first_last = first_last.reset_index()
+        returns = returns.replace([np.inf, -np.inf], np.nan).fillna(0.0)
+        first_last = pd.DataFrame(
+            {
+                "year": month_end.index.year.astype(str),
+                "month": month_end.index.month,
+                "ret": returns.to_numpy(dtype=float),
+            }
+        )
 
         if first_last.empty:
             return None
@@ -1867,16 +1946,15 @@ return this.labels[index] || "";
         other_col = "Other" if "Other" in alloc_df.columns else None
         all_cols = pos_cols + ([other_col] if other_col else []) + ["Cash"]
 
-        # Normalise against actual equity (from the equity curve) so allocation
-        # fractions stay consistent with the Cash/Equity panel.
+        # Normalise signed components against actual equity so short liabilities
+        # remain visible instead of being turned into positive long exposure.
         equity_total = eq["equity"].values.copy()
-        # Fallback: if equity is zero or unavailable, use sum of components
         component_total = alloc_df[all_cols].sum(axis=1).values
-        row_total = pd.Series(
-            np.where(equity_total > 0, np.maximum(equity_total, component_total), component_total),
-            index=alloc_df.index,
-        ).replace(0, 1.0)
-        normed = alloc_df[all_cols].div(row_total, axis=0).fillna(0.0).clip(0.0, 1.0)
+        row_total_values = np.where(np.abs(equity_total) > 1e-12, equity_total, component_total)
+        row_total = pd.Series(row_total_values, index=alloc_df.index).replace(0, 1.0)
+        normed = (
+            alloc_df[all_cols].div(row_total, axis=0).replace([np.inf, -np.inf], np.nan).fillna(0.0)
+        )
 
         # Allocation is downsampled to the same rows as eq, so use eq's index.
         alloc_src_data: dict[str, Any] = {"index": eq.index.values}
@@ -1947,7 +2025,11 @@ return this.labels[index] || "";
             legend_items.append(LegendItem(label=f"+{n_hidden} more", renderers=[]))
         fig.legend.items = legend_items
 
-        fig.y_range = Range1d(0, 1)
+        cumulative = normed[all_cols].cumsum(axis=1)
+        lower = min(0.0, float(np.nanmin(cumulative.to_numpy(dtype=float))))
+        upper = max(1.0, float(np.nanmax(cumulative.to_numpy(dtype=float))))
+        padding = max(0.02, (upper - lower) * 0.05)
+        fig.y_range = Range1d(lower - padding, upper + padding)
         fig.yaxis.formatter = NumeralTickFormatter(format="0%")
 
         return fig

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -1798,7 +1798,7 @@ return this.labels[index] || "";
         if fills_df.empty:
             return
 
-        relevant = fills_df.copy()
+        relevant = fills_df[fills_df["market_id"].isin(display_markets)].copy()
         if relevant.empty:
             return
 

--- a/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
+++ b/prediction_market_extensions/analysis/legacy_backtesting/plotting.py
@@ -1268,14 +1268,13 @@ return this.labels[index] || "";
                 pnl_values: list[float] = []
                 for market_id, group in relevant_fills.groupby("market_id", sort=False):
                     key = str(market_id)
-                    if key in market_pnls_by_id:
-                        pnl_rows.append(group.sort_values("bar").iloc[-1].copy())
-                        pnl_values.append(market_pnls_by_id[key])
-                        continue
-                    for _, row in group.iterrows():
+                    for _, row in group.sort_values("bar").iterrows():
                         pnl_rows.append(row.copy())
-                        cashflow = float(row["price"]) * float(row["quantity"])
-                        pnl_values.append(cashflow if row["action"] == "sell" else -cashflow)
+                        if key in market_pnls_by_id:
+                            pnl_values.append(market_pnls_by_id[key])
+                        else:
+                            cashflow = float(row["price"]) * float(row["quantity"])
+                            pnl_values.append(cashflow if row["action"] == "sell" else -cashflow)
                 relevant_fills = (
                     pd.DataFrame(pnl_rows).reset_index(drop=True)
                     if pnl_rows

--- a/prediction_market_extensions/analysis/legacy_plot_adapter.py
+++ b/prediction_market_extensions/analysis/legacy_plot_adapter.py
@@ -586,9 +586,16 @@ def _normalize_market_prices(
 def _market_prices_from_fills(fills: list[Any]) -> dict[str, list[tuple[datetime, float]]]:
     market_prices: dict[str, list[tuple[datetime, float]]] = {}
     for fill in fills:
-        market_prices.setdefault(str(fill.market_id), []).append(
-            (fill.timestamp, float(fill.price))
-        )
+        market_id = getattr(fill, "market_id", None)
+        timestamp = _to_naive_utc(getattr(fill, "timestamp", None))
+        price = getattr(fill, "price", None)
+        if market_id is None or timestamp is None or price is None:
+            continue
+        try:
+            parsed_price = float(price)
+        except (TypeError, ValueError):
+            continue
+        market_prices.setdefault(str(market_id), []).append((timestamp, parsed_price))
     return market_prices
 
 

--- a/prediction_market_extensions/analysis/legacy_plot_adapter.py
+++ b/prediction_market_extensions/analysis/legacy_plot_adapter.py
@@ -219,14 +219,11 @@ def _infer_market_side(models_module: Any, market_id: str) -> Any:
 
 
 def _signed_quantity(action: str, side: str, qty: float) -> float:
-    if action == "buy" and side == "yes":
+    del side
+    if action == "buy":
         return qty
-    if action == "sell" and side == "yes":
+    if action == "sell":
         return -qty
-    if action == "buy" and side == "no":
-        return -qty
-    if action == "sell" and side == "no":
-        return qty
     return 0.0
 
 
@@ -475,8 +472,7 @@ def _mark_to_market(
 
     for market_id, qty in pos_qty.items():
         prices = np.nan_to_num(price_on_bar.get(market_id, np.zeros(n_bars, dtype=float)), nan=0.0)
-        values = np.where(qty >= 0.0, qty * prices, np.abs(qty) * (1.0 - prices))
-        values = np.maximum(values, 0.0)
+        values = qty * prices
         total_pos_value += values
         num_positions += (np.abs(qty) > 1e-12).astype(int)
 
@@ -774,7 +770,12 @@ def _build_brier_timeseries_panel(
             frame.index[0], frame.index[-1], bounds=(frame.index[0] - pad, frame.index[-1] + pad)
         )
     else:
-        x_range = None
+        pad = pd.Timedelta(minutes=1)
+        x_range = Range1d(
+            frame.index[0] - pad,
+            frame.index[0] + pad,
+            bounds=(frame.index[0] - pad, frame.index[0] + pad),
+        )
 
     source = ColumnDataSource(
         {
@@ -1464,8 +1465,10 @@ def _focus_allocation_panel(layout: Any) -> None:
             stacked += np.nan_to_num(np.asarray(data[col], dtype=float))
 
         peak = float(np.nanmax(stacked)) if len(stacked) else 0.0
-        upper = min(1.0, max(0.05, peak * 1.3))
-        fig.y_range = Range1d(0.0, upper)
+        trough = float(np.nanmin(stacked)) if len(stacked) else 0.0
+        upper = max(0.05, peak * 1.3)
+        lower = min(0.0, trough * 1.3)
+        fig.y_range = Range1d(lower, upper)
         fig.yaxis[0].axis_label = "Market Allocation (ex-cash)"
 
         # Hide the grey cash stack so market allocation is visible.

--- a/prediction_market_extensions/backtesting/_backtest_runtime.py
+++ b/prediction_market_extensions/backtesting/_backtest_runtime.py
@@ -28,9 +28,28 @@ from prediction_market_extensions.adapters.prediction_market.backtest_utils impo
 from prediction_market_extensions.adapters.prediction_market.fill_model import (
     PredictionMarketTakerFillModel,
 )
+from prediction_market_extensions.backtesting._execution_config import StaticLatencyConfig
 from prediction_market_extensions.backtesting._result_policies import (
     apply_binary_settlement_pnl,
 )
+from prediction_market_extensions.backtesting._prediction_market_order_guard import (
+    PredictionMarketOrderGuard,
+)
+
+_DEFAULT_LATENCY_MODEL = object()
+_DEFAULT_PREDICTION_MARKET_LATENCY = StaticLatencyConfig(
+    base_latency_ms=75.0,
+    insert_latency_ms=10.0,
+    update_latency_ms=5.0,
+    cancel_latency_ms=5.0,
+)
+
+
+def _default_prediction_market_latency_model() -> Any:
+    latency_model = _DEFAULT_PREDICTION_MARKET_LATENCY.build_latency_model()
+    if latency_model is None:
+        raise AssertionError("default prediction-market latency model must be non-zero")
+    return latency_model
 
 
 def _record_timestamp_ns(record: object) -> int | None:
@@ -198,7 +217,7 @@ def run_market_backtest(
     base_currency: Currency,
     fee_model: Any,
     fill_model: Any | None = None,
-    apply_default_fill_model: bool = True,
+    apply_default_fill_model: bool = False,
     slippage_ticks: int = 1,
     entry_slippage_pct: float = 0.0,
     exit_slippage_pct: float = 0.0,
@@ -210,15 +229,20 @@ def run_market_backtest(
     chart_resample_rule: str | None = None,
     market_key: str = "market",
     return_summary_series: bool = False,
-    book_type: BookType = BookType.L1_MBP,
-    liquidity_consumption: bool = False,
-    queue_position: bool = False,
-    latency_model: Any | None = None,
+    book_type: BookType = BookType.L2_MBP,
+    liquidity_consumption: bool = True,
+    queue_position: bool = True,
+    latency_model: Any | None = _DEFAULT_LATENCY_MODEL,
     nautilus_log_level: str = "INFO",
     requested_start_ns: int | None = None,
     requested_end_ns: int | None = None,
 ) -> dict[str, Any]:
     install_commission_patch()
+    if latency_model is _DEFAULT_LATENCY_MODEL:
+        latency_model = _default_prediction_market_latency_model()
+    elif isinstance(latency_model, StaticLatencyConfig):
+        latency_model = latency_model.build_latency_model()
+
     if fill_model is None and apply_default_fill_model:
         fill_model = PredictionMarketTakerFillModel(
             slippage_ticks=slippage_ticks,
@@ -246,9 +270,13 @@ def run_market_backtest(
         book_type=book_type,
         liquidity_consumption=liquidity_consumption,
         queue_position=queue_position,
+        bar_execution=False,
+        trade_execution=True,
     )
     engine.add_instrument(instrument)
     add_engine_data_by_type(engine, data_records)
+    order_guard = PredictionMarketOrderGuard()
+    order_guard.install(strategy)
     engine.add_strategy(strategy)
     try:
         engine.run()
@@ -280,6 +308,7 @@ def run_market_backtest(
                 instrument.id,
             )
         result_warnings: list[str] = []
+        result_warnings.extend(order_guard.warnings)
         user_probabilities, market_probabilities, outcomes = build_brier_inputs(
             points=price_points,
             window=probability_window,

--- a/prediction_market_extensions/backtesting/_backtest_runtime.py
+++ b/prediction_market_extensions/backtesting/_backtest_runtime.py
@@ -299,6 +299,9 @@ def run_market_backtest(
         fill_events = prediction_market_research._serialize_fill_events(
             market_id=market_id,
             fills_report=fills,
+            default_side=prediction_market_research._fill_event_side_hint(
+                outcome=getattr(instrument, "outcome", None)
+            ),
         )
         if realized_outcome is None:
             import logging
@@ -329,13 +332,15 @@ def run_market_backtest(
             summary_legacy_models, _ = (
                 prediction_market_research.legacy_plot_adapter._load_legacy_modules()
             )
-            summary_legacy_fills = prediction_market_research.legacy_plot_adapter._convert_fills(
-                fills, summary_legacy_models
+            summary_legacy_fills = prediction_market_research._deserialize_fill_events(
+                market_id=market_id,
+                fill_events=fill_events,
+                models_module=summary_legacy_models,
             )
             summary_market_prices = (
                 prediction_market_research.legacy_plot_adapter._market_prices_with_fill_points(
-                    {str(instrument.id): chart_market_prices}, summary_legacy_fills
-                ).get(str(instrument.id), chart_market_prices)
+                    {market_id: chart_market_prices}, summary_legacy_fills
+                ).get(market_id, chart_market_prices)
             )
             dense_equity_series, dense_cash_series = (
                 prediction_market_research._dense_market_account_series_from_fill_events(

--- a/prediction_market_extensions/backtesting/_optimizer.py
+++ b/prediction_market_extensions/backtesting/_optimizer.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import contextlib
 import csv
 import json
+import math
 import multiprocessing
 import pickle
 import tempfile
 import traceback
 import warnings
+from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -114,6 +116,13 @@ class ParameterSearchConfig:
             raise ValueError("holdout_top_k must be positive.")
         if self.min_fills_per_window < 0:
             raise ValueError("min_fills_per_window must be non-negative.")
+        try:
+            invalid_score = float(self.invalid_score)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("invalid_score must be finite.") from exc
+        if not math.isfinite(invalid_score):
+            raise ValueError("invalid_score must be finite.")
+        object.__setattr__(self, "invalid_score", invalid_score)
         if self.sampler not in _SUPPORTED_SAMPLERS:
             raise ValueError(f"sampler must be one of {_SUPPORTED_SAMPLERS}, got {self.sampler!r}.")
 
@@ -141,9 +150,9 @@ class ParameterSearchConfig:
                     normalized_grid[str(name)] = tuple(spec["choices"])
         elif has_grid:
             for name, values in self.parameter_grid.items():
-                normalized_values = tuple(values)
-                if not normalized_values:
-                    raise ValueError(f"parameter_grid[{name!r}] must not be empty.")
+                normalized_values = _normalize_discrete_values(
+                    name=str(name), values=values, label="parameter_grid"
+                )
                 normalized_grid[str(name)] = normalized_values
                 normalized_space[str(name)] = MappingProxyType(
                     {"type": "categorical", "choices": normalized_values}
@@ -258,34 +267,109 @@ def _validate_parameter_spec(name: str, spec: Any) -> ParameterSpec:
         raise ValueError(f"parameter_space[{name!r}] must be a mapping, got {type(spec).__name__}.")
     spec_type = spec.get("type")
     if spec_type == "categorical":
-        choices = spec.get("choices")
-        if not choices:
-            raise ValueError(f"parameter_space[{name!r}] categorical needs non-empty 'choices'.")
-        return MappingProxyType({"type": "categorical", "choices": tuple(choices)})
+        choices = _normalize_discrete_values(
+            name=name, values=spec.get("choices"), label="parameter_space"
+        )
+        return MappingProxyType({"type": "categorical", "choices": choices})
     if spec_type in ("int", "float"):
         low = spec.get("low")
         high = spec.get("high")
         if low is None or high is None:
             raise ValueError(f"parameter_space[{name!r}] {spec_type} needs 'low' and 'high'.")
-        if low >= high:
-            raise ValueError(f"parameter_space[{name!r}]: low must be < high.")
         log = bool(spec.get("log", False))
         step = spec.get("step")
+        if spec_type == "int":
+            if not _is_integral_bound(low):
+                raise ValueError(f"parameter_space[{name!r}]: int low must be an integer.")
+            if not _is_integral_bound(high):
+                raise ValueError(f"parameter_space[{name!r}]: int high must be an integer.")
+            low_value = int(low)
+            high_value = int(high)
+            if low_value >= high_value:
+                raise ValueError(f"parameter_space[{name!r}]: low must be < high.")
+            if log and low_value <= 0:
+                raise ValueError(f"parameter_space[{name!r}]: log sampling requires low > 0.")
+            payload: dict[str, Any] = {
+                "type": spec_type,
+                "low": low_value,
+                "high": high_value,
+                "log": log,
+            }
+            if step is not None:
+                if log:
+                    raise ValueError(
+                        f"parameter_space[{name!r}]: step is not supported with log sampling."
+                    )
+                if not _is_integral_bound(step):
+                    raise ValueError(f"parameter_space[{name!r}]: int step must be an integer.")
+                step_value = int(step)
+                if step_value <= 0:
+                    raise ValueError(f"parameter_space[{name!r}]: step must be positive.")
+                if (high_value - low_value) % step_value != 0:
+                    raise ValueError(
+                        f"parameter_space[{name!r}]: high-low must be divisible by step."
+                    )
+                payload["step"] = step_value
+            return MappingProxyType(payload)
+
+        low_value = _numeric_bound(name=name, label="low", value=low)
+        high_value = _numeric_bound(name=name, label="high", value=high)
+        if low_value >= high_value:
+            raise ValueError(f"parameter_space[{name!r}]: low must be < high.")
+        if log and low_value <= 0.0:
+            raise ValueError(f"parameter_space[{name!r}]: log sampling requires low > 0.")
+        payload = {"type": spec_type, "low": low_value, "high": high_value, "log": log}
         if step is not None:
             if log:
                 raise ValueError(
                     f"parameter_space[{name!r}]: step is not supported with log sampling."
                 )
-            if step <= 0:
+            step_value = _numeric_bound(name=name, label="step", value=step)
+            if step_value <= 0.0:
                 raise ValueError(f"parameter_space[{name!r}]: step must be positive.")
-        payload: dict[str, Any] = {"type": spec_type, "low": low, "high": high, "log": log}
-        if step is not None:
-            payload["step"] = step
+            steps = (high_value - low_value) / step_value
+            if not math.isclose(steps, round(steps), rel_tol=1e-12, abs_tol=1e-12):
+                raise ValueError(f"parameter_space[{name!r}]: high-low must be divisible by step.")
+            payload["step"] = step_value
         return MappingProxyType(payload)
     raise ValueError(
         f"parameter_space[{name!r}] has unsupported type {spec_type!r}; "
         "expected 'categorical', 'int', or 'float'."
     )
+
+
+def _numeric_bound(*, name: str, label: str, value: Any) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"parameter_space[{name!r}]: {label} must be numeric.")
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"parameter_space[{name!r}]: {label} must be numeric.") from exc
+    if not math.isfinite(numeric):
+        raise ValueError(f"parameter_space[{name!r}]: {label} must be finite.")
+    return numeric
+
+
+def _is_integral_bound(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value) and value.is_integer()
+    return False
+
+
+def _normalize_discrete_values(*, name: str, values: Any, label: str) -> tuple[Any, ...]:
+    if values is None or isinstance(values, str | bytes) or isinstance(values, Mapping):
+        raise ValueError(f"{label}[{name!r}] must be a non-empty sequence of values.")
+    try:
+        normalized_values = tuple(values)
+    except TypeError as exc:
+        raise ValueError(f"{label}[{name!r}] must be a non-empty sequence of values.") from exc
+    if not normalized_values:
+        raise ValueError(f"{label}[{name!r}] must not be empty.")
+    return normalized_values
 
 
 def _collect_search_placeholders(value: Any) -> set[str]:
@@ -317,6 +401,47 @@ def _replace_search_placeholders(value: Any, params: Mapping[str, Any]) -> Any:
     return value
 
 
+def _candidate_identity(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            "type": "mapping",
+            "items": [
+                (str(key), _candidate_identity(inner))
+                for key, inner in sorted(value.items(), key=lambda item: str(item[0]))
+            ],
+        }
+    if isinstance(value, tuple):
+        return {"type": "tuple", "items": [_candidate_identity(inner) for inner in value]}
+    if isinstance(value, list):
+        return {"type": "list", "items": [_candidate_identity(inner) for inner in value]}
+    if isinstance(value, Path):
+        return {"type": "path", "value": str(value)}
+    if isinstance(value, datetime):
+        return {"type": "datetime", "value": value.astimezone(UTC).isoformat()}
+    if isinstance(value, bool):
+        return {"type": "bool", "value": value}
+    if isinstance(value, int):
+        return {"type": "int", "value": value}
+    if isinstance(value, float):
+        return {"type": "float", "value": value if math.isfinite(value) else str(value)}
+    if isinstance(value, str):
+        return {"type": "str", "value": value}
+    if value is None:
+        return {"type": "none", "value": None}
+    return {
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "value": str(value),
+    }
+
+
+def _candidate_key(params: ParameterValues) -> str:
+    return json.dumps(
+        {name: _candidate_identity(value) for name, value in params},
+        sort_keys=True,
+        allow_nan=False,
+    )
+
+
 def _parameter_candidates(parameter_grid: Mapping[str, Sequence[Any]]) -> list[ParameterValues]:
     keys = tuple(parameter_grid)
     values_product = product(*(parameter_grid[key] for key in keys))
@@ -324,7 +449,7 @@ def _parameter_candidates(parameter_grid: Mapping[str, Sequence[Any]]) -> list[P
     seen: set[str] = set()
     for values in values_product:
         params = tuple(zip(keys, values, strict=True))
-        canonical = json.dumps(_json_safe(dict(params)), sort_keys=True)
+        canonical = _candidate_key(params)
         if canonical in seen:
             continue
         seen.add(canonical)
@@ -532,18 +657,136 @@ def _coerce_results(value: object) -> list[dict[str, Any]]:
     raise TypeError("optimizer evaluator must return a mapping or a sequence of mappings")
 
 
-def _series_values(series: object) -> list[float]:
+def _replay_result_key_from_replay(replay: ReplaySpec) -> tuple[str, str] | None:
+    market_id = getattr(replay, "market_slug", None) or getattr(replay, "market_ticker", None)
+    if market_id is None:
+        return None
+    token_index = getattr(replay, "token_index", 0)
+    return (str(market_id), str(token_index if token_index is not None else 0))
+
+
+def _replay_result_key_from_result(result: Mapping[str, Any]) -> tuple[str, str] | None:
+    market_id = (
+        result.get("slug")
+        or result.get("ticker")
+        or result.get("market_slug")
+        or result.get("market_ticker")
+        or result.get("market")
+    )
+    if market_id is None:
+        return None
+    token_index = result.get("token_index", 0)
+    return (str(market_id), str(token_index if token_index is not None else 0))
+
+
+def _format_replay_result_keys(keys: Sequence[tuple[str, str]]) -> str:
+    return json.dumps([{"market": market, "token_index": token} for market, token in keys])
+
+
+def _validate_result_market_coverage(
+    *, config: ParameterSearchConfig, results: Sequence[Mapping[str, Any]]
+) -> str | None:
+    if len(config.base_replays) <= 1:
+        return None
+
+    expected_keys = [
+        key for replay in config.base_replays if (key := _replay_result_key_from_replay(replay))
+    ]
+    if len(expected_keys) != len(config.base_replays):
+        return None
+
+    result_keys: list[tuple[str, str]] = []
+    missing_indices: list[int] = []
+    for index, result in enumerate(results):
+        key = _replay_result_key_from_result(result)
+        if key is None:
+            missing_indices.append(index)
+            continue
+        result_keys.append(key)
+
+    if missing_indices:
+        return (
+            "all multi-replay optimizer results must include market identifiers; "
+            "missing identifiers on result indices "
+            + ", ".join(str(index) for index in missing_indices)
+        )
+
+    if Counter(result_keys) != Counter(expected_keys):
+        return (
+            "expected result markets "
+            f"{_format_replay_result_keys(expected_keys)}, received "
+            f"{_format_replay_result_keys(result_keys)}"
+        )
+    return None
+
+
+def _joint_portfolio_equity_series_from_results(
+    results: Sequence[Mapping[str, Any]],
+) -> tuple[object | None, str | None]:
+    joint_series_by_index: list[tuple[int, object]] = []
+    for index, result in enumerate(results):
+        series = result.get("joint_portfolio_equity_series")
+        if series is None:
+            continue
+        values, error = _series_values_checked(
+            series,
+            name=f"result[{index}].joint_portfolio_equity_series",
+        )
+        if error is not None:
+            return None, error
+        if values:
+            joint_series_by_index.append((index, series))
+
+    if len(joint_series_by_index) > 1:
+        indices = ", ".join(str(index) for index, _series in joint_series_by_index)
+        return (
+            None,
+            f"multiple nonempty joint_portfolio_equity_series values on result indices {indices}",
+        )
+    if joint_series_by_index:
+        return joint_series_by_index[0][1], None
+    return None, None
+
+
+def _coerce_finite_series_value(value: object, *, name: str) -> tuple[float | None, str | None]:
+    if value is None:
+        return None, f"{name} is missing"
+    try:
+        numeric = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None, f"{name} is non-numeric: {value!r}"
+    if not math.isfinite(numeric):
+        return None, f"{name} is non-finite: {value!r}"
+    return numeric, None
+
+
+def _series_values_checked(series: object, *, name: str) -> tuple[list[float], str | None]:
     values: list[float] = []
-    if not isinstance(series, Sequence):
-        return values
-    for point in series:
+    if series is None:
+        return values, None
+    if not isinstance(series, Sequence) or isinstance(series, str | bytes):
+        return values, f"{name} must be a sequence of timestamp/value pairs"
+    for index, point in enumerate(series):
         value = None
+        has_value = False
         if isinstance(point, Mapping):
+            has_value = "value" in point
             value = point.get("value")
-        elif isinstance(point, Sequence) and not isinstance(point, str) and len(point) >= 2:
+        elif isinstance(point, Sequence) and not isinstance(point, str | bytes) and len(point) >= 2:
+            has_value = True
             value = point[1]
-        if isinstance(value, int | float):
-            values.append(float(value))
+        if not has_value:
+            return values, f"{name}[{index}] is missing a value"
+        numeric, error = _coerce_finite_series_value(value, name=f"{name}[{index}]")
+        if error is not None:
+            return values, error
+        assert numeric is not None
+        values.append(numeric)
+    return values, None
+
+
+def _series_values(series: object) -> list[float]:
+    values, _error = _series_values_checked(series, name="series")
     return values
 
 
@@ -576,8 +819,8 @@ def _joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float:
 
     frames: list[pd.Series] = []
     for series in equity_series_list:
-        if not isinstance(series, Sequence):
-            continue
+        if not isinstance(series, Sequence) or isinstance(series, str | bytes):
+            return float("nan")
         timestamps: list[Any] = []
         values: list[float] = []
         for point in series:
@@ -593,13 +836,19 @@ def _joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float:
             ):
                 ts = point[0]
                 value = point[1]
-            if ts is None or not isinstance(value, int | float):
-                continue
+            if ts is None:
+                return float("nan")
+            numeric, error = _coerce_finite_series_value(value, name="joint equity value")
+            if error is not None:
+                return float("nan")
             timestamps.append(ts)
-            values.append(float(value))
+            assert numeric is not None
+            values.append(numeric)
         if not timestamps:
             continue
         index = pd.to_datetime(timestamps, utc=True, errors="coerce")
+        if bool(index.isna().any()):
+            return float("nan")
         frame = pd.Series(values, index=index).dropna().sort_index()
         if not frame.empty:
             frames.append(frame)
@@ -614,13 +863,9 @@ def _joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float:
 
     joint = None
     for frame in frames:
-        reindexed = frame.reindex(combined_index).ffill()
+        reindexed = frame.reindex(combined_index).ffill().bfill()
         if reindexed.empty:
             continue
-        first_valid = reindexed.first_valid_index()
-        if first_valid is not None:
-            reindexed.loc[reindexed.index < first_valid] = 0.0
-        reindexed = reindexed.fillna(0.0)
         joint = reindexed if joint is None else joint + reindexed
     if joint is None or joint.empty:
         return 0.0
@@ -630,16 +875,48 @@ def _joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float:
 
 def _as_float(value: object, *, default: float = 0.0) -> float:
     if isinstance(value, int | float):
-        return float(value)
+        numeric = float(value)
+        if math.isfinite(numeric):
+            return numeric
     return default
 
 
 def _as_int(value: object, *, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
     if isinstance(value, int):
         return value
     if isinstance(value, float):
-        return int(value)
+        return int(value) if math.isfinite(value) else default
     return default
+
+
+def _finite_float_metric(value: object, *, name: str) -> tuple[float | None, str | None]:
+    if isinstance(value, int | float):
+        numeric = float(value)
+        if math.isfinite(numeric):
+            return numeric, None
+        return None, f"{name} is non-finite: {value!r}"
+    return None, f"{name} is missing or non-numeric: {value!r}"
+
+
+def _finite_int_metric(value: object, *, name: str) -> tuple[int | None, str | None]:
+    if isinstance(value, bool):
+        return None, f"{name} is boolean, expected an integer count"
+    if isinstance(value, int):
+        if value >= 0:
+            return value, None
+        return None, f"{name} is negative: {value!r}"
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None, f"{name} is non-finite: {value!r}"
+        if not value.is_integer():
+            return None, f"{name} is not an integer count: {value!r}"
+        integer = int(value)
+        if integer >= 0:
+            return integer, None
+        return None, f"{name} is negative: {value!r}"
+    return None, f"{name} is missing or non-numeric: {value!r}"
 
 
 def _score_result(
@@ -724,16 +1001,133 @@ def _evaluate_window(
             status="invalid_result_count",
             error=f"expected {expected_market_count} results, received {len(results)}",
         )
+    market_coverage_error = _validate_result_market_coverage(config=config, results=results)
+    if market_coverage_error is not None:
+        return _WindowEvaluation(
+            window_name=window.name,
+            score=config.invalid_score,
+            pnl=0.0,
+            max_drawdown_currency=0.0,
+            fills=0,
+            requested_coverage_ratio=0.0,
+            terminated_early=True,
+            status="invalid_market_coverage",
+            error=market_coverage_error,
+        )
 
-    pnl = sum(_as_float(r.get("pnl")) for r in results)
-    fills = sum(_as_int(r.get("fills")) for r in results)
-    coverages = [_as_float(r.get("requested_coverage_ratio"), default=0.0) for r in results]
-    requested_coverage_ratio = (sum(coverages) / len(coverages)) if coverages else 0.0
-    terminated_early = any(bool(r.get("terminated_early")) for r in results)
-    if len(results) == 1:
+    metric_errors: list[str] = []
+    pnl_values: list[float] = []
+    fill_values: list[int] = []
+    coverage_values: list[float] = []
+    for index, result in enumerate(results):
+        pnl_value, pnl_error = _finite_float_metric(result.get("pnl"), name=f"result[{index}].pnl")
+        if pnl_error is not None:
+            metric_errors.append(pnl_error)
+        else:
+            assert pnl_value is not None
+            pnl_values.append(pnl_value)
+
+        fills_value, fills_error = _finite_int_metric(
+            result.get("fills"), name=f"result[{index}].fills"
+        )
+        if fills_error is not None:
+            metric_errors.append(fills_error)
+        else:
+            assert fills_value is not None
+            fill_values.append(fills_value)
+
+        coverage_value, coverage_error = _finite_float_metric(
+            result.get("requested_coverage_ratio", 0.0),
+            name=f"result[{index}].requested_coverage_ratio",
+        )
+        if coverage_error is not None:
+            metric_errors.append(coverage_error)
+        else:
+            assert coverage_value is not None
+            coverage_values.append(coverage_value)
+
+        _equity_values, equity_error = _series_values_checked(
+            result.get("equity_series"),
+            name=f"result[{index}].equity_series",
+        )
+        if equity_error is not None:
+            metric_errors.append(equity_error)
+        elif not _equity_values:
+            metric_errors.append(f"result[{index}].equity_series is missing or empty")
+
+    if metric_errors:
+        return _WindowEvaluation(
+            window_name=window.name,
+            score=config.invalid_score,
+            pnl=0.0,
+            max_drawdown_currency=0.0,
+            fills=0,
+            requested_coverage_ratio=0.0,
+            terminated_early=True,
+            status="invalid_nonfinite_metric",
+            error="; ".join(metric_errors),
+        )
+
+    joint_portfolio_equity_series, joint_portfolio_equity_error = (
+        _joint_portfolio_equity_series_from_results(results)
+    )
+    if joint_portfolio_equity_error is not None:
+        return _WindowEvaluation(
+            window_name=window.name,
+            score=config.invalid_score,
+            pnl=0.0,
+            max_drawdown_currency=0.0,
+            fills=0,
+            requested_coverage_ratio=0.0,
+            terminated_early=True,
+            status="invalid_nonfinite_metric",
+            error=joint_portfolio_equity_error,
+        )
+
+    pnl = sum(pnl_values)
+    fills = sum(fill_values)
+    requested_coverage_ratio = (
+        (sum(coverage_values) / len(coverage_values)) if coverage_values else 0.0
+    )
+    realism_invalid_indices = [
+        index
+        for index, result in enumerate(results)
+        if bool(result.get("backtest_realism_invalid"))
+    ]
+    terminated_early = any(
+        bool(r.get("terminated_early")) or bool(r.get("backtest_realism_invalid")) for r in results
+    )
+    if joint_portfolio_equity_series is not None:
+        max_drawdown_currency = _joint_portfolio_drawdown([joint_portfolio_equity_series])
+    elif len(results) == 1:
         max_drawdown_currency = _max_drawdown_currency(results[0].get("equity_series"))
     else:
         max_drawdown_currency = _joint_portfolio_drawdown([r.get("equity_series") for r in results])
+    if not math.isfinite(max_drawdown_currency):
+        return _WindowEvaluation(
+            window_name=window.name,
+            score=config.invalid_score,
+            pnl=0.0,
+            max_drawdown_currency=0.0,
+            fills=0,
+            requested_coverage_ratio=0.0,
+            terminated_early=True,
+            status="invalid_nonfinite_metric",
+            error=f"max_drawdown_currency is non-finite: {max_drawdown_currency!r}",
+        )
+    if realism_invalid_indices:
+        return _WindowEvaluation(
+            window_name=window.name,
+            score=config.invalid_score,
+            pnl=pnl,
+            max_drawdown_currency=max_drawdown_currency,
+            fills=fills,
+            requested_coverage_ratio=requested_coverage_ratio,
+            terminated_early=True,
+            status="backtest_realism_invalid",
+            error="backtest_realism_invalid set on result indices "
+            + ", ".join(str(index) for index in realism_invalid_indices),
+        )
     score = _score_result(
         pnl=pnl,
         max_drawdown_currency=max_drawdown_currency,
@@ -743,6 +1137,18 @@ def _evaluate_window(
         initial_cash=config.initial_cash,
         min_fills_per_window=config.min_fills_per_window,
     )
+    if not math.isfinite(score):
+        return _WindowEvaluation(
+            window_name=window.name,
+            score=config.invalid_score,
+            pnl=0.0,
+            max_drawdown_currency=0.0,
+            fills=0,
+            requested_coverage_ratio=0.0,
+            terminated_early=True,
+            status="invalid_nonfinite_metric",
+            error=f"score is non-finite: {score!r}",
+        )
     return _WindowEvaluation(
         window_name=window.name,
         score=score,
@@ -759,12 +1165,23 @@ def _median_metric(values: Sequence[float]) -> float:
     return float(median(values))
 
 
+def _phase_median_score(
+    evaluations: Sequence[_WindowEvaluation],
+    *,
+    invalid_score: float,
+) -> float:
+    if any(evaluation.status != "ok" for evaluation in evaluations):
+        return float(invalid_score)
+    return _median_metric([evaluation.score for evaluation in evaluations])
+
+
 def _build_leaderboard_row(
     *,
     trial_id: int,
     params: ParameterValues,
     train_evaluations: Sequence[_WindowEvaluation],
     holdout_evaluations: Sequence[_WindowEvaluation] = (),
+    invalid_score: float = DEFAULT_INVALID_SCORE,
 ) -> ParameterSearchLeaderboardRow:
     train_scores = tuple(evaluation.score for evaluation in train_evaluations)
     holdout_scores = tuple(evaluation.score for evaluation in holdout_evaluations)
@@ -773,8 +1190,12 @@ def _build_leaderboard_row(
         params=params,
         train_scores=train_scores,
         holdout_scores=holdout_scores,
-        train_median_score=_median_metric(train_scores),
-        holdout_median_score=(_median_metric(holdout_scores) if holdout_scores else None),
+        train_median_score=_phase_median_score(train_evaluations, invalid_score=invalid_score),
+        holdout_median_score=(
+            _phase_median_score(holdout_evaluations, invalid_score=invalid_score)
+            if holdout_scores
+            else None
+        ),
         train_median_pnl=_median_metric([evaluation.pnl for evaluation in train_evaluations]),
         holdout_median_pnl=(
             _median_metric([evaluation.pnl for evaluation in holdout_evaluations])
@@ -835,7 +1256,13 @@ def _json_safe(value: Any) -> Any:
         return str(value)
     if isinstance(value, datetime):
         return value.astimezone(UTC).isoformat()
-    if isinstance(value, bool | int | float | str) or value is None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, str) or value is None:
         return value
     return str(value)
 
@@ -895,9 +1322,13 @@ def _write_leaderboard_csv(
                         if row.holdout_median_coverage is None
                         else f"{row.holdout_median_coverage:.6f}"
                     ),
-                    "train_scores_json": json.dumps(list(row.train_scores)),
-                    "holdout_scores_json": json.dumps(list(row.holdout_scores)),
-                    "params_json": json.dumps(_json_safe(_params_dict(row.params)), sort_keys=True),
+                    "train_scores_json": json.dumps(list(row.train_scores), allow_nan=False),
+                    "holdout_scores_json": json.dumps(list(row.holdout_scores), allow_nan=False),
+                    "params_json": json.dumps(
+                        _json_safe(_params_dict(row.params)),
+                        sort_keys=True,
+                        allow_nan=False,
+                    ),
                 }
             )
     return str(output_path.resolve())
@@ -948,7 +1379,7 @@ def _write_summary_json(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     payload = _summary_payload(config=config, summary=summary)
     output_path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
         encoding="utf-8",
     )
 
@@ -979,7 +1410,7 @@ def _print_top_candidates(
             f"{row.train_median_drawdown:9.4f}  "
             f"{row.train_median_fills:12.1f}  "
             f"{row.train_median_coverage:10.3f}  "
-            f"{json.dumps(_json_safe(_params_dict(row.params)), sort_keys=True)}"
+            f"{json.dumps(_json_safe(_params_dict(row.params)), sort_keys=True, allow_nan=False)}"
         )
 
 
@@ -1018,7 +1449,10 @@ def _run_random_trials(
         )
         train_evaluations_by_trial[trial_id] = train_evaluations
         train_rows[trial_id] = _build_leaderboard_row(
-            trial_id=trial_id, params=params, train_evaluations=train_evaluations
+            trial_id=trial_id,
+            params=params,
+            train_evaluations=train_evaluations,
+            invalid_score=config.invalid_score,
         )
     return train_evaluations_by_trial, train_rows, len(candidate_pool), len(sampled_params)
 
@@ -1090,7 +1524,10 @@ def _run_tpe_trials(
         )
         train_evaluations_by_trial[trial_id] = train_evaluations
         row = _build_leaderboard_row(
-            trial_id=trial_id, params=params, train_evaluations=train_evaluations
+            trial_id=trial_id,
+            params=params,
+            train_evaluations=train_evaluations,
+            invalid_score=config.invalid_score,
         )
         train_rows[trial_id] = row
         study.tell(trial, row.train_median_score)
@@ -1121,8 +1558,15 @@ def run_parameter_search(
     rows_by_trial = dict(train_rows)
 
     if holdout_enabled:
-        top_k = min(config.holdout_top_k, len(rows_by_train))
-        for row in rows_by_train[:top_k]:
+        holdout_candidates = [
+            row
+            for row in rows_by_train
+            if all(
+                evaluation.status == "ok" for evaluation in train_evaluations_by_trial[row.trial_id]
+            )
+        ]
+        top_k = min(config.holdout_top_k, len(holdout_candidates))
+        for row in holdout_candidates[:top_k]:
             holdout_evaluations = tuple(
                 _evaluate_window(
                     config=config,
@@ -1138,6 +1582,7 @@ def run_parameter_search(
                 params=row.params,
                 train_evaluations=train_evaluations_by_trial[row.trial_id],
                 holdout_evaluations=holdout_evaluations,
+                invalid_score=config.invalid_score,
             )
 
     final_rows = sorted(rows_by_trial.values(), key=_final_row_sort_key)
@@ -1181,7 +1626,11 @@ def run_parameter_search(
         )
     print(
         "Selected params: "
-        + json.dumps(_json_safe(_params_dict(summary.selected_params)), sort_keys=True)
+        + json.dumps(
+            _json_safe(_params_dict(summary.selected_params)),
+            sort_keys=True,
+            allow_nan=False,
+        )
     )
     print(f"Leaderboard CSV: {summary.leaderboard_csv_path}")
     print(f"Summary JSON: {summary.summary_json_path}")

--- a/prediction_market_extensions/backtesting/_prediction_market_backtest.py
+++ b/prediction_market_extensions/backtesting/_prediction_market_backtest.py
@@ -31,10 +31,17 @@ from prediction_market_extensions.backtesting._backtest_runtime import (
     add_engine_data_by_type,
     build_backtest_run_state,
 )
-from prediction_market_extensions.backtesting._execution_config import ExecutionModelConfig
+from prediction_market_extensions.backtesting._execution_config import (
+    ExecutionModelConfig,
+    StaticLatencyConfig,
+)
 from prediction_market_extensions.backtesting._market_data_config import MarketDataConfig
+from prediction_market_extensions.backtesting._prediction_market_order_guard import (
+    PredictionMarketOrderGuard,
+)
 from prediction_market_extensions.backtesting._replay_specs import ReplaySpec
 from prediction_market_extensions.backtesting._result_policies import (
+    append_result_warning,
     apply_joint_portfolio_settlement_pnl,
     apply_repo_research_disclosures,
 )
@@ -68,6 +75,19 @@ type StrategyFactory = Callable[[InstrumentId], Strategy]
 
 LARGE_DATA_GAP_NS = 4 * 60 * 60 * 1_000_000_000
 REPO_STATUS_TOPIC = "prediction_market.backtest.status"
+DEFAULT_PREDICTION_MARKET_LATENCY = StaticLatencyConfig(
+    base_latency_ms=75.0,
+    insert_latency_ms=10.0,
+    update_latency_ms=5.0,
+    cancel_latency_ms=5.0,
+)
+
+
+def _default_prediction_market_execution() -> ExecutionModelConfig:
+    return ExecutionModelConfig(
+        queue_position=True,
+        latency_model=DEFAULT_PREDICTION_MARKET_LATENCY,
+    )
 
 
 def _record_ts_event(record: Any) -> int | None:
@@ -118,6 +138,75 @@ def _serialize_engine_result_stats(engine_result: Any) -> dict[str, Any]:
     }
 
 
+def _install_prediction_market_order_guard(
+    strategy: Strategy, order_guard: PredictionMarketOrderGuard
+) -> Strategy:
+    order_guard.install(strategy)
+    return strategy
+
+
+def _apply_order_guard_warnings(
+    results: list[dict[str, Any]],
+    order_guard: PredictionMarketOrderGuard,
+) -> None:
+    if not results:
+        return
+    for warning in order_guard.warnings:
+        append_result_warning(results[0], warning)
+
+
+def _timestamp_ns_from_iso(value: object | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        timestamp = pd.Timestamp(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(timestamp):
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("UTC")
+    else:
+        timestamp = timestamp.tz_convert("UTC")
+    return int(timestamp.value)
+
+
+def _iso_from_nanos(timestamp_ns: int) -> str:
+    return pd.Timestamp(timestamp_ns, unit="ns", tz="UTC").isoformat()
+
+
+def _run_state_for_loaded_sim(
+    *,
+    data: Sequence[Any],
+    backtest_end_ns: int | None,
+    forced_stop: bool,
+    loaded_sim: LoadedReplay,
+) -> dict[str, Any]:
+    run_state = build_backtest_run_state(
+        data=data,
+        backtest_end_ns=backtest_end_ns,
+        forced_stop=forced_stop,
+        requested_start_ns=loaded_sim.requested_window.start_ns,
+        requested_end_ns=loaded_sim.requested_window.end_ns,
+    )
+    if forced_stop:
+        return run_state
+
+    expiration_ns_value = loaded_sim.metadata.get("records_clipped_at_expiration_ns")
+    try:
+        expiration_ns = int(expiration_ns_value)
+    except (TypeError, ValueError):
+        return run_state
+    requested_end_ns = loaded_sim.requested_window.end_ns
+    if requested_end_ns is None or requested_end_ns < expiration_ns:
+        return run_state
+
+    simulated_through_ns = _timestamp_ns_from_iso(run_state.get("simulated_through"))
+    if simulated_through_ns is None or simulated_through_ns < expiration_ns:
+        run_state["simulated_through"] = _iso_from_nanos(expiration_ns)
+    return run_state
+
+
 class PredictionMarketBacktest:
     def __init__(
         self,
@@ -163,7 +252,9 @@ class PredictionMarketBacktest:
         self.default_start_time = default_start_time
         self.default_end_time = default_end_time
         self.nautilus_log_level = nautilus_log_level
-        self.execution = execution if execution is not None else ExecutionModelConfig()
+        self.execution = (
+            execution if execution is not None else _default_prediction_market_execution()
+        )
         self.chart_resample_rule = chart_resample_rule
         self.return_summary_series = return_summary_series
 
@@ -208,12 +299,23 @@ class PredictionMarketBacktest:
                 engine.add_instrument(loaded_sim.instrument)
                 add_engine_data_by_type(engine, list(loaded_sim.records))
 
+            order_guard = PredictionMarketOrderGuard()
             if self.strategy_factory is not None:
                 for loaded_sim in loaded_sims:
-                    engine.add_strategy(self.strategy_factory(loaded_sim.instrument.id))
+                    engine.add_strategy(
+                        _install_prediction_market_order_guard(
+                            self.strategy_factory(loaded_sim.instrument.id),
+                            order_guard,
+                        )
+                    )
             else:
                 for importable_config in self._build_importable_strategy_configs(loaded_sims):
-                    engine.add_strategy(NautilusStrategyFactory.create(importable_config))
+                    engine.add_strategy(
+                        _install_prediction_market_order_guard(
+                            NautilusStrategyFactory.create(importable_config),
+                            order_guard,
+                        )
+                    )
 
             _emit_engine_status(
                 engine,
@@ -242,16 +344,16 @@ class PredictionMarketBacktest:
                     joint_portfolio_artifacts=joint_portfolio_artifacts
                     if result_index == 0
                     else None,
-                    run_state=build_backtest_run_state(
+                    run_state=_run_state_for_loaded_sim(
                         data=loaded_sim.records,
                         backtest_end_ns=engine_result.backtest_end,
                         forced_stop=forced_stop,
-                        requested_start_ns=loaded_sim.requested_window.start_ns,
-                        requested_end_ns=loaded_sim.requested_window.end_ns,
+                        loaded_sim=loaded_sim,
                     ),
                 )
                 for result_index, loaded_sim in enumerate(loaded_sims)
             ]
+            _apply_order_guard_warnings(results, order_guard)
             apply_joint_portfolio_settlement_pnl(results)
             if results:
                 results[0]["portfolio_stats"] = _serialize_engine_result_stats(engine_result)

--- a/prediction_market_extensions/backtesting/_prediction_market_order_guard.py
+++ b/prediction_market_extensions/backtesting/_prediction_market_order_guard.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from types import SimpleNamespace
+
+from nautilus_trader.model.enums import OrderSide, OrderType
+
+_EPSILON = Decimal("1e-9")
+type _ReservationKey = tuple[int, str]
+
+
+def _decimal_or_none(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    for attr in ("as_decimal", "as_double", "as_f64_c"):
+        method = getattr(value, attr, None)
+        if callable(method):
+            try:
+                return Decimal(str(method()))
+            except (InvalidOperation, TypeError, ValueError):
+                return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def _call_or_value(value: object) -> object:
+    if callable(value):
+        try:
+            return value()
+        except TypeError:
+            return value
+    return value
+
+
+def _order_side(order: object) -> OrderSide | None:
+    side = getattr(order, "side", None)
+    if side in (OrderSide.BUY, OrderSide.SELL):
+        return side
+    side = getattr(order, "order_side", None)
+    if side in (OrderSide.BUY, OrderSide.SELL):
+        return side
+    is_buy = getattr(order, "is_buy", None)
+    if bool(_call_or_value(is_buy)):
+        return OrderSide.BUY
+    is_sell = getattr(order, "is_sell", None)
+    if bool(_call_or_value(is_sell)):
+        return OrderSide.SELL
+    return None
+
+
+def _order_quantity(order: object) -> Decimal | None:
+    return _decimal_or_none(getattr(order, "quantity", None))
+
+
+def _order_leaves_quantity(order: object) -> Decimal | None:
+    leaves_quantity = _decimal_or_none(getattr(order, "leaves_qty", None))
+    if leaves_quantity is not None:
+        return leaves_quantity
+    return _decimal_or_none(getattr(order, "leaves_quantity", None))
+
+
+def _order_price(order: object) -> Decimal | None:
+    has_price = getattr(order, "has_price", None)
+    if has_price is not None and not bool(_call_or_value(has_price)):
+        return None
+    return _decimal_or_none(getattr(order, "price", None))
+
+
+def _order_type(order: object) -> OrderType | None:
+    order_type = getattr(order, "order_type", None)
+    return order_type if isinstance(order_type, OrderType) else None
+
+
+def _client_order_id(order: object) -> str:
+    return str(getattr(order, "client_order_id", "unknown-order"))
+
+
+def _event_order_is_closed(strategy: object, event: object) -> bool:
+    client_order_id = getattr(event, "client_order_id", None)
+    if client_order_id is None:
+        return True
+    try:
+        order = strategy.cache.order(client_order_id)
+    except (AttributeError, KeyError, TypeError):
+        return True
+    if order is None:
+        return True
+    is_closed = getattr(order, "is_closed", True)
+    return bool(_call_or_value(is_closed))
+
+
+def _prediction_market_instrument(instrument: object | None) -> bool:
+    if instrument is None:
+        return False
+    return instrument.__class__.__name__ == "BinaryOption" or hasattr(instrument, "outcome")
+
+
+def _best_book_price(strategy: object, order: object, side: OrderSide) -> Decimal | None:
+    instrument_id = getattr(order, "instrument_id", None)
+    if instrument_id is None:
+        return None
+    try:
+        book = strategy.cache.order_book(instrument_id)
+    except (AttributeError, KeyError, TypeError):
+        book = None
+    if book is not None:
+        method_name = "best_ask_price" if side == OrderSide.BUY else "best_bid_price"
+        method = getattr(book, method_name, None)
+        if callable(method):
+            price = _decimal_or_none(method())
+            if price is not None:
+                return price
+    try:
+        quote = strategy.cache.quote_tick(instrument_id)
+    except (AttributeError, KeyError, TypeError):
+        quote = None
+    if quote is None:
+        return None
+    attr = "ask_price" if side == OrderSide.BUY else "bid_price"
+    return _decimal_or_none(getattr(quote, attr, None))
+
+
+def _buy_reference_price(strategy: object, order: object) -> Decimal:
+    price = _order_price(order)
+    if price is not None and price > 0:
+        return price
+    price = _best_book_price(strategy, order, OrderSide.BUY)
+    if price is not None and price > 0:
+        return price
+    return Decimal("1")
+
+
+def _fee_rate(instrument: object | None, *, taker: bool) -> Decimal:
+    if instrument is None:
+        return Decimal("0")
+    attr = "taker_fee" if taker else "maker_fee"
+    rate = _decimal_or_none(getattr(instrument, attr, None))
+    if rate is None:
+        return Decimal("0")
+    return max(rate, Decimal("0"))
+
+
+def _buy_cash_cost(
+    *,
+    strategy: object,
+    order: object,
+    instrument: object | None,
+    quantity: Decimal,
+) -> Decimal:
+    price = min(max(_buy_reference_price(strategy, order), Decimal("0")), Decimal("1"))
+    order_type = _order_type(order)
+    taker = order_type in (OrderType.MARKET, OrderType.MARKET_TO_LIMIT)
+    fee = _fee_rate(instrument, taker=taker) * price * (Decimal("1") - price)
+    return quantity * (price + fee)
+
+
+def _free_quote_balance(strategy: object, instrument: object) -> Decimal | None:
+    try:
+        account = strategy.portfolio.account(venue=instrument.id.venue)
+    except (AttributeError, KeyError, TypeError):
+        return None
+    if account is None:
+        return None
+    free_balance = account.balance_free(instrument.quote_currency)
+    return _decimal_or_none(free_balance)
+
+
+def _long_position_qty(strategy: object, instrument_id: object) -> Decimal:
+    try:
+        net_position = strategy.portfolio.net_position(instrument_id)
+    except (AttributeError, KeyError, TypeError):
+        return Decimal("0")
+    position = _decimal_or_none(net_position)
+    if position is None and hasattr(net_position, "signed_decimal_qty"):
+        position = _decimal_or_none(_call_or_value(getattr(net_position, "signed_decimal_qty")))
+    if position is None and hasattr(net_position, "signed_qty"):
+        position = _decimal_or_none(getattr(net_position, "signed_qty"))
+    if position is None:
+        return Decimal("0")
+    return max(position, Decimal("0"))
+
+
+@dataclass
+class _Reservation:
+    instrument_id: object
+    strategy_key: int
+    quote_currency: object | None = None
+    buy_cash: Decimal = Decimal("0")
+    buy_cash_per_unit: Decimal = Decimal("0")
+    sell_qty: Decimal = Decimal("0")
+
+
+class PredictionMarketOrderGuard:
+    """Pre-trade guard for long-only binary prediction-market backtests."""
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+        self._reservations: dict[_ReservationKey, _Reservation] = {}
+
+    def install(self, strategy: object) -> None:
+        original_submit_order = strategy.submit_order
+
+        def guarded_submit_order(order: object, *args: object, **kwargs: object) -> object:
+            reservation_key = self._reservation_key(strategy, order)
+            allowed, reason, reservation = self._check_order(strategy, order)
+            if not allowed:
+                self._deny_order(strategy, order, reason)
+                return None
+            if reservation is not None and reservation_key in self._reservations:
+                self._deny_order(
+                    strategy,
+                    order,
+                    f"duplicate open client_order_id {_client_order_id(order)}",
+                )
+                return None
+            if reservation is not None:
+                self._reservations[reservation_key] = reservation
+            try:
+                return original_submit_order(order, *args, **kwargs)
+            except Exception:
+                self._reservations.pop(reservation_key, None)
+                raise
+
+        strategy.submit_order = guarded_submit_order
+        self._wrap_order_event(strategy, "on_order_filled", release_on_closed=False)
+        for handler_name in (
+            "on_order_rejected",
+            "on_order_denied",
+            "on_order_canceled",
+            "on_order_expired",
+        ):
+            self._wrap_order_event(strategy, handler_name, release_on_closed=True)
+        self._wrap_reset_event(strategy)
+
+    def _strategy_key(self, strategy: object) -> int:
+        return id(strategy)
+
+    def _reservation_key(
+        self, strategy: object, order_or_client_order_id: object
+    ) -> _ReservationKey:
+        if hasattr(order_or_client_order_id, "client_order_id"):
+            client_order_id = _client_order_id(order_or_client_order_id)
+        else:
+            client_order_id = str(order_or_client_order_id)
+        return self._strategy_key(strategy), client_order_id
+
+    def _clear_strategy_reservations(self, strategy: object) -> None:
+        strategy_key = self._strategy_key(strategy)
+        stale_order_ids = [
+            reservation_key
+            for reservation_key, reservation in self._reservations.items()
+            if reservation.strategy_key == strategy_key
+        ]
+        for reservation_key in stale_order_ids:
+            self._reservations.pop(reservation_key, None)
+
+    def _wrap_reset_event(self, strategy: object) -> None:
+        original_handler = getattr(strategy, "on_reset", None)
+        if not callable(original_handler):
+            return
+
+        def wrapped(*args: object, **kwargs: object) -> object:
+            try:
+                return original_handler(*args, **kwargs)
+            finally:
+                self._clear_strategy_reservations(strategy)
+
+        setattr(strategy, "on_reset", wrapped)
+
+    def _wrap_order_event(
+        self,
+        strategy: object,
+        handler_name: str,
+        *,
+        release_on_closed: bool,
+    ) -> None:
+        original_handler = getattr(strategy, handler_name, None)
+        if not callable(original_handler):
+            return
+
+        def wrapped(event: object, *args: object, **kwargs: object) -> object:
+            if not bool(getattr(event, "_prediction_market_guard_denial", False)):
+                client_order_id = getattr(event, "client_order_id", "")
+                reservation_key = self._reservation_key(strategy, client_order_id)
+                if release_on_closed or _event_order_is_closed(strategy, event):
+                    self._reservations.pop(reservation_key, None)
+                else:
+                    self._refresh_reservation(
+                        strategy, reservation_key, client_order_id=client_order_id, event=event
+                    )
+            return original_handler(event, *args, **kwargs)
+
+        setattr(strategy, handler_name, wrapped)
+
+    def _check_order(
+        self, strategy: object, order: object
+    ) -> tuple[bool, str, _Reservation | None]:
+        instrument_id = getattr(order, "instrument_id", None)
+        if instrument_id is None:
+            return True, "", None
+        try:
+            instrument = strategy.cache.instrument(instrument_id)
+        except (AttributeError, KeyError, TypeError):
+            instrument = None
+        if not _prediction_market_instrument(instrument):
+            return True, "", None
+
+        side = _order_side(order)
+        quantity = _order_quantity(order)
+        if side is None or quantity is None or quantity <= 0:
+            return True, "", None
+
+        if side == OrderSide.SELL:
+            pending_sell_qty = sum(
+                reservation.sell_qty
+                for reservation in self._reservations.values()
+                if reservation.instrument_id == instrument_id
+            )
+            available_qty = _long_position_qty(strategy, instrument_id) - pending_sell_qty
+            if quantity > available_qty + _EPSILON:
+                return (
+                    False,
+                    f"SELL quantity {quantity} exceeds available long token inventory "
+                    f"{max(available_qty, Decimal('0'))}",
+                    None,
+                )
+            return (
+                True,
+                "",
+                _Reservation(
+                    instrument_id=instrument_id,
+                    strategy_key=self._strategy_key(strategy),
+                    sell_qty=quantity,
+                ),
+            )
+
+        quote_currency = getattr(instrument, "quote_currency", None)
+        pending_buy_cash = sum(
+            reservation.buy_cash
+            for reservation in self._reservations.values()
+            if reservation.quote_currency == quote_currency
+        )
+        free_cash = _free_quote_balance(strategy, instrument)
+        if free_cash is None:
+            return True, "", None
+        cash_cost = _buy_cash_cost(
+            strategy=strategy,
+            order=order,
+            instrument=instrument,
+            quantity=quantity,
+        )
+        available_cash = free_cash - pending_buy_cash
+        if cash_cost > available_cash + _EPSILON:
+            return (
+                False,
+                f"BUY cash cost {cash_cost} exceeds available cash {max(available_cash, Decimal('0'))}",
+                None,
+            )
+        return (
+            True,
+            "",
+            _Reservation(
+                instrument_id=instrument_id,
+                strategy_key=self._strategy_key(strategy),
+                quote_currency=quote_currency,
+                buy_cash=cash_cost,
+                buy_cash_per_unit=cash_cost / quantity,
+            ),
+        )
+
+    def _deny_order(self, strategy: object, order: object, reason: str) -> None:
+        message = (
+            f"Prediction-market order guard denied {_client_order_id(order)} for "
+            f"{getattr(order, 'instrument_id', 'unknown instrument')}: {reason}."
+        )
+        if message not in self.warnings:
+            self.warnings.append(message)
+        event = SimpleNamespace(
+            client_order_id=getattr(order, "client_order_id", ""),
+            instrument_id=getattr(order, "instrument_id", None),
+            order_side=_order_side(order),
+            order_type=_order_type(order),
+            quantity=getattr(order, "quantity", None),
+            price=getattr(order, "price", None),
+            reason=reason,
+            ts_event=getattr(order, "ts_init", 0),
+            _prediction_market_guard_denial=True,
+        )
+        handler = getattr(strategy, "on_order_denied", None)
+        if callable(handler):
+            handler(event)
+
+    def _refresh_reservation(
+        self,
+        strategy: object,
+        reservation_key: _ReservationKey,
+        *,
+        client_order_id: object,
+        event: object | None = None,
+    ) -> None:
+        existing = self._reservations.get(reservation_key)
+        if existing is None:
+            return
+        try:
+            order = strategy.cache.order(client_order_id)
+        except (AttributeError, KeyError, TypeError):
+            try:
+                order = strategy.cache.order(str(client_order_id))
+            except (AttributeError, KeyError, TypeError):
+                order = None
+        if order is None:
+            self._reduce_reservation_from_fill(existing, event=event, side=None)
+            return
+
+        leaves_qty = _order_leaves_quantity(order)
+        if leaves_qty is None:
+            self._reduce_reservation_from_fill(existing, event=event, side=_order_side(order))
+            return
+        if leaves_qty <= 0:
+            self._reservations.pop(reservation_key, None)
+            return
+
+        side = _order_side(order)
+        instrument_id = getattr(order, "instrument_id", None)
+        try:
+            instrument = strategy.cache.instrument(instrument_id)
+        except (AttributeError, KeyError, TypeError):
+            instrument = None
+        if side == OrderSide.BUY:
+            existing.buy_cash = _buy_cash_cost(
+                strategy=strategy,
+                order=order,
+                instrument=instrument,
+                quantity=leaves_qty,
+            )
+            return
+        if side == OrderSide.SELL:
+            existing.sell_qty = leaves_qty
+
+    def _reduce_reservation_from_fill(
+        self, existing: _Reservation, *, event: object | None, side: OrderSide | None
+    ) -> None:
+        if event is None:
+            return
+        fill_qty = _decimal_or_none(
+            getattr(
+                event,
+                "last_qty",
+                getattr(event, "quantity", getattr(event, "filled_qty", None)),
+            )
+        )
+        if fill_qty is None or fill_qty <= 0:
+            return
+        event_side = _order_side(event)
+        side = event_side if event_side is not None else side
+        if side == OrderSide.BUY or (side is None and existing.buy_cash > 0):
+            existing.buy_cash = max(
+                Decimal("0"), existing.buy_cash - (fill_qty * existing.buy_cash_per_unit)
+            )
+            return
+        if side == OrderSide.SELL or (side is None and existing.sell_qty > 0):
+            existing.sell_qty = max(Decimal("0"), existing.sell_qty - fill_qty)

--- a/prediction_market_extensions/backtesting/_result_policies.py
+++ b/prediction_market_extensions/backtesting/_result_policies.py
@@ -21,6 +21,7 @@ _CURATED_REPLAY_WARNING = (
 _PORTFOLIO_RISK_WARNING = (
     "No portfolio-level drawdown or daily-loss circuit breaker is configured for this run."
 )
+_REALISM_EPSILON = 1e-9
 
 
 def _timestamp_ns(value: object | None) -> int | None:
@@ -44,7 +45,17 @@ def _timestamp_ns(value: object | None) -> int | None:
         else:
             timestamp = timestamp.tz_convert("UTC")
         return int(timestamp.value)
-    return None
+    try:
+        timestamp = pd.Timestamp(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(timestamp):
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("UTC")
+    else:
+        timestamp = timestamp.tz_convert("UTC")
+    return int(timestamp.value)
 
 
 def _timestamp_utc(value: object | None) -> pd.Timestamp | None:
@@ -131,6 +142,74 @@ def _fill_event_timestamp(event: Mapping[object, object]) -> pd.Timestamp | None
     return None
 
 
+def _explicit_settlement_cutoff_timestamp(
+    result: Mapping[str, Any],
+    *,
+    settlement_observable_ns_key: str,
+    settlement_observable_time_key: str,
+) -> pd.Timestamp | None:
+    timestamps: list[pd.Timestamp] = []
+    for key in (
+        "market_close_time_ns",
+        settlement_observable_time_key,
+        settlement_observable_ns_key,
+    ):
+        timestamp = _timestamp_utc(result.get(key))
+        if timestamp is not None:
+            timestamps.append(timestamp)
+    return max(timestamps) if timestamps else None
+
+
+def _settlement_observable_timestamp(
+    result: Mapping[str, Any],
+    *,
+    settlement_observable_ns_key: str,
+    settlement_observable_time_key: str,
+) -> pd.Timestamp | None:
+    timestamps: list[pd.Timestamp] = []
+    for key in (settlement_observable_time_key, settlement_observable_ns_key):
+        timestamp = _timestamp_utc(result.get(key))
+        if timestamp is not None:
+            timestamps.append(timestamp)
+    return max(timestamps) if timestamps else None
+
+
+def _fill_events_at_or_before(
+    fill_events: object, timestamp: pd.Timestamp | None
+) -> tuple[object, int]:
+    if (
+        timestamp is None
+        or not isinstance(fill_events, Sequence)
+        or isinstance(fill_events, str | bytes)
+    ):
+        return fill_events, 0
+
+    filtered: list[object] = []
+    ignored = 0
+    for event in fill_events:
+        if not isinstance(event, Mapping):
+            filtered.append(event)
+            continue
+        fill_timestamp = _fill_event_timestamp(event)
+        if fill_timestamp is not None and fill_timestamp > timestamp:
+            ignored += 1
+            continue
+        filtered.append(event)
+    return filtered, ignored
+
+
+def _fill_event_count(fill_events: object) -> int | None:
+    if not isinstance(fill_events, Sequence) or isinstance(fill_events, str | bytes):
+        return None
+    return len(fill_events)
+
+
+def _mapping_fill_events(fill_events: object) -> list[Mapping[object, object]]:
+    if not isinstance(fill_events, Sequence) or isinstance(fill_events, str | bytes):
+        return []
+    return [event for event in fill_events if isinstance(event, Mapping)]
+
+
 def _binary_mark_to_market_pnl_at_settlement(
     *,
     fill_events: object,
@@ -182,10 +261,90 @@ def _binary_mark_to_market_pnl_at_settlement(
     if market_price is None:
         return None
 
-    position_value = (
-        open_qty * market_price if open_qty >= 0.0 else abs(open_qty) * (1.0 - market_price)
-    )
-    return float(cash_pnl + max(position_value, 0.0)), float(cash_pnl)
+    position_value = open_qty * market_price
+    return float(cash_pnl + position_value), float(cash_pnl)
+
+
+def _fill_inventory_bounds(fill_events: object) -> tuple[float, float] | None:
+    if not isinstance(fill_events, Sequence) or isinstance(fill_events, str | bytes):
+        return None
+
+    position = 0.0
+    min_position = 0.0
+    saw_fill = False
+    for event in sorted(
+        (event for event in fill_events if isinstance(event, Mapping)),
+        key=lambda item: _fill_event_timestamp(item) or pd.Timestamp.min.tz_localize("UTC"),
+    ):
+        action = str(event.get("action") or "").strip().lower()
+        quantity = _coerce_float(event.get("quantity")) or 0.0
+        if quantity <= 0.0:
+            continue
+        if action == "buy":
+            position += quantity
+        elif action == "sell":
+            position -= quantity
+        else:
+            continue
+        min_position = min(min_position, position)
+        saw_fill = True
+
+    if not saw_fill:
+        return None
+    return min_position, position
+
+
+def _set_realism_invalid(
+    result: dict[str, Any],
+    *,
+    stop_reason: str,
+    warning: str,
+) -> None:
+    result["backtest_realism_invalid"] = True
+    append_result_warning(result, warning)
+    if not bool(result.get("terminated_early")):
+        result["terminated_early"] = True
+    if not result.get("stop_reason"):
+        result["stop_reason"] = stop_reason
+
+
+def _apply_result_integrity_checks(
+    result: dict[str, Any],
+    *,
+    fill_events_key: str,
+) -> dict[str, Any]:
+    inventory_bounds = _fill_inventory_bounds(result.get(fill_events_key, []))
+    if inventory_bounds is not None:
+        min_position, final_position = inventory_bounds
+        result["min_signed_position"] = float(min_position)
+        result["final_signed_position"] = float(final_position)
+        if min_position < -_REALISM_EPSILON:
+            _set_realism_invalid(
+                result,
+                stop_reason="invalid_short_position",
+                warning=(
+                    "Token inventory went negative during replay. This backtest does not "
+                    "model collateralized naked short exposure, so the result is not "
+                    "realistic enough to trust as executable."
+                ),
+            )
+
+    cash_series = _pairs_to_series(result.get("cash_series"))
+    if not cash_series.empty:
+        min_cash = float(cash_series.min())
+        result["min_cash"] = min_cash
+        if min_cash < -_REALISM_EPSILON:
+            _set_realism_invalid(
+                result,
+                stop_reason="account_error",
+                warning=(
+                    "Cash balance went negative during replay. The backtest filled orders "
+                    "without sufficient cash, so the result is not realistic enough to trust "
+                    "as executable."
+                ),
+            )
+
+    return result
 
 
 def _series_bounds(*series_values: object) -> tuple[pd.Timestamp | None, pd.Timestamp | None]:
@@ -265,10 +424,13 @@ def _settlement_timestamp(
         result.get("pnl_series"),
         result.get("price_series"),
     )
+    explicit_settlement_time = _explicit_settlement_cutoff_timestamp(
+        result,
+        settlement_observable_ns_key=settlement_observable_ns_key,
+        settlement_observable_time_key=settlement_observable_time_key,
+    )
     candidates = (
-        result.get("market_close_time_ns"),
-        result.get(settlement_observable_time_key),
-        result.get(settlement_observable_ns_key),
+        explicit_settlement_time,
         result.get("planned_end"),
         result.get("simulated_through"),
         series_end,
@@ -290,6 +452,7 @@ def _apply_settlement_to_summary_series(
     result: dict[str, Any],
     *,
     settlement_pnl: float,
+    fill_events_key: str,
     settlement_observable_ns_key: str,
     settlement_observable_time_key: str,
 ) -> None:
@@ -313,15 +476,25 @@ def _apply_settlement_to_summary_series(
     )
 
     result["settlement_series_time"] = timestamp.isoformat()
+    final_equity: float | None = None
+    final_cash: float | None = None
     mark_to_market_pnl = _binary_mark_to_market_pnl_at_settlement(
-        fill_events=result.get("fill_events"),
+        fill_events=result.get(fill_events_key),
         price_series=result.get("price_series"),
         timestamp=timestamp,
     )
     if mark_to_market_pnl is not None:
         current_mtm_pnl, current_cash_pnl = mark_to_market_pnl
-        result["settlement_equity_adjustment"] = float(settlement_pnl - current_mtm_pnl)
-        result["settlement_cash_adjustment"] = float(settlement_pnl - current_cash_pnl)
+        settlement_equity_adjustment = float(settlement_pnl - current_mtm_pnl)
+        settlement_cash_adjustment = float(settlement_pnl - current_cash_pnl)
+        result["settlement_equity_adjustment"] = settlement_equity_adjustment
+        result["settlement_cash_adjustment"] = settlement_cash_adjustment
+        current_equity = _series_value_at_or_before(equity_series, timestamp)
+        if current_equity is not None:
+            final_equity = float(current_equity + settlement_equity_adjustment)
+        current_cash = _series_value_at_or_before(cash_series, timestamp)
+        if current_cash is not None:
+            final_cash = float(current_cash + settlement_cash_adjustment)
 
     if initial_equity is None:
         if not pnl_series.empty:
@@ -335,7 +508,8 @@ def _apply_settlement_to_summary_series(
             )
         return
 
-    final_equity = float(initial_equity + settlement_pnl)
+    if final_equity is None:
+        final_equity = float(initial_equity + settlement_pnl)
 
     if not equity_series.empty:
         current_equity = _series_value_at_or_before(equity_series, timestamp)
@@ -351,10 +525,12 @@ def _apply_settlement_to_summary_series(
 
     if not cash_series.empty:
         current_cash = _series_value_at_or_before(cash_series, timestamp)
+        if final_cash is None:
+            final_cash = final_equity
         if current_cash is not None and "settlement_cash_adjustment" not in result:
-            result["settlement_cash_adjustment"] = float(final_equity - current_cash)
+            result["settlement_cash_adjustment"] = float(final_cash - current_cash)
         result["cash_series"] = _series_to_pairs(
-            _set_series_value_at_and_after(cash_series, timestamp=timestamp, value=final_equity)
+            _set_series_value_at_and_after(cash_series, timestamp=timestamp, value=final_cash)
         )
 
     if not pnl_series.empty:
@@ -396,26 +572,73 @@ def apply_binary_settlement_pnl(
     settlement_observable_ns_key: str = "settlement_observable_ns",
     settlement_observable_time_key: str = "settlement_observable_time",
     simulated_through_key: str = "simulated_through",
+    planned_end_key: str = "planned_end",
 ) -> dict[str, Any]:
-    settlement_observable_ns = _timestamp_ns(
-        result.get(settlement_observable_ns_key) or result.get(settlement_observable_time_key)
+    settlement_cutoff_timestamp = _explicit_settlement_cutoff_timestamp(
+        result,
+        settlement_observable_ns_key=settlement_observable_ns_key,
+        settlement_observable_time_key=settlement_observable_time_key,
+    )
+    settlement_observable_timestamp = _settlement_observable_timestamp(
+        result,
+        settlement_observable_ns_key=settlement_observable_ns_key,
+        settlement_observable_time_key=settlement_observable_time_key,
+    )
+    settlement_cutoff_ns = _timestamp_ns(settlement_cutoff_timestamp)
+    settlement_observable_ns = _timestamp_ns(settlement_observable_timestamp)
+    settlement_required_ns = (
+        settlement_cutoff_ns
+        if settlement_observable_ns is not None and settlement_cutoff_ns is not None
+        else settlement_observable_ns
     )
     simulated_through_ns = _timestamp_ns(result.get(simulated_through_key))
-    if settlement_observable_ns is not None and simulated_through_ns is None:
+    planned_end_ns = _timestamp_ns(result.get(planned_end_key))
+    if result.get(realized_outcome_key) is not None and settlement_required_ns is None:
+        append_result_warning(
+            result,
+            "Settlement outcome metadata exists but no settlement observable timestamp was "
+            "provided; keeping mark-to-market PnL because resolution observability cannot "
+            "be verified.",
+        )
+        result["settlement_pnl_applied"] = False
+        return _apply_result_integrity_checks(result, fill_events_key=fill_events_key)
+    if (
+        settlement_required_ns is not None
+        and planned_end_ns is not None
+        and planned_end_ns < settlement_required_ns
+    ):
+        observable_time = (
+            settlement_cutoff_timestamp.isoformat()
+            if settlement_cutoff_timestamp is not None
+            else result.get(settlement_observable_time_key)
+            or result.get(settlement_observable_ns_key)
+        )
+        append_result_warning(
+            result,
+            f"Settlement outcome exists after the requested replay window; keeping "
+            f"mark-to-market PnL instead of resolved settlement because the planned end "
+            f"was {result.get(planned_end_key)} (observable at {observable_time}).",
+        )
+        result["settlement_pnl_applied"] = False
+        return _apply_result_integrity_checks(result, fill_events_key=fill_events_key)
+    if settlement_required_ns is not None and simulated_through_ns is None:
         append_result_warning(
             result,
             "Settlement outcome metadata exists but simulated_through is missing; keeping "
             "mark-to-market PnL because settlement observability cannot be verified.",
         )
         result["settlement_pnl_applied"] = False
-        return result
+        return _apply_result_integrity_checks(result, fill_events_key=fill_events_key)
     if (
-        settlement_observable_ns is not None
+        settlement_required_ns is not None
         and simulated_through_ns is not None
-        and simulated_through_ns < settlement_observable_ns
+        and simulated_through_ns < settlement_required_ns
     ):
-        observable_time = result.get(settlement_observable_time_key) or result.get(
-            settlement_observable_ns_key
+        observable_time = (
+            settlement_cutoff_timestamp.isoformat()
+            if settlement_cutoff_timestamp is not None
+            else result.get(settlement_observable_time_key)
+            or result.get(settlement_observable_ns_key)
         )
         append_result_warning(
             result,
@@ -424,15 +647,32 @@ def apply_binary_settlement_pnl(
             f"{result.get(simulated_through_key)} (observable at {observable_time}).",
         )
         result["settlement_pnl_applied"] = False
-        return result
+        return _apply_result_integrity_checks(result, fill_events_key=fill_events_key)
+
+    settlement_fill_events, ignored_post_settlement_fills = _fill_events_at_or_before(
+        result.get(fill_events_key, []), settlement_cutoff_timestamp
+    )
+    if ignored_post_settlement_fills:
+        result[fill_events_key] = settlement_fill_events
+        result["post_settlement_fill_events_ignored"] = ignored_post_settlement_fills
+        pruned_fill_count = _fill_event_count(settlement_fill_events)
+        if pruned_fill_count is not None:
+            if "fills" in result and result.get("fills") != pruned_fill_count:
+                result["fills_before_post_settlement_pruning"] = result.get("fills")
+            result["fills"] = pruned_fill_count
+        append_result_warning(
+            result,
+            f"Ignored {ignored_post_settlement_fills} fill event(s) after the settlement cutoff "
+            f"when computing resolved settlement PnL and downstream reports.",
+        )
 
     settlement_pnl = settlement_pnl_fn(
-        result.get(fill_events_key, []),
+        _mapping_fill_events(settlement_fill_events),
         result.get(realized_outcome_key),
     )
     if settlement_pnl is None:
         result["settlement_pnl_applied"] = False
-        return result
+        return _apply_result_integrity_checks(result, fill_events_key=fill_events_key)
 
     result[market_exit_pnl_key] = float(result.get(pnl_key, 0.0))
     result[pnl_key] = float(settlement_pnl)
@@ -440,10 +680,11 @@ def apply_binary_settlement_pnl(
     _apply_settlement_to_summary_series(
         result,
         settlement_pnl=float(settlement_pnl),
+        fill_events_key=fill_events_key,
         settlement_observable_ns_key=settlement_observable_ns_key,
         settlement_observable_time_key=settlement_observable_time_key,
     )
-    return result
+    return _apply_result_integrity_checks(result, fill_events_key=fill_events_key)
 
 
 def apply_joint_portfolio_settlement_pnl(results: Results) -> Results:

--- a/prediction_market_extensions/backtesting/data_sources/pmxt.py
+++ b/prediction_market_extensions/backtesting/data_sources/pmxt.py
@@ -184,6 +184,82 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
     def _raw_paths_for_hour_at_root(self, raw_root: Path, hour) -> tuple[Path, ...]:  # type: ignore[no-untyped-def]
         return self._local_archive_candidate_paths_for_hour(raw_root, hour)
 
+    def _local_source_fingerprint_for_hour(self, raw_root: Path, hour) -> dict[str, object] | None:  # type: ignore[no-untyped-def]
+        for raw_path in self._raw_paths_for_hour_at_root(raw_root, hour):
+            fingerprint = self._local_file_fingerprint(raw_path)
+            if fingerprint is not None:
+                fingerprint["source_stage"] = _PMXT_SOURCE_STAGE_RAW_LOCAL
+                return fingerprint
+        return None
+
+    def _remote_source_fingerprint_for_hour(self, base_url: str, hour) -> dict[str, object]:  # type: ignore[no-untyped-def]
+        url = self._archive_url_for_base_url(base_url, hour)
+        fingerprint: dict[str, object] = {
+            "kind": "remote",
+            "source_stage": _PMXT_SOURCE_STAGE_RAW_REMOTE,
+            "url": url,
+        }
+        request = Request(url, method="HEAD", headers={"User-Agent": _PMXT_RUNNER_HTTP_USER_AGENT})
+        try:
+            with urlopen(request, timeout=_PMXT_RUNNER_HTTP_TIMEOUT_SECS) as response:
+                content_length = self._content_length_from_response(response)
+                if content_length is not None:
+                    fingerprint["content_length"] = int(content_length)
+                headers = getattr(response, "headers", {})
+                for header, key in (
+                    ("ETag", "etag"),
+                    ("Last-Modified", "last_modified"),
+                    ("Content-MD5", "content_md5"),
+                ):
+                    value = None
+                    if hasattr(headers, "get"):
+                        value = headers.get(header) or headers.get(header.lower())
+                    if value:
+                        fingerprint[key] = str(value)
+        except Exception:
+            fingerprint["remote_fingerprint_unavailable_ns"] = time.time_ns()
+        return fingerprint
+
+    def _source_fingerprint_for_entry(
+        self, kind: str, target: str, hour
+    ) -> dict[str, object] | None:  # type: ignore[no-untyped-def]
+        if kind == _PMXT_SOURCE_STAGE_RAW_LOCAL:
+            return self._local_source_fingerprint_for_hour(Path(target).expanduser(), hour)
+        if kind == _PMXT_SOURCE_STAGE_RAW_REMOTE:
+            return self._remote_source_fingerprint_for_hour(str(target), hour)
+        return None
+
+    def _source_cache_fingerprint_for_hour(self, hour):  # type: ignore[override,no-untyped-def]
+        ordered_entries = getattr(self, "_pmxt_ordered_source_entries", ()) or ()
+        if ordered_entries:
+            for kind, target in ordered_entries:
+                fingerprint = self._source_fingerprint_for_entry(kind, target, hour)
+                if fingerprint is not None:
+                    return fingerprint
+            return None
+
+        for stage in self._pmxt_source_priority:
+            if stage == _PMXT_SOURCE_STAGE_RAW_LOCAL:
+                raw_root = getattr(self, "_pmxt_raw_root", None)
+                if raw_root is None:
+                    continue
+                fingerprint = self._local_source_fingerprint_for_hour(
+                    Path(raw_root).expanduser(),
+                    hour,
+                )
+                if fingerprint is not None:
+                    return fingerprint
+                continue
+
+            if stage == _PMXT_SOURCE_STAGE_RAW_REMOTE:
+                urls = getattr(self, "_pmxt_remote_base_urls", ()) or ()
+                if not urls and getattr(self, "_pmxt_remote_base_url", None) is not None:
+                    urls = (self._pmxt_remote_base_url,)
+                if urls:
+                    return self._remote_source_fingerprint_for_hour(str(urls[0]), hour)
+
+        return None
+
     def _load_local_raw_market_batches_from_root(
         self,
         raw_root: Path,
@@ -365,10 +441,20 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
             )
         return None
 
-    def _write_cache_if_enabled(self, hour, table) -> None:  # type: ignore[no-untyped-def]
+    def _write_cache_if_enabled(
+        self,
+        hour,
+        table,
+        *,
+        source: dict[str, object] | None,
+    ) -> None:  # type: ignore[no-untyped-def]
         if self._pmxt_cache_dir is not None:
             with suppress(OSError, pa.ArrowException):
-                self._write_market_cache(hour, table)
+                self._write_market_cache(
+                    hour,
+                    table,
+                    metadata=self._cache_metadata_payload(hour, source=source),
+                )
 
     def _load_market_table(self, hour, *, batch_size: int):  # type: ignore[no-untyped-def]
         table = self._load_cached_market_table(hour)
@@ -386,6 +472,7 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
                 )
                 if entry_batches is None:
                     continue
+                source = self._source_fingerprint_for_entry(kind, target, hour)
                 if kind == _PMXT_SOURCE_STAGE_RAW_REMOTE:
                     table = (
                         pa.Table.from_batches(entry_batches)
@@ -399,7 +486,7 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
                         if entry_batches
                         else self._empty_market_table()
                     )
-                self._write_cache_if_enabled(hour, table)
+                self._write_cache_if_enabled(hour, table, source=source)
                 return table
             return None
 
@@ -409,20 +496,34 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
                     hour, batch_size=batch_size
                 )
                 if local_archive_batches is not None:
+                    raw_root = getattr(self, "_pmxt_raw_root", None)
+                    source = (
+                        self._local_source_fingerprint_for_hour(Path(raw_root).expanduser(), hour)
+                        if raw_root is not None
+                        else None
+                    )
                     table = (
                         pa.Table.from_batches(local_archive_batches)
                         if local_archive_batches
                         else self._empty_market_table()
                     )
-                    self._write_cache_if_enabled(hour, table)
+                    self._write_cache_if_enabled(hour, table, source=source)
                     return table
                 continue
 
             if stage == _PMXT_SOURCE_STAGE_RAW_REMOTE:
                 remote_table = self._load_remote_market_table(hour, batch_size=batch_size)
                 if remote_table is not None:
+                    urls = getattr(self, "_pmxt_remote_base_urls", ()) or ()
+                    if not urls and getattr(self, "_pmxt_remote_base_url", None) is not None:
+                        urls = (self._pmxt_remote_base_url,)
+                    source = (
+                        self._remote_source_fingerprint_for_hour(str(urls[0]), hour)
+                        if urls
+                        else None
+                    )
                     remote_table = self._filter_table_to_token(remote_table)
-                    self._write_cache_if_enabled(hour, remote_table)
+                    self._write_cache_if_enabled(hour, remote_table, source=source)
                     return remote_table
                 continue
 
@@ -443,13 +544,14 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
                     batch_size=batch_size,
                 )
                 if entry_batches is not None:
+                    source = self._source_fingerprint_for_entry(kind, target, hour)
                     if self._pmxt_cache_dir is not None:
                         table = (
                             pa.Table.from_batches(entry_batches)
                             if entry_batches
                             else self._empty_market_table()
                         )
-                        self._write_cache_if_enabled(hour, table)
+                        self._write_cache_if_enabled(hour, table, source=source)
                     return entry_batches
             return None
 
@@ -457,26 +559,40 @@ class RunnerPolymarketPMXTDataLoader(PolymarketPMXTDataLoader):
             if stage == _PMXT_SOURCE_STAGE_RAW_LOCAL:
                 batches = self._load_local_archive_market_batches(hour, batch_size=batch_size)
                 if batches is not None:
+                    raw_root = getattr(self, "_pmxt_raw_root", None)
+                    source = (
+                        self._local_source_fingerprint_for_hour(Path(raw_root).expanduser(), hour)
+                        if raw_root is not None
+                        else None
+                    )
                     if self._pmxt_cache_dir is not None:
                         table = (
                             pa.Table.from_batches(batches)
                             if batches
                             else self._empty_market_table()
                         )
-                        self._write_cache_if_enabled(hour, table)
+                        self._write_cache_if_enabled(hour, table, source=source)
                     return batches
                 continue
 
             if stage == _PMXT_SOURCE_STAGE_RAW_REMOTE:
                 batches = self._load_remote_market_batches(hour, batch_size=batch_size)
                 if batches is not None:
+                    urls = getattr(self, "_pmxt_remote_base_urls", ()) or ()
+                    if not urls and getattr(self, "_pmxt_remote_base_url", None) is not None:
+                        urls = (self._pmxt_remote_base_url,)
+                    source = (
+                        self._remote_source_fingerprint_for_hour(str(urls[0]), hour)
+                        if urls
+                        else None
+                    )
                     if self._pmxt_cache_dir is not None:
                         table = (
                             pa.Table.from_batches(batches)
                             if batches
                             else self._empty_market_table()
                         )
-                        self._write_cache_if_enabled(hour, table)
+                        self._write_cache_if_enabled(hour, table, source=source)
                     return batches
                 continue
 

--- a/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
+++ b/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import time
+import warnings
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -95,6 +96,115 @@ def _loaded_window(records: tuple[object, ...]) -> ReplayWindow | None:
     if start_ns is None and end_ns is None:
         return None
     return ReplayWindow(start_ns=start_ns, end_ns=end_ns)
+
+
+def _instrument_expiration_ns(instrument: Any) -> int | None:
+    value = getattr(instrument, "expiration_ns", None)
+    try:
+        expiration_ns = int(value)
+    except (TypeError, ValueError):
+        return None
+    return expiration_ns if expiration_ns > 0 else None
+
+
+def _clip_records_at_instrument_expiration(
+    *,
+    instrument: Any,
+    records: tuple[object, ...],
+    market_label: str,
+) -> tuple[tuple[object, ...], dict[str, Any]]:
+    expiration_ns = _instrument_expiration_ns(instrument)
+    if expiration_ns is None:
+        return records, {}
+
+    clipped = tuple(
+        record
+        for record in records
+        if (timestamp_ns := _record_timestamp_ns(record)) is None or timestamp_ns <= expiration_ns
+    )
+    dropped = len(records) - len(clipped)
+    if dropped <= 0:
+        return records, {}
+
+    warnings.warn(
+        f"Dropped {dropped} post-expiration replay record(s) for {market_label}; "
+        "prediction-market orders cannot fill after the instrument expiration.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    return clipped, {
+        "post_expiration_records_dropped": dropped,
+        "records_clipped_at_expiration_ns": expiration_ns,
+    }
+
+
+def _book_is_crossed(book: OrderBook) -> bool:
+    best_bid = book.best_bid_price()
+    best_ask = book.best_ask_price()
+    return best_bid is not None and best_ask is not None and float(best_bid) >= float(best_ask)
+
+
+def _drop_crossed_l2_book_records(
+    *,
+    instrument: Any,
+    records: tuple[object, ...],
+    deltas_type: type[Any],
+    market_label: str,
+) -> tuple[tuple[object, ...], dict[str, Any]]:
+    book_records_seen = any(isinstance(record, deltas_type) for record in records)
+    if not book_records_seen:
+        return records, {}
+
+    local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
+    has_valid_book = False
+    dropped_crossed = 0
+    dropped_without_snapshot = 0
+    sanitized: list[object] = []
+
+    for record in records:
+        if not isinstance(record, deltas_type):
+            sanitized.append(record)
+            continue
+
+        is_snapshot = bool(getattr(record, "is_snapshot", False))
+        if is_snapshot:
+            local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
+            has_valid_book = False
+        elif not has_valid_book:
+            dropped_without_snapshot += 1
+            continue
+
+        try:
+            local_book.apply_deltas(record)
+        except Exception:
+            dropped_crossed += 1
+            local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
+            has_valid_book = False
+            continue
+
+        if _book_is_crossed(local_book):
+            dropped_crossed += 1
+            local_book = OrderBook(instrument.id, book_type=BookType.L2_MBP)
+            has_valid_book = False
+            continue
+
+        has_valid_book = True
+        sanitized.append(record)
+
+    metadata: dict[str, Any] = {}
+    if dropped_crossed:
+        metadata["crossed_book_records_dropped"] = dropped_crossed
+    if dropped_without_snapshot:
+        metadata["book_delta_records_without_snapshot_dropped"] = dropped_without_snapshot
+    if metadata:
+        warnings.warn(
+            f"Dropped invalid L2 replay record(s) for {market_label}: "
+            f"{dropped_crossed} crossed/invalid book record(s), "
+            f"{dropped_without_snapshot} delta record(s) before a valid snapshot.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return tuple(sanitized), metadata
 
 
 def _requested_window(start: pd.Timestamp, end: pd.Timestamp) -> ReplayWindow:
@@ -470,6 +580,23 @@ class PolymarketPMXTBookReplayAdapter(_BaseReplayAdapter):
             return None
 
         deltas_type = _resolve_backtest_compat_symbol("OrderBookDeltas", OrderBookDeltas)
+        metadata = dict(replay.metadata or {})
+        records, clip_metadata = _clip_records_at_instrument_expiration(
+            instrument=loader.instrument,
+            records=records,
+            market_label=replay.market_slug,
+        )
+        metadata.update(clip_metadata)
+        records, invalid_book_metadata = _drop_crossed_l2_book_records(
+            instrument=loader.instrument,
+            records=records,
+            deltas_type=deltas_type,
+            market_label=replay.market_slug,
+        )
+        metadata.update(invalid_book_metadata)
+        if not records:
+            print(f"Skip {replay.market_slug}: no valid PMXT L2 book data remained")
+            return None
         book_event_count, prices_tuple = _book_event_count_and_midpoints(
             instrument=loader.instrument,
             records=records,
@@ -496,7 +623,7 @@ class PolymarketPMXTBookReplayAdapter(_BaseReplayAdapter):
             prices=prices_tuple,
             outcome=str(loader.instrument.outcome or replay.outcome or ""),
             realized_outcome=_loader_realized_outcome(loader),
-            metadata=dict(replay.metadata or {}),
+            metadata=metadata,
             requested_window=_requested_window(start, end),
         )
 
@@ -593,6 +720,23 @@ class PolymarketTelonexBookReplayAdapter(_BaseReplayAdapter):
             return None
 
         deltas_type = _resolve_backtest_compat_symbol("OrderBookDeltas", OrderBookDeltas)
+        metadata = dict(replay.metadata or {})
+        records, clip_metadata = _clip_records_at_instrument_expiration(
+            instrument=loader.instrument,
+            records=records,
+            market_label=replay.market_slug,
+        )
+        metadata.update(clip_metadata)
+        records, invalid_book_metadata = _drop_crossed_l2_book_records(
+            instrument=loader.instrument,
+            records=records,
+            deltas_type=deltas_type,
+            market_label=replay.market_slug,
+        )
+        metadata.update(invalid_book_metadata)
+        if not records:
+            print(f"Skip {replay.market_slug}: no valid Telonex L2 book data remained")
+            return None
         book_event_count, prices_tuple = _book_event_count_and_midpoints(
             instrument=loader.instrument,
             records=records,
@@ -619,7 +763,7 @@ class PolymarketTelonexBookReplayAdapter(_BaseReplayAdapter):
             prices=prices_tuple,
             outcome=selected_outcome,
             realized_outcome=_loader_realized_outcome(loader),
-            metadata=dict(replay.metadata or {}),
+            metadata=metadata,
             requested_window=_requested_window(start, end),
         )
 

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import threading
 import warnings
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC
+from decimal import Decimal, InvalidOperation
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
@@ -63,7 +65,8 @@ _TELONEX_SOURCE_API = "api"
 _TELONEX_BLOB_DB_FILENAME = "telonex.duckdb"
 _TELONEX_DATA_SUBDIR = "data"
 _TELONEX_CACHE_SUBDIR = "api-days"
-_TELONEX_DELTAS_CACHE_SUBDIR = "book-deltas-v1"
+_TELONEX_DELTAS_CACHE_SUBDIR = "book-deltas-v2"
+_TELONEX_DELTAS_CACHE_METADATA_VERSION = 2
 _TELONEX_DELTAS_CACHE_COLUMNS = frozenset(
     {
         "event_index",
@@ -600,6 +603,16 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             )
         else:
             part_paths, incomplete_parts = manifest_parts
+            if not part_paths and not incomplete_parts:
+                # A manifest can lag a local blob copy or be rebuilt after the
+                # parquet parts are already present. Falling back preserves
+                # correctness; predicate pushdown still filters the legacy scan
+                # to the requested market/outcome/time window.
+                part_paths, incomplete_parts = self._readable_blob_part_paths(
+                    channel_dir=channel_dir,
+                    start=start_utc,
+                    end=end_utc,
+                )
         if incomplete_parts:
             return None
         if not part_paths:
@@ -1046,6 +1059,63 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             return None
         return cache_path.parent / f"{cache_path.stem}.fast.parquet"
 
+    @staticmethod
+    def _fast_api_cache_metadata_path(fast_path: Path) -> Path:
+        return fast_path.with_name(f"{fast_path.name}.metadata.json")
+
+    def _fast_api_cache_metadata_payload(
+        self,
+        *,
+        base_url: str,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> dict[str, object] | None:
+        cache_path = self._api_cache_path(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if cache_path is None:
+            return None
+        source = self._local_file_fingerprint(cache_path)
+        if source is None:
+            return None
+        return {"version": 1, "source": source}
+
+    def _fast_api_cache_metadata_matches(
+        self,
+        *,
+        fast_path: Path,
+        base_url: str,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> bool:
+        expected = self._fast_api_cache_metadata_payload(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if expected is None:
+            return False
+        metadata_path = self._fast_api_cache_metadata_path(fast_path)
+        try:
+            actual = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        return actual == expected
+
     def _load_fast_cache_day(
         self,
         *,
@@ -1065,6 +1135,21 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             outcome=outcome,
         )
         if fast_path is None or not fast_path.exists():
+            return None
+        if not self._fast_api_cache_metadata_matches(
+            fast_path=fast_path,
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        ):
+            try:
+                fast_path.unlink()
+                self._fast_api_cache_metadata_path(fast_path).unlink(missing_ok=True)
+            except OSError:
+                pass
             return None
         frame = self._safe_read_parquet(fast_path)
         if frame is not None:
@@ -1098,6 +1183,14 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             return
         if "bids" not in frame.columns or "asks" not in frame.columns:
             return
+        metadata = self._fast_api_cache_metadata_payload(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
         bid_prices_list: list[list[str]] = []
         bid_sizes_list: list[list[str]] = []
         ask_prices_list: list[list[str]] = []
@@ -1134,13 +1227,28 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         fast_frame["ask_prices"] = ask_prices_list
         fast_frame["ask_sizes"] = ask_sizes_list
         tmp_path = fast_path.with_name(f"{fast_path.name}.tmp.{os.getpid()}")
+        metadata_path = self._fast_api_cache_metadata_path(fast_path)
+        metadata_tmp_path = metadata_path.with_name(f"{metadata_path.name}.tmp.{os.getpid()}")
         try:
             fast_path.parent.mkdir(parents=True, exist_ok=True)
             fast_frame.to_parquet(tmp_path, compression="zstd", index=False)
+            if metadata is not None:
+                metadata_tmp_path.write_text(
+                    json.dumps(metadata, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
             os.replace(tmp_path, fast_path)
+            if metadata is not None:
+                os.replace(metadata_tmp_path, metadata_path)
+            else:
+                metadata_path.unlink(missing_ok=True)
         except OSError as exc:
             try:
                 tmp_path.unlink()
+            except OSError:
+                pass
+            try:
+                metadata_tmp_path.unlink()
             except OSError:
                 pass
             warnings.warn(
@@ -1255,6 +1363,221 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             / f"{date}.{start_ns}-{end_ns}.parquet"
         )
 
+    @staticmethod
+    def _deltas_cache_metadata_path(cache_path: Path) -> Path:
+        return cache_path.with_name(f"{cache_path.name}.metadata.json")
+
+    @staticmethod
+    def _local_file_fingerprint(path: Path) -> dict[str, object] | None:
+        try:
+            stat = path.expanduser().resolve().stat()
+        except OSError:
+            return None
+        return {
+            "kind": "local",
+            "path": str(path.expanduser().resolve()),
+            "size": int(stat.st_size),
+            "mtime_ns": int(stat.st_mtime_ns),
+            "ctime_ns": int(stat.st_ctime_ns),
+        }
+
+    def _local_blob_source_fingerprint_for_day(
+        self,
+        *,
+        root: Path,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> dict[str, object] | None:
+        blob_root = self._local_blob_root(root)
+        if blob_root is None:
+            return None
+
+        day_start = pd.Timestamp(date, tz=UTC)
+        day_end = day_start + pd.Timedelta(days=1) - pd.Timedelta(nanoseconds=1)
+        manifest_path = blob_root / _TELONEX_BLOB_DB_FILENAME
+        manifest = self._local_file_fingerprint(manifest_path)
+        manifest_parts = self._manifest_blob_part_paths(
+            store_root=blob_root,
+            channel=channel,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+            start=day_start,
+            end=day_end,
+        )
+        if manifest_parts is None:
+            channel_dir = blob_root / _TELONEX_DATA_SUBDIR / f"channel={channel}"
+            part_paths, incomplete = self._readable_blob_part_paths(
+                channel_dir=channel_dir,
+                start=day_start,
+                end=day_end,
+            )
+            source_layout = "blob-legacy"
+        else:
+            part_paths, incomplete = manifest_parts
+            source_layout = "blob-manifest"
+            if not part_paths and not incomplete:
+                channel_dir = blob_root / _TELONEX_DATA_SUBDIR / f"channel={channel}"
+                part_paths, incomplete = self._readable_blob_part_paths(
+                    channel_dir=channel_dir,
+                    start=day_start,
+                    end=day_end,
+                )
+                source_layout = "blob-legacy"
+
+        parts: list[dict[str, object]] = []
+        for raw_part in sorted({str(part) for part in part_paths}):
+            fingerprint = self._local_file_fingerprint(Path(raw_part))
+            if fingerprint is None:
+                incomplete = True
+                continue
+            parts.append(fingerprint)
+
+        if not parts:
+            return None
+
+        return {
+            "kind": _TELONEX_SOURCE_LOCAL,
+            "source_stage": _TELONEX_SOURCE_LOCAL,
+            "layout": source_layout,
+            "root": str(root.expanduser().resolve()),
+            "channel": channel,
+            "date": date,
+            "market_slug": market_slug,
+            "token_index": token_index,
+            "outcome": outcome,
+            "manifest": manifest,
+            "parts": parts,
+            "incomplete": bool(incomplete),
+        }
+
+    def _telonex_source_fingerprint_for_entry(
+        self,
+        *,
+        entry: TelonexSourceEntry,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> dict[str, object] | None:
+        if entry.kind == _TELONEX_SOURCE_API:
+            # API responses can be corrected for the same request URL. Without
+            # response-side validation (ETag/content hash), a materialized
+            # deltas cache would mask those corrections. Keep API day caching
+            # separate and skip this derived deltas cache for API sources.
+            return None
+        if entry.kind != _TELONEX_SOURCE_LOCAL or entry.target is None:
+            return None
+
+        root = Path(entry.target).expanduser()
+        blob_fingerprint = self._local_blob_source_fingerprint_for_day(
+            root=root,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if blob_fingerprint is not None:
+            return blob_fingerprint
+
+        path = self._local_path_for_day(
+            root=root,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if path is None:
+            path = self._local_consolidated_path(
+                root=root,
+                channel=channel,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+            )
+        fingerprint = self._local_file_fingerprint(path) if path is not None else None
+        if fingerprint is not None:
+            fingerprint["source_stage"] = _TELONEX_SOURCE_LOCAL
+            return fingerprint
+        return {
+            "kind": _TELONEX_SOURCE_LOCAL,
+            "root": str(root.resolve()),
+            "channel": channel,
+            "date": date,
+            "market_slug": market_slug,
+            "token_index": token_index,
+            "outcome": outcome,
+        }
+
+    def _deltas_cache_source_fingerprint(
+        self,
+        *,
+        config: TelonexLoaderConfig,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> dict[str, object] | None:
+        for entry in config.ordered_source_entries:
+            fingerprint = self._telonex_source_fingerprint_for_entry(
+                entry=entry,
+                channel=config.channel,
+                date=date,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+            )
+            if fingerprint is not None:
+                return fingerprint
+        return None
+
+    def _deltas_cache_metadata_payload(
+        self,
+        *,
+        source: Mapping[str, object] | None,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+    ) -> dict[str, object] | None:
+        if source is None:
+            return None
+        instrument = getattr(self, "_instrument", None)
+        instrument_id = str(getattr(instrument, "id", "unknown"))
+        return {
+            "version": _TELONEX_DELTAS_CACHE_METADATA_VERSION,
+            "instrument_id": instrument_id,
+            "channel": channel,
+            "date": date,
+            "market_slug": market_slug,
+            "token_index": token_index,
+            "outcome": outcome,
+            "start_ns": int(self._normalize_to_utc(start).value),
+            "end_ns": int(self._normalize_to_utc(end).value),
+            "source": dict(source),
+        }
+
+    def _deltas_cache_metadata_matches(
+        self, *, cache_path: Path, expected_metadata: Mapping[str, object] | None
+    ) -> bool:
+        if expected_metadata is None:
+            return False
+        metadata_path = self._deltas_cache_metadata_path(cache_path)
+        try:
+            actual = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        return actual == dict(expected_metadata)
+
     def _load_deltas_cache_day(
         self,
         *,
@@ -1265,6 +1588,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         outcome: str | None,
         start: pd.Timestamp,
         end: pd.Timestamp,
+        expected_metadata: Mapping[str, object] | None,
     ) -> tuple[list[OrderBookDeltas] | None, str]:
         cache_path = self._deltas_cache_path(
             channel=channel,
@@ -1277,6 +1601,11 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             end=end,
         )
         if cache_path is None or not cache_path.exists():
+            return None, "none"
+        if not self._deltas_cache_metadata_matches(
+            cache_path=cache_path,
+            expected_metadata=expected_metadata,
+        ):
             return None, "none"
         try:
             table = pq.read_table(cache_path)
@@ -1307,6 +1636,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         outcome: str | None,
         start: pd.Timestamp,
         end: pd.Timestamp,
+        metadata: Mapping[str, object] | None,
     ) -> None:
         cache_path = self._deltas_cache_path(
             channel=channel,
@@ -1321,6 +1651,8 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         if cache_path is None:
             return
         tmp_path = cache_path.with_name(f"{cache_path.name}.tmp.{os.getpid()}")
+        metadata_path = self._deltas_cache_metadata_path(cache_path)
+        metadata_tmp_path = metadata_path.with_name(f"{metadata_path.name}.tmp.{os.getpid()}")
         try:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
             pq.write_table(
@@ -1328,10 +1660,23 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                 tmp_path,
                 compression="zstd",
             )
+            if metadata is not None:
+                metadata_tmp_path.write_text(
+                    json.dumps(dict(metadata), sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
             os.replace(tmp_path, cache_path)
+            if metadata is not None:
+                os.replace(metadata_tmp_path, metadata_path)
+            else:
+                metadata_path.unlink(missing_ok=True)
         except Exception as exc:  # noqa: BLE001 - cache writes must not break replay
             try:
                 tmp_path.unlink()
+            except OSError:
+                pass
+            try:
+                metadata_tmp_path.unlink()
             except OSError:
                 pass
             warnings.warn(
@@ -1543,14 +1888,28 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
     @staticmethod
     def _column_to_ns(column: pd.Series, column_name: str) -> np.ndarray:
         if column_name == "timestamp_us":
-            return column.to_numpy(dtype="int64") * 1_000
+            return RunnerPolymarketTelonexBookDataLoader._scaled_column_to_ns(column, 1_000)
         if column_name == "timestamp_ms":
-            numeric = pd.to_numeric(column, errors="coerce")
-            return (numeric.astype("float64") * 1_000_000).to_numpy(dtype="int64")
+            return RunnerPolymarketTelonexBookDataLoader._scaled_column_to_ns(column, 1_000_000)
         if pd.api.types.is_numeric_dtype(column):
-            return (column.astype("float64") * 1_000_000_000).to_numpy(dtype="int64")
+            return RunnerPolymarketTelonexBookDataLoader._scaled_column_to_ns(column, 1_000_000_000)
         parsed = pd.to_datetime(column, utc=True, errors="coerce")
         return parsed.astype("int64").to_numpy()
+
+    @staticmethod
+    def _scaled_column_to_ns(column: pd.Series, multiplier: int) -> np.ndarray:
+        invalid = np.iinfo(np.int64).min
+        values: list[int] = []
+        scale = Decimal(multiplier)
+        for value in column.to_numpy():
+            if pd.isna(value):
+                values.append(invalid)
+                continue
+            try:
+                values.append(int(Decimal(str(value)) * scale))
+            except (InvalidOperation, ValueError):
+                values.append(invalid)
+        return np.array(values, dtype="int64")
 
     @staticmethod
     def _normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp:
@@ -1634,6 +1993,16 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
     def _book_side_map(levels: Sequence[PolymarketBookLevel]) -> dict[str, str]:
         return {str(level.price): str(level.size) for level in levels}
 
+    @staticmethod
+    def _book_levels_are_crossed(
+        *,
+        bids: Sequence[PolymarketBookLevel],
+        asks: Sequence[PolymarketBookLevel],
+    ) -> bool:
+        if not bids or not asks:
+            return False
+        return float(bids[-1].price) >= float(asks[-1].price)
+
     def _snapshot_to_deltas(
         self,
         *,
@@ -1646,9 +2015,27 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             asset_id=str(getattr(self, "token_id", "") or ""),
             bids=list(bids),
             asks=list(asks),
-            timestamp=str(ts_event / 1_000_000),
+            timestamp=str(Decimal(ts_event) / Decimal(1_000_000)),
         )
-        return snapshot.parse_to_snapshot(instrument=self.instrument, ts_init=ts_event)
+        deltas = snapshot.parse_to_snapshot(instrument=self.instrument, ts_init=ts_event)
+        if deltas is None:
+            return None
+        return self._retimestamp_deltas(deltas, ts_event=ts_event)
+
+    def _retimestamp_deltas(self, deltas: OrderBookDeltas, *, ts_event: int) -> OrderBookDeltas:
+        exact_deltas = [
+            OrderBookDelta(
+                instrument_id=delta.instrument_id,
+                action=delta.action,
+                order=delta.order,
+                flags=delta.flags,
+                sequence=delta.sequence,
+                ts_event=ts_event,
+                ts_init=ts_event,
+            )
+            for delta in deltas.deltas
+        ]
+        return OrderBookDeltas(self.instrument.id, exact_deltas)
 
     def _diff_to_deltas(
         self,
@@ -1745,19 +2132,32 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         previous_bids: dict[str, str] | None = None
         previous_asks: dict[str, str] | None = None
         emitted_snapshot = False
+        dropped_invalid_snapshots = 0
 
         for idx in order:
             ts_event = int(ns_arr[idx])
-            if has_flat:
-                bids = self._book_levels_from_arrays(
-                    prices=bid_prices_values[idx], sizes=bid_sizes_values[idx], side="bid"
-                )
-                asks = self._book_levels_from_arrays(
-                    prices=ask_prices_values[idx], sizes=ask_sizes_values[idx], side="ask"
-                )
-            else:
-                bids = self._book_levels_from_value(bids_values[idx], side="bid")
-                asks = self._book_levels_from_value(asks_values[idx], side="ask")
+            try:
+                if has_flat:
+                    bids = self._book_levels_from_arrays(
+                        prices=bid_prices_values[idx], sizes=bid_sizes_values[idx], side="bid"
+                    )
+                    asks = self._book_levels_from_arrays(
+                        prices=ask_prices_values[idx], sizes=ask_sizes_values[idx], side="ask"
+                    )
+                else:
+                    bids = self._book_levels_from_value(bids_values[idx], side="bid")
+                    asks = self._book_levels_from_value(asks_values[idx], side="ask")
+                crossed = self._book_levels_are_crossed(bids=bids, asks=asks)
+            except (TypeError, ValueError, InvalidOperation, OverflowError):
+                crossed = True
+                bids = ()
+                asks = ()
+            if crossed:
+                dropped_invalid_snapshots += 1
+                previous_bids = None
+                previous_asks = None
+                emitted_snapshot = False
+                continue
             current_bids = self._book_side_map(bids)
             current_asks = self._book_side_map(asks)
 
@@ -1786,6 +2186,14 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             previous_bids = current_bids
             previous_asks = current_asks
 
+        if dropped_invalid_snapshots:
+            warnings.warn(
+                "Telonex: dropped "
+                f"{dropped_invalid_snapshots} crossed/invalid full-book snapshot(s); "
+                "book state was reset until the next valid snapshot.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         events.sort(key=lambda record: int(record.ts_event))
         return events
 
@@ -1852,6 +2260,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
     ) -> pd.DataFrame | None:
         assert entry.target is not None
         root = Path(entry.target).expanduser()
+        self._telonex_last_local_source_fingerprint = None
         blob_root = self._local_blob_root(root)
         if blob_root is not None:
             try:
@@ -1871,9 +2280,28 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                 )
                 blob_frame = None
             if blob_frame is not None:
+                self._telonex_last_local_source_fingerprint = (
+                    self._local_blob_source_fingerprint_for_day(
+                        root=root,
+                        channel=channel,
+                        date=date,
+                        market_slug=market_slug,
+                        token_index=token_index,
+                        outcome=outcome,
+                    )
+                )
                 return blob_frame
 
+        daily_path: Path | None = None
         try:
+            daily_path = self._local_path_for_day(
+                root=root,
+                channel=channel,
+                date=date,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+            )
             daily_frame = self._load_local_day(
                 root=root,
                 channel=channel,
@@ -1889,6 +2317,12 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             )
             daily_frame = None
         if daily_frame is not None:
+            if daily_path is not None:
+                fingerprint = self._local_file_fingerprint(daily_path)
+                if fingerprint is not None:
+                    fingerprint["source_stage"] = _TELONEX_SOURCE_LOCAL
+                    fingerprint["layout"] = "daily"
+                    self._telonex_last_local_source_fingerprint = fingerprint
             return daily_frame
 
         path = self._local_consolidated_path(
@@ -1902,6 +2336,12 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             return None
         if path not in range_cache:
             range_cache[path] = self._safe_read_parquet(path)
+        if range_cache[path] is not None:
+            fingerprint = self._local_file_fingerprint(path)
+            if fingerprint is not None:
+                fingerprint["source_stage"] = _TELONEX_SOURCE_LOCAL
+                fingerprint["layout"] = "consolidated"
+                self._telonex_last_local_source_fingerprint = fingerprint
         return range_cache[path]
 
     def _try_load_day_from_entry(
@@ -2031,7 +2471,14 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                 return _TelonexDayResult(date=date, records=[], source=day_source)
 
             day_start, day_end = day_window
-            cached_records, cached_source = self._load_deltas_cache_day(
+            expected_cache_metadata = self._deltas_cache_metadata_payload(
+                source=self._deltas_cache_source_fingerprint(
+                    config=config,
+                    date=date,
+                    market_slug=market_slug,
+                    token_index=token_index,
+                    outcome=outcome,
+                ),
                 channel=config.channel,
                 date=date,
                 market_slug=market_slug,
@@ -2040,12 +2487,23 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                 start=day_start,
                 end=day_end,
             )
+            cached_records, cached_source = self._load_deltas_cache_day(
+                channel=config.channel,
+                date=date,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+                start=day_start,
+                end=day_end,
+                expected_metadata=expected_cache_metadata,
+            )
             if cached_records is not None:
                 self._day_progress(date, "complete", cached_source, len(cached_records))
                 emitted_day_complete = True
                 return _TelonexDayResult(date=date, records=cached_records, source=cached_source)
 
             frame: pd.DataFrame | None = None
+            day_source_fingerprint: dict[str, object] | None = None
             if frame is None:
                 for entry in config.ordered_source_entries:
                     if entry.kind == _TELONEX_SOURCE_LOCAL:
@@ -2074,6 +2532,19 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                         )
                         day_source = source if frame is not None else day_source
                     if frame is not None:
+                        if entry.kind == _TELONEX_SOURCE_LOCAL:
+                            day_source_fingerprint = getattr(
+                                self, "_telonex_last_local_source_fingerprint", None
+                            )
+                        if day_source_fingerprint is None:
+                            day_source_fingerprint = self._telonex_source_fingerprint_for_entry(
+                                entry=entry,
+                                channel=config.channel,
+                                date=date,
+                                market_slug=market_slug,
+                                token_index=token_index,
+                                outcome=outcome,
+                            )
                         break
 
             if frame is None:
@@ -2097,6 +2568,16 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                     outcome=outcome,
                     start=day_start,
                     end=day_end,
+                    metadata=self._deltas_cache_metadata_payload(
+                        source=day_source_fingerprint,
+                        channel=config.channel,
+                        date=date,
+                        market_slug=market_slug,
+                        token_index=token_index,
+                        outcome=outcome,
+                        start=day_start,
+                        end=day_end,
+                    ),
                 )
             self._day_progress(date, "complete", day_source, len(day_records))
             emitted_day_complete = True

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -1000,6 +1000,42 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             pass
         return None
 
+    def _api_cache_source_fingerprint_for_day(
+        self,
+        *,
+        base_url: str,
+        channel: str,
+        date: str,
+        market_slug: str,
+        token_index: int,
+        outcome: str | None,
+    ) -> dict[str, object] | None:
+        cache_path = self._api_cache_path(
+            base_url=base_url,
+            channel=channel,
+            date=date,
+            market_slug=market_slug,
+            token_index=token_index,
+            outcome=outcome,
+        )
+        if cache_path is None:
+            return None
+        fingerprint = self._local_file_fingerprint(cache_path)
+        if fingerprint is None:
+            return None
+        fingerprint.update(
+            {
+                "source_stage": _TELONEX_SOURCE_API,
+                "base_url": base_url.rstrip("/"),
+                "channel": channel,
+                "date": date,
+                "market_slug": market_slug,
+                "token_index": token_index,
+                "outcome": outcome,
+            }
+        )
+        return fingerprint
+
     def _write_api_cache_day(
         self,
         *,
@@ -1465,11 +1501,16 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         outcome: str | None,
     ) -> dict[str, object] | None:
         if entry.kind == _TELONEX_SOURCE_API:
-            # API responses can be corrected for the same request URL. Without
-            # response-side validation (ETag/content hash), a materialized
-            # deltas cache would mask those corrections. Keep API day caching
-            # separate and skip this derived deltas cache for API sources.
-            return None
+            if entry.target is None:
+                return None
+            return self._api_cache_source_fingerprint_for_day(
+                base_url=entry.target,
+                channel=channel,
+                date=date,
+                market_slug=market_slug,
+                token_index=token_index,
+                outcome=outcome,
+            )
         if entry.kind != _TELONEX_SOURCE_LOCAL or entry.target is None:
             return None
 
@@ -2419,17 +2460,17 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             return None, "none"
         if frame is None:
             return None, "none"
-        return (
-            frame,
-            self._telonex_api_source_label(
+        source = getattr(self, "_telonex_last_api_source", None)
+        if not source:
+            source = self._telonex_api_source_label(
                 base_url=entry.target,
                 channel=channel,
                 date=date,
                 market_slug=market_slug,
                 token_index=token_index,
                 outcome=outcome,
-            ),
-        )
+            )
+        return frame, source
 
     def _telonex_api_source_label(
         self,

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -5,7 +5,7 @@ import os
 import re
 import threading
 import warnings
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -2093,6 +2093,8 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         start: pd.Timestamp,
         end: pd.Timestamp,
         include_order_book: bool = True,
+        invalid_snapshot_warning: bool = True,
+        invalid_snapshot_counter: Callable[[int], None] | None = None,
     ) -> list[OrderBookDeltas]:
         if frame.empty:
             return []
@@ -2187,13 +2189,16 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             previous_asks = current_asks
 
         if dropped_invalid_snapshots:
-            warnings.warn(
-                "Telonex: dropped "
-                f"{dropped_invalid_snapshots} crossed/invalid full-book snapshot(s); "
-                "book state was reset until the next valid snapshot.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
+            if invalid_snapshot_counter is not None:
+                invalid_snapshot_counter(dropped_invalid_snapshots)
+            elif invalid_snapshot_warning:
+                warnings.warn(
+                    "Telonex: dropped "
+                    f"{dropped_invalid_snapshots} crossed/invalid full-book snapshot(s); "
+                    "book state was reset until the next valid snapshot.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
         events.sort(key=lambda record: int(record.ts_event))
         return events
 
@@ -2458,6 +2463,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         outcome: str | None,
         include_order_book: bool,
         range_cache: dict[Path, pd.DataFrame | None],
+        invalid_snapshot_counter: Callable[[int], None] | None = None,
     ) -> _TelonexDayResult:
         self._day_progress(date, "start", "none", 0)
         _ = api_entries  # API cache is consulted only when an API source is reached.
@@ -2557,6 +2563,8 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                 start=day_start,
                 end=day_end,
                 include_order_book=include_order_book,
+                invalid_snapshot_warning=invalid_snapshot_counter is None,
+                invalid_snapshot_counter=invalid_snapshot_counter,
             )
             if include_order_book:
                 self._write_deltas_cache_day(
@@ -2598,6 +2606,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         token_index: int,
         outcome: str | None,
         include_order_book: bool,
+        invalid_snapshot_counter: Callable[[int], None] | None = None,
     ) -> Iterator[_TelonexDayResult]:
         prefetch_workers = getattr(
             self, "_telonex_prefetch_workers", self._resolve_prefetch_workers()
@@ -2617,6 +2626,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                     outcome=outcome,
                     include_order_book=include_order_book,
                     range_cache=range_cache,
+                    invalid_snapshot_counter=invalid_snapshot_counter,
                 )
             return
 
@@ -2642,6 +2652,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
                     outcome=outcome,
                     include_order_book=include_order_book,
                     range_cache={},
+                    invalid_snapshot_counter=invalid_snapshot_counter,
                 )
 
             for _ in range(max_workers):
@@ -2664,6 +2675,13 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
     ) -> list[OrderBookDeltas]:
         config = self._config()
         records: list[OrderBookDeltas] = []
+        invalid_snapshot_counts: list[int] = []
+        invalid_snapshot_lock = threading.Lock()
+
+        def _count_invalid_snapshots(count: int) -> None:
+            with invalid_snapshot_lock:
+                invalid_snapshot_counts.append(count)
+
         api_entries = [
             entry for entry in config.ordered_source_entries if entry.kind == _TELONEX_SOURCE_API
         ]
@@ -2678,8 +2696,19 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
             token_index=token_index,
             outcome=outcome,
             include_order_book=include_order_book,
+            invalid_snapshot_counter=_count_invalid_snapshots,
         ):
             records.extend(result.records)
+        invalid_snapshot_count = sum(invalid_snapshot_counts)
+        if invalid_snapshot_count:
+            warnings.warn(
+                "Telonex: dropped "
+                f"{invalid_snapshot_count} crossed/invalid full-book snapshot(s) while loading "
+                f"{market_slug} token_index={token_index}; book state was reset until the next "
+                "valid snapshot.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         records.sort(key=lambda record: int(record.ts_event))
         return records
 

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -1546,15 +1546,7 @@ class RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader):
         if fingerprint is not None:
             fingerprint["source_stage"] = _TELONEX_SOURCE_LOCAL
             return fingerprint
-        return {
-            "kind": _TELONEX_SOURCE_LOCAL,
-            "root": str(root.resolve()),
-            "channel": channel,
-            "date": date,
-            "market_slug": market_slug,
-            "token_index": token_index,
-            "outcome": outcome,
-        }
+        return None
 
     def _deltas_cache_source_fingerprint(
         self,

--- a/prediction_market_extensions/backtesting/prediction_market/artifacts.py
+++ b/prediction_market_extensions/backtesting/prediction_market/artifacts.py
@@ -225,17 +225,24 @@ class PredictionMarketArtifactBuilder:
         outcomes: pd.Series,
         include_portfolio_series: bool,
     ) -> dict[str, Any]:
+        fill_events = prediction_market_research._serialize_fill_events(
+            market_id=loaded_sim.market_id,
+            fills_report=fills_report,
+            default_side=prediction_market_research._fill_event_side_hint(
+                outcome=loaded_sim.outcome,
+                token_index=getattr(loaded_sim.spec, "token_index", None),
+            ),
+        )
         legacy_models, _ = prediction_market_research.legacy_plot_adapter._load_legacy_modules()
-        legacy_fills = prediction_market_research.legacy_plot_adapter._convert_fills(
-            fills_report, legacy_models
+        legacy_fills = prediction_market_research._deserialize_fill_events(
+            market_id=loaded_sim.market_id,
+            fill_events=fill_events,
+            models_module=legacy_models,
         )
         market_prices_with_fills = (
             prediction_market_research.legacy_plot_adapter._market_prices_with_fill_points(
                 {loaded_sim.market_id: market_prices}, legacy_fills
             ).get(loaded_sim.market_id, market_prices)
-        )
-        fill_events = prediction_market_research._serialize_fill_events(
-            market_id=loaded_sim.market_id, fills_report=fills_report
         )
         series_artifacts: dict[str, Any] = {
             "price_series": prediction_market_research._series_to_iso_pairs(

--- a/prediction_market_extensions/backtesting/prediction_market/artifacts.py
+++ b/prediction_market_extensions/backtesting/prediction_market/artifacts.py
@@ -293,7 +293,8 @@ class PredictionMarketArtifactBuilder:
     def _filter_report_rows(report: pd.DataFrame, *, instrument_id: str) -> pd.DataFrame:
         if report.empty or "instrument_id" not in report.columns:
             return pd.DataFrame()
-        return report.loc[report["instrument_id"] == instrument_id].copy()
+        instrument_ids = report["instrument_id"].map(str)
+        return report.loc[instrument_ids == instrument_id].copy()
 
 
 __all__ = ["PredictionMarketArtifactBuilder", "resolve_repo_relative_path"]

--- a/prediction_market_extensions/backtesting/profile_replay.py
+++ b/prediction_market_extensions/backtesting/profile_replay.py
@@ -84,6 +84,17 @@ def _timestamp_from_payload(value: object) -> pd.Timestamp:
     return timestamp
 
 
+def _normalize_timestamp_bound(value: object) -> pd.Timestamp | None:
+    if value is None:
+        return None
+    timestamp = pd.Timestamp(value)
+    if pd.isna(timestamp):
+        return None
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize("UTC")
+    return timestamp.tz_convert("UTC")
+
+
 def normalize_profile_trade(payload: Mapping[str, object]) -> ProfileTrade:
     slug = str(payload.get("slug") or "").strip()
     if not slug:
@@ -172,7 +183,11 @@ def select_profile_trade_groups(
     max_groups: int,
     allowed_slug_prefixes: Sequence[str] = DEFAULT_PROFILE_REPLAY_PREFIXES,
     require_complete_inventory: bool = True,
+    min_latest_trade_time: object | None = None,
+    max_latest_trade_time: object | None = None,
 ) -> tuple[ProfileTradeGroup, ...]:
+    min_latest = _normalize_timestamp_bound(min_latest_trade_time)
+    max_latest = _normalize_timestamp_bound(max_latest_trade_time)
     grouped: dict[tuple[str, int], list[ProfileTrade]] = defaultdict(list)
     for trade in trades:
         if allowed_slug_prefixes and not trade.slug.startswith(tuple(allowed_slug_prefixes)):
@@ -183,6 +198,11 @@ def select_profile_trade_groups(
     for (slug, outcome_index), group_trades in grouped.items():
         ordered = tuple(sorted(group_trades, key=lambda item: item.timestamp_ns))
         if require_complete_inventory and not _inventory_never_negative(ordered):
+            continue
+        latest_trade_time = max(trade.timestamp for trade in ordered)
+        if min_latest is not None and latest_trade_time < min_latest:
+            continue
+        if max_latest is not None and latest_trade_time > max_latest:
             continue
         candidates.append(ProfileTradeGroup(slug=slug, outcome_index=outcome_index, trades=ordered))
 

--- a/prediction_market_extensions/backtesting/profile_replay.py
+++ b/prediction_market_extensions/backtesting/profile_replay.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+from prediction_market_extensions.backtesting._replay_specs import BookReplay
+
+POLYMARKET_PROFILE_TRADES_URL = "https://data-api.polymarket.com/trades"
+DEFAULT_PROFILE_REPLAY_PREFIXES = ("btc-updown-5m-", "btc-updown-15m-")
+PROFILE_REPLAY_USER_AGENT = "prediction-market-backtesting/profile-replay"
+
+_BTC_UPDOWN_SLUG_RE = re.compile(r"^btc-updown-(?P<minutes>\d+)m-(?P<start>\d+)$")
+
+
+@dataclass(frozen=True)
+class ProfileTrade:
+    slug: str
+    outcome_index: int
+    side: str
+    size: Decimal
+    price: Decimal
+    timestamp: pd.Timestamp
+    transaction_hash: str
+    title: str = ""
+    outcome: str = ""
+
+    @property
+    def key(self) -> str:
+        return profile_replay_key(slug=self.slug, outcome_index=self.outcome_index)
+
+    @property
+    def timestamp_ns(self) -> int:
+        return int(self.timestamp.value)
+
+
+@dataclass(frozen=True)
+class ProfileTradeGroup:
+    slug: str
+    outcome_index: int
+    trades: tuple[ProfileTrade, ...]
+
+    @property
+    def key(self) -> str:
+        return profile_replay_key(slug=self.slug, outcome_index=self.outcome_index)
+
+    @property
+    def outcome(self) -> str:
+        return self.trades[0].outcome if self.trades else ""
+
+    @property
+    def title(self) -> str:
+        return self.trades[0].title if self.trades else self.slug
+
+
+def profile_replay_key(*, slug: str, outcome_index: int) -> str:
+    return f"{slug}:{int(outcome_index)}"
+
+
+def _decimal_from_payload(value: object, *, field: str) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"profile trade field {field!r} is not decimal-like: {value!r}") from exc
+    if not parsed.is_finite():
+        raise ValueError(f"profile trade field {field!r} is not finite: {value!r}")
+    return parsed
+
+
+def _timestamp_from_payload(value: object) -> pd.Timestamp:
+    try:
+        timestamp = pd.Timestamp(float(value), unit="s", tz="UTC")
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"profile trade timestamp is invalid: {value!r}") from exc
+    if pd.isna(timestamp):
+        raise ValueError(f"profile trade timestamp is invalid: {value!r}")
+    return timestamp
+
+
+def normalize_profile_trade(payload: Mapping[str, object]) -> ProfileTrade:
+    slug = str(payload.get("slug") or "").strip()
+    if not slug:
+        raise ValueError("profile trade is missing slug")
+
+    side = str(payload.get("side") or "").strip().upper()
+    if side not in {"BUY", "SELL"}:
+        raise ValueError(f"profile trade side must be BUY or SELL, got {side!r}")
+
+    try:
+        outcome_index = int(payload.get("outcomeIndex"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("profile trade is missing integer outcomeIndex") from exc
+
+    size = _decimal_from_payload(payload.get("size"), field="size")
+    price = _decimal_from_payload(payload.get("price"), field="price")
+    if size <= 0:
+        raise ValueError(f"profile trade size must be positive, got {size}")
+    if price < 0 or price > 1:
+        raise ValueError(f"profile trade price must be in [0, 1], got {price}")
+
+    return ProfileTrade(
+        slug=slug,
+        outcome_index=outcome_index,
+        side=side,
+        size=size,
+        price=price,
+        timestamp=_timestamp_from_payload(payload.get("timestamp")),
+        transaction_hash=str(payload.get("transactionHash") or ""),
+        title=str(payload.get("title") or ""),
+        outcome=str(payload.get("outcome") or ""),
+    )
+
+
+def normalize_profile_trades(payloads: Iterable[Mapping[str, object]]) -> tuple[ProfileTrade, ...]:
+    trades: list[ProfileTrade] = []
+    for payload in payloads:
+        try:
+            trades.append(normalize_profile_trade(payload))
+        except ValueError:
+            continue
+    return tuple(sorted(trades, key=lambda trade: (trade.timestamp_ns, trade.transaction_hash)))
+
+
+def fetch_profile_trades(
+    *,
+    user: str,
+    limit: int = 500,
+    taker_only: bool = False,
+    base_url: str = POLYMARKET_PROFILE_TRADES_URL,
+    timeout_seconds: float = 30.0,
+) -> tuple[ProfileTrade, ...]:
+    query = urlencode(
+        {
+            "user": user,
+            "limit": int(limit),
+            "takerOnly": "true" if taker_only else "false",
+        }
+    )
+    request = Request(
+        f"{base_url}?{query}",
+        headers={"User-Agent": PROFILE_REPLAY_USER_AGENT},
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("Polymarket profile trades API did not return a list")
+    return normalize_profile_trades(item for item in payload if isinstance(item, Mapping))
+
+
+def _inventory_never_negative(trades: Sequence[ProfileTrade]) -> bool:
+    inventory = Decimal("0")
+    for trade in sorted(trades, key=lambda item: item.timestamp_ns):
+        if trade.side == "BUY":
+            inventory += trade.size
+        else:
+            inventory -= trade.size
+        if inventory < Decimal("-0.000001"):
+            return False
+    return True
+
+
+def select_profile_trade_groups(
+    trades: Sequence[ProfileTrade],
+    *,
+    max_groups: int,
+    allowed_slug_prefixes: Sequence[str] = DEFAULT_PROFILE_REPLAY_PREFIXES,
+    require_complete_inventory: bool = True,
+) -> tuple[ProfileTradeGroup, ...]:
+    grouped: dict[tuple[str, int], list[ProfileTrade]] = defaultdict(list)
+    for trade in trades:
+        if allowed_slug_prefixes and not trade.slug.startswith(tuple(allowed_slug_prefixes)):
+            continue
+        grouped[(trade.slug, trade.outcome_index)].append(trade)
+
+    candidates: list[ProfileTradeGroup] = []
+    for (slug, outcome_index), group_trades in grouped.items():
+        ordered = tuple(sorted(group_trades, key=lambda item: item.timestamp_ns))
+        if require_complete_inventory and not _inventory_never_negative(ordered):
+            continue
+        candidates.append(ProfileTradeGroup(slug=slug, outcome_index=outcome_index, trades=ordered))
+
+    candidates.sort(
+        key=lambda group: max(trade.timestamp_ns for trade in group.trades),
+        reverse=True,
+    )
+    return tuple(candidates[: max(0, int(max_groups))])
+
+
+def infer_profile_replay_window(
+    group: ProfileTradeGroup,
+    *,
+    lead_time_seconds: float,
+    start_buffer_seconds: float,
+    end_buffer_seconds: float,
+) -> tuple[pd.Timestamp, pd.Timestamp]:
+    first_trade = min(trade.timestamp for trade in group.trades)
+    last_trade = max(trade.timestamp for trade in group.trades)
+
+    market_start: pd.Timestamp | None = None
+    market_end: pd.Timestamp | None = None
+    match = _BTC_UPDOWN_SLUG_RE.match(group.slug)
+    if match is not None:
+        market_start = pd.Timestamp(int(match.group("start")), unit="s", tz="UTC")
+        market_end = market_start + pd.Timedelta(minutes=int(match.group("minutes")))
+
+    start_anchor = min(first_trade, market_start) if market_start is not None else first_trade
+    end_anchor = max(last_trade, market_end) if market_end is not None else last_trade
+    return (
+        start_anchor
+        - pd.Timedelta(seconds=float(start_buffer_seconds) + max(float(lead_time_seconds), 0.0)),
+        end_anchor + pd.Timedelta(seconds=float(end_buffer_seconds)),
+    )
+
+
+def profile_trades_by_key(
+    groups: Sequence[ProfileTradeGroup],
+) -> dict[str, list[dict[str, object]]]:
+    return {
+        group.key: [
+            {
+                "side": trade.side,
+                "size": float(trade.size),
+                "price": float(trade.price),
+                "timestamp_ns": trade.timestamp_ns,
+                "transaction_hash": trade.transaction_hash,
+            }
+            for trade in group.trades
+        ]
+        for group in groups
+    }
+
+
+def build_profile_replays(
+    groups: Sequence[ProfileTradeGroup],
+    *,
+    profile_user: str,
+    lead_time_seconds: float,
+    start_buffer_seconds: float = 120.0,
+    end_buffer_seconds: float = 1800.0,
+) -> tuple[BookReplay, ...]:
+    replays: list[BookReplay] = []
+    for group in groups:
+        start_time, end_time = infer_profile_replay_window(
+            group,
+            lead_time_seconds=lead_time_seconds,
+            start_buffer_seconds=start_buffer_seconds,
+            end_buffer_seconds=end_buffer_seconds,
+        )
+        replays.append(
+            BookReplay(
+                market_slug=group.slug,
+                token_index=group.outcome_index,
+                start_time=start_time,
+                end_time=end_time,
+                metadata={
+                    "sim_label": group.key,
+                    "profile_replay_key": group.key,
+                    "profile_user": profile_user,
+                    "profile_trade_count": len(group.trades),
+                    "profile_outcome": group.outcome,
+                },
+            )
+        )
+    return tuple(replays)
+
+
+def profile_actual_pnl(
+    trades: Sequence[ProfileTrade],
+    *,
+    realized_outcome: float | int | None,
+) -> dict[str, float | None]:
+    cashflow = Decimal("0")
+    inventory = Decimal("0")
+    buy_quantity = Decimal("0")
+    sell_quantity = Decimal("0")
+    for trade in sorted(trades, key=lambda item: item.timestamp_ns):
+        notional = trade.price * trade.size
+        if trade.side == "BUY":
+            cashflow -= notional
+            inventory += trade.size
+            buy_quantity += trade.size
+        else:
+            cashflow += notional
+            inventory -= trade.size
+            sell_quantity += trade.size
+
+    settlement_value: Decimal | None = None
+    pnl: Decimal | None = None
+    if realized_outcome is not None:
+        settlement_value = inventory * Decimal(str(realized_outcome))
+        pnl = cashflow + settlement_value
+
+    return {
+        "profile_trade_cashflow": float(cashflow),
+        "profile_open_quantity": float(inventory),
+        "profile_buy_quantity": float(buy_quantity),
+        "profile_sell_quantity": float(sell_quantity),
+        "profile_settlement_value": float(settlement_value)
+        if settlement_value is not None
+        else None,
+        "profile_actual_pnl": float(pnl) if pnl is not None else None,
+    }
+
+
+def append_profile_replay_diagnostics(
+    results: Sequence[Mapping[str, object]],
+    groups: Sequence[ProfileTradeGroup],
+) -> list[dict[str, object]]:
+    groups_by_key = {group.key: group for group in groups}
+    enriched: list[dict[str, object]] = []
+    for result in results:
+        row = dict(result)
+        key = str(row.get("profile_replay_key") or row.get("sim_label") or "")
+        group = groups_by_key.get(key)
+        if group is None:
+            enriched.append(row)
+            continue
+        actual = profile_actual_pnl(
+            group.trades,
+            realized_outcome=row.get("realized_outcome"),  # type: ignore[arg-type]
+        )
+        row.update(actual)
+        if actual["profile_actual_pnl"] is not None:
+            row["profile_pnl_error"] = float(row.get("pnl") or 0.0) - float(
+                actual["profile_actual_pnl"] or 0.0
+            )
+        enriched.append(row)
+    return enriched
+
+
+__all__ = [
+    "DEFAULT_PROFILE_REPLAY_PREFIXES",
+    "POLYMARKET_PROFILE_TRADES_URL",
+    "PROFILE_REPLAY_USER_AGENT",
+    "ProfileTrade",
+    "ProfileTradeGroup",
+    "append_profile_replay_diagnostics",
+    "build_profile_replays",
+    "fetch_profile_trades",
+    "infer_profile_replay_window",
+    "normalize_profile_trade",
+    "normalize_profile_trades",
+    "profile_actual_pnl",
+    "profile_replay_key",
+    "profile_trades_by_key",
+    "select_profile_trade_groups",
+]

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -14,6 +14,7 @@ This package contains reusable, venue-agnostic strategy classes for prediction m
 ## Modules
 
 - `core.py`: shared single-instrument long-only lifecycle and order plumbing.
+- `buy_sell_random.py`: deterministic-random three-day buy/sell cadence.
 - `mean_reversion.py`: rolling-average spread capture.
 - `microprice_imbalance.py`: L2 spread, depth-imbalance, and microprice pressure.
 - `ema_crossover.py`: trend-following crossover.

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -25,6 +25,10 @@ from strategies.breakout import (
     BookBreakoutConfig,
     BookBreakoutStrategy,
 )
+from strategies.buy_sell_random import (
+    BookBuySellRandomConfig,
+    BookBuySellRandomStrategy,
+)
 from strategies.binary_pair_arbitrage import (
     BookBinaryPairArbitrageConfig,
     BookBinaryPairArbitrageStrategy,
@@ -107,6 +111,8 @@ __all__ = [
     "BookBinaryPairArbitrageStrategy",
     "BookBreakoutConfig",
     "BookBreakoutStrategy",
+    "BookBuySellRandomConfig",
+    "BookBuySellRandomStrategy",
     "BookDeepValueHoldConfig",
     "BookDeepValueHoldStrategy",
     "BookEMACrossoverConfig",

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -67,6 +67,10 @@ from strategies.panic_fade import (
     BookPanicFadeConfig,
     BookPanicFadeStrategy,
 )
+from strategies.profile_replay import (
+    BookProfileReplayConfig,
+    BookProfileReplayStrategy,
+)
 from strategies.rsi_reversion import (
     BarRSIReversionConfig,
     BarRSIReversionStrategy,
@@ -119,6 +123,8 @@ __all__ = [
     "BookMicropriceImbalanceStrategy",
     "BookPanicFadeConfig",
     "BookPanicFadeStrategy",
+    "BookProfileReplayConfig",
+    "BookProfileReplayStrategy",
     "BookRSIReversionConfig",
     "BookRSIReversionStrategy",
     "BookThresholdMomentumConfig",

--- a/strategies/binary_pair_arbitrage.py
+++ b/strategies/binary_pair_arbitrage.py
@@ -279,6 +279,11 @@ class BookBinaryPairArbitrageStrategy(Strategy):
             return
         avg_price_decimals = [Decimal(str(avg_prices[i])) for i in range(2)]
 
+        if any(
+            float(avg_price) > float(self.config.max_leg_price) for avg_price in avg_price_decimals
+        ):
+            return
+
         expected_slippages = [float(avg_price_decimals[i] - asks[i]) for i in range(2)]
         if any(
             slippage > float(self.config.max_expected_slippage) for slippage in expected_slippages
@@ -357,6 +362,8 @@ class BookBinaryPairArbitrageStrategy(Strategy):
                 self.submit_order(order)
         except Exception:
             self._pending_by_pair[pair] = 0
+            self._entries_by_pair[pair] = max(0, self._entries_by_pair.get(pair, 0) - 1)
+            self._cooldown_by_pair[pair] = 0
             raise
 
     def _event_order_is_closed(self, event) -> bool:  # type: ignore[no-untyped-def]
@@ -382,20 +389,34 @@ class BookBinaryPairArbitrageStrategy(Strategy):
         if self._event_order_is_closed(event):
             self._pending_by_pair[pair] = max(0, self._pending_by_pair.get(pair, 0) - 1)
 
+    def _rollback_empty_failed_pair_entry(self, event) -> None:  # type: ignore[no-untyped-def]
+        instrument_id = getattr(event, "instrument_id", None)
+        pair = self._pair_by_instrument.get(instrument_id)
+        if pair is None:
+            return
+        if self._pending_by_pair.get(pair, 0) > 0 or self._pair_has_position(pair):
+            return
+        self._entries_by_pair[pair] = max(0, self._entries_by_pair.get(pair, 0) - 1)
+        self._cooldown_by_pair[pair] = 0
+
     def on_order_filled(self, event) -> None:  # type: ignore[no-untyped-def]
         self._mark_order_event(event)
 
     def on_order_rejected(self, event) -> None:  # type: ignore[no-untyped-def]
         self._mark_order_event(event)
+        self._rollback_empty_failed_pair_entry(event)
 
     def on_order_denied(self, event) -> None:  # type: ignore[no-untyped-def]
         self._mark_order_event(event)
+        self._rollback_empty_failed_pair_entry(event)
 
     def on_order_canceled(self, event) -> None:  # type: ignore[no-untyped-def]
         self._mark_order_event(event)
+        self._rollback_empty_failed_pair_entry(event)
 
     def on_order_expired(self, event) -> None:  # type: ignore[no-untyped-def]
         self._mark_order_event(event)
+        self._rollback_empty_failed_pair_entry(event)
 
     def on_stop(self) -> None:
         for instrument_id in self.config.instrument_ids:

--- a/strategies/buy_sell_random.py
+++ b/strategies/buy_sell_random.py
@@ -1,0 +1,216 @@
+# Derived from NautilusTrader prediction-market example code.
+# Distributed under the GNU Lesser General Public License Version 3.0 or later.
+# Added in this repository on 2026-04-28.
+# See the repository NOTICE file for provenance and licensing scope.
+
+from __future__ import annotations
+
+import random
+from decimal import Decimal
+
+from nautilus_trader.model.book import OrderBook
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.trading.strategy import StrategyConfig
+
+from strategies._validation import (
+    require_finite_nonnegative_float,
+    require_nonnegative_int,
+    require_positive_decimal,
+    require_probability,
+)
+from strategies.core import LongOnlyPredictionMarketStrategy
+
+_NANOSECONDS_PER_SECOND = 1_000_000_000
+_DEFAULT_THREE_DAY_INTERVAL_SECONDS = 3.0 * 24.0 * 60.0 * 60.0
+
+
+class BookBuySellRandomConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]
+    instrument_id: InstrumentId
+    trade_size: Decimal = Decimal(5)
+    interval_seconds: float = _DEFAULT_THREE_DAY_INTERVAL_SECONDS
+    random_seed: int = 7
+    max_entry_price: float = 1.0
+    max_spread: float = 1.0
+    min_visible_size: float = 0.0
+
+    def __post_init__(self) -> None:
+        require_positive_decimal("trade_size", self.trade_size)
+        require_finite_nonnegative_float("interval_seconds", self.interval_seconds)
+        if self.interval_seconds <= 0.0:
+            raise ValueError(f"interval_seconds must be > 0, got {self.interval_seconds}")
+        require_nonnegative_int("random_seed", self.random_seed)
+        require_probability("max_entry_price", self.max_entry_price)
+        require_probability("max_spread", self.max_spread)
+        require_finite_nonnegative_float("min_visible_size", self.min_visible_size)
+
+
+def _as_float(value: object | None) -> float | None:
+    if value is None:
+        return None
+    if callable(value):
+        value = value()
+    as_double = getattr(value, "as_double", None)
+    if callable(as_double):
+        return float(as_double())
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: object | None) -> int | None:
+    if value is None:
+        return None
+    if callable(value):
+        value = value()
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+class BookBuySellRandomStrategy(LongOnlyPredictionMarketStrategy):
+    """
+    Alternate random buy and sell attempts on a fixed three-day cadence.
+
+    Each flat period schedules one random buy timestamp inside the next
+    interval. After a buy fills, each long period schedules one random sell
+    timestamp inside the next interval. The RNG is seeded for reproducible
+    backtests.
+    """
+
+    def __init__(self, config: BookBuySellRandomConfig) -> None:
+        super().__init__(config)
+        self._rng = random.Random(int(config.random_seed))
+        self._interval_ns = max(
+            1,
+            int(float(config.interval_seconds) * _NANOSECONDS_PER_SECOND),
+        )
+        self._buy_window_start_ns: int | None = None
+        self._next_buy_ns: int | None = None
+        self._sell_window_start_ns: int | None = None
+        self._next_sell_ns: int | None = None
+
+    def _subscribe(self) -> None:
+        self.subscribe_order_book_deltas(
+            instrument_id=self.config.instrument_id,
+            book_type=BookType.L2_MBP,
+        )
+
+    def _random_offset_ns(self) -> int:
+        return self._rng.randrange(self._interval_ns + 1)
+
+    def _schedule_buy_from(self, window_start_ns: int) -> None:
+        self._buy_window_start_ns = int(window_start_ns)
+        self._next_buy_ns = self._buy_window_start_ns + self._random_offset_ns()
+
+    def _schedule_sell_from(self, window_start_ns: int) -> None:
+        self._sell_window_start_ns = int(window_start_ns)
+        self._next_sell_ns = self._sell_window_start_ns + self._random_offset_ns()
+
+    def _advance_buy_window_after_attempt(self, current_ts_ns: int) -> None:
+        if self._buy_window_start_ns is None:
+            next_start = current_ts_ns + self._interval_ns
+        else:
+            next_start = self._buy_window_start_ns + self._interval_ns
+            while next_start <= current_ts_ns:
+                next_start += self._interval_ns
+        self._schedule_buy_from(next_start)
+
+    def _advance_sell_window_after_attempt(self, current_ts_ns: int) -> None:
+        if self._sell_window_start_ns is None:
+            next_start = current_ts_ns + self._interval_ns
+        else:
+            next_start = self._sell_window_start_ns + self._interval_ns
+            while next_start <= current_ts_ns:
+                next_start += self._interval_ns
+        self._schedule_sell_from(next_start)
+
+    def on_order_book(self, order_book: OrderBook) -> None:
+        bid = _as_float(order_book.best_bid_price())
+        ask = _as_float(order_book.best_ask_price())
+        bid_size = _as_float(order_book.best_bid_size())
+        ask_size = _as_float(order_book.best_ask_size())
+        current_ts_ns = _as_int(getattr(order_book, "ts_event", None)) or _as_int(
+            getattr(order_book, "ts_last", None)
+        )
+        if (
+            bid is None
+            or ask is None
+            or bid_size is None
+            or ask_size is None
+            or current_ts_ns is None
+        ):
+            return
+        self._on_book_signal(
+            bid=bid,
+            ask=ask,
+            bid_size=bid_size,
+            ask_size=ask_size,
+            current_ts_ns=current_ts_ns,
+        )
+
+    def _on_book_signal(
+        self,
+        *,
+        bid: float,
+        ask: float,
+        bid_size: float,
+        ask_size: float,
+        current_ts_ns: int,
+    ) -> None:
+        if ask <= bid:
+            return
+        spread = ask - bid
+        if spread > float(self.config.max_spread):
+            return
+        if ask_size < float(self.config.min_visible_size) or bid_size <= 0.0:
+            return
+
+        self._remember_market_context(
+            entry_reference_price=ask,
+            entry_visible_size=ask_size,
+            exit_visible_size=bid_size,
+        )
+        if self._pending:
+            return
+
+        if not self._in_position():
+            self._next_sell_ns = None
+            self._sell_window_start_ns = None
+            if self._next_buy_ns is None:
+                self._schedule_buy_from(current_ts_ns)
+            if current_ts_ns < int(self._next_buy_ns):
+                return
+            if ask > float(self.config.max_entry_price):
+                self._advance_buy_window_after_attempt(current_ts_ns)
+                return
+            self._advance_buy_window_after_attempt(current_ts_ns)
+            self._submit_entry(reference_price=ask, visible_size=ask_size)
+            return
+
+        self._next_buy_ns = None
+        self._buy_window_start_ns = None
+        if self._next_sell_ns is None:
+            self._schedule_sell_from(current_ts_ns)
+        if current_ts_ns < int(self._next_sell_ns):
+            return
+        self._advance_sell_window_after_attempt(current_ts_ns)
+        self._submit_exit()
+
+    def on_order_filled(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().on_order_filled(event)
+        self._next_buy_ns = None
+        self._buy_window_start_ns = None
+        self._next_sell_ns = None
+        self._sell_window_start_ns = None
+
+    def on_reset(self) -> None:
+        super().on_reset()
+        self._rng = random.Random(int(self.config.random_seed))
+        self._buy_window_start_ns = None
+        self._next_buy_ns = None
+        self._sell_window_start_ns = None
+        self._next_sell_ns = None

--- a/strategies/profile_replay.py
+++ b/strategies/profile_replay.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from nautilus_trader.model.book import OrderBook
+from nautilus_trader.model.enums import BookType, OrderSide, TimeInForce
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.trading.strategy import Strategy
+from nautilus_trader.trading.strategy import StrategyConfig
+
+from prediction_market_extensions.adapters.prediction_market.order_tags import (
+    format_order_intent_tag,
+)
+
+
+@dataclass(frozen=True)
+class _ScheduledProfileOrder:
+    side: OrderSide
+    size: float
+    price: float
+    timestamp_ns: int
+    scheduled_time_ns: int
+    transaction_hash: str
+
+
+class BookProfileReplayConfig(StrategyConfig, frozen=True):  # type: ignore[call-arg]
+    instrument_id: InstrumentId
+    selection_key: str
+    trades_by_key: Mapping[str, Sequence[Mapping[str, Any]]]
+    lead_time_seconds: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not str(self.selection_key).strip():
+            raise ValueError("selection_key is required")
+        if not isinstance(self.trades_by_key, Mapping) or not self.trades_by_key:
+            raise ValueError("trades_by_key must contain at least one scheduled trade group")
+        if float(self.lead_time_seconds) < 0.0:
+            raise ValueError("lead_time_seconds must be >= 0")
+
+
+def _payload_float(payload: Mapping[str, Any], field: str) -> float:
+    value = float(payload[field])
+    if value <= 0.0:
+        raise ValueError(f"scheduled profile trade {field} must be positive, got {value}")
+    return value
+
+
+def _payload_timestamp_ns(payload: Mapping[str, Any]) -> int:
+    if "timestamp_ns" in payload:
+        timestamp_ns = int(payload["timestamp_ns"])
+    else:
+        timestamp_ns = int(float(payload["timestamp"]) * 1_000_000_000)
+    if timestamp_ns <= 0:
+        raise ValueError(f"scheduled profile trade timestamp must be positive, got {timestamp_ns}")
+    return timestamp_ns
+
+
+def _decimal_or_none(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _scheduled_orders_from_config(
+    config: BookProfileReplayConfig,
+) -> tuple[_ScheduledProfileOrder, ...]:
+    raw_trades = config.trades_by_key.get(str(config.selection_key))
+    if raw_trades is None:
+        raise ValueError(f"selection_key {config.selection_key!r} not found in trades_by_key")
+
+    lead_time_ns = int(float(config.lead_time_seconds) * 1_000_000_000)
+    scheduled: list[_ScheduledProfileOrder] = []
+    for payload in raw_trades:
+        raw_side = str(payload.get("side") or "").strip().upper()
+        if raw_side == "BUY":
+            side = OrderSide.BUY
+        elif raw_side == "SELL":
+            side = OrderSide.SELL
+        else:
+            raise ValueError(f"scheduled profile trade side must be BUY or SELL, got {raw_side!r}")
+        timestamp_ns = _payload_timestamp_ns(payload)
+        price = _payload_float(payload, "price")
+        if price > 1.0:
+            raise ValueError(f"scheduled profile trade price must be <= 1, got {price}")
+        scheduled.append(
+            _ScheduledProfileOrder(
+                side=side,
+                size=_payload_float(payload, "size"),
+                price=price,
+                timestamp_ns=timestamp_ns,
+                scheduled_time_ns=max(0, timestamp_ns - lead_time_ns),
+                transaction_hash=str(payload.get("transaction_hash") or ""),
+            )
+        )
+
+    scheduled.sort(
+        key=lambda trade: (
+            trade.scheduled_time_ns,
+            trade.timestamp_ns,
+            trade.transaction_hash,
+        )
+    )
+    return tuple(scheduled)
+
+
+class BookProfileReplayStrategy(Strategy):
+    """
+    Submit IOC limit orders just before a known public profile trade occurs.
+
+    This is an audit/validation strategy, not alpha. It lets us compare whether
+    the book replay and fill model can reproduce an already observed wallet's
+    execution when we submit the same side, price, and size slightly earlier.
+    """
+
+    def __init__(self, config: BookProfileReplayConfig) -> None:
+        super().__init__(config)
+        self._instrument = None
+        self._order_book: OrderBook | None = None
+        self._scheduled_orders = _scheduled_orders_from_config(config)
+        self._next_order_index = 0
+
+    def on_start(self) -> None:
+        self._instrument = self.cache.instrument(self.config.instrument_id)
+        if self._instrument is None:
+            self.log.error(f"Instrument {self.config.instrument_id} not found - stopping.")
+            self.stop()
+            return
+        self.subscribe_order_book_deltas(
+            instrument_id=self.config.instrument_id,
+            book_type=BookType.L2_MBP,
+        )
+
+    def on_order_book_deltas(self, deltas) -> None:  # type: ignore[no-untyped-def]
+        instrument_id = getattr(deltas, "instrument_id", self.config.instrument_id)
+        if self._order_book is None:
+            self._order_book = OrderBook(instrument_id, book_type=BookType.L2_MBP)
+        self._order_book.apply_deltas(deltas)
+        self.on_order_book(self._order_book)
+
+    def on_order_book(self, order_book) -> None:  # type: ignore[no-untyped-def]
+        self._submit_due_orders(ts_event_ns=int(order_book.ts_event))
+
+    def _submit_due_orders(self, *, ts_event_ns: int) -> None:
+        while self._next_order_index < len(self._scheduled_orders):
+            scheduled_order = self._scheduled_orders[self._next_order_index]
+            if scheduled_order.scheduled_time_ns > ts_event_ns:
+                return
+            self._next_order_index += 1
+            self._submit_scheduled_order(scheduled_order)
+
+    def _sell_quantity_cap(self) -> float:
+        try:
+            net_position = self.portfolio.net_position(self.config.instrument_id)
+        except (AttributeError, KeyError, TypeError):
+            return 0.0
+
+        position_size = _decimal_or_none(net_position)
+        if position_size is None and hasattr(net_position, "signed_decimal_qty"):
+            try:
+                position_size = _decimal_or_none(net_position.signed_decimal_qty())
+            except TypeError:
+                position_size = _decimal_or_none(getattr(net_position, "signed_decimal_qty", None))
+        if position_size is None and hasattr(net_position, "signed_qty"):
+            position_size = _decimal_or_none(getattr(net_position, "signed_qty", None))
+        if position_size is None:
+            return 0.0
+        return float(max(position_size, Decimal("0")))
+
+    def _submit_scheduled_order(self, scheduled_order: _ScheduledProfileOrder) -> None:
+        assert self._instrument is not None
+        requested_size = scheduled_order.size
+        if scheduled_order.side == OrderSide.SELL:
+            requested_size = min(requested_size, self._sell_quantity_cap())
+            if requested_size <= 0.0:
+                self.log.warning(
+                    "Skipping scheduled profile SELL for "
+                    f"{self.config.instrument_id}: no simulated inventory is available."
+                )
+                return
+
+        try:
+            quantity = self._instrument.make_qty(requested_size, round_down=True)
+            price = self._instrument.make_price(scheduled_order.price)
+        except ValueError as exc:
+            self.log.warning(
+                "Skipping scheduled profile order for "
+                f"{self.config.instrument_id}: instrument rejected size/price ({exc})."
+            )
+            return
+        if quantity.as_double() <= 0.0:
+            return
+
+        order = self.order_factory.limit(
+            instrument_id=self.config.instrument_id,
+            order_side=scheduled_order.side,
+            quantity=quantity,
+            price=price,
+            time_in_force=TimeInForce.IOC,
+            reduce_only=scheduled_order.side == OrderSide.SELL,
+            tags=[format_order_intent_tag("profile_replay")],
+        )
+        self.submit_order(order)
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+
+    def on_reset(self) -> None:
+        self._instrument = None
+        self._order_book = None
+        self._scheduled_orders = _scheduled_orders_from_config(self.config)
+        self._next_order_index = 0
+
+
+__all__ = [
+    "BookProfileReplayConfig",
+    "BookProfileReplayStrategy",
+]

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -32,6 +32,7 @@ EXPECTED_PUBLIC_RUNNER_PATHS = [
     Path("backtests/generic_optimizer_research.ipynb"),
     Path("backtests/generic_tpe_research.ipynb"),
     Path("backtests/pmxt_book_joint_portfolio_runner.ipynb"),
+    Path("backtests/polymarket_book_buy_sell_random.py"),
     Path("backtests/polymarket_book_ema_crossover.py"),
     Path("backtests/polymarket_book_ema_optimizer.py"),
     Path("backtests/polymarket_book_joint_portfolio_runner.py"),
@@ -42,7 +43,10 @@ EXPECTED_PUBLIC_RUNNER_PATHS = [
     Path("backtests/telonex_book_joint_portfolio_runner.ipynb"),
 ]
 
-PMXT_SINGLE_MARKET_BOOK_RUNNERS = [Path("backtests/polymarket_book_ema_crossover.py")]
+PMXT_SINGLE_MARKET_BOOK_RUNNERS = [
+    Path("backtests/polymarket_book_buy_sell_random.py"),
+    Path("backtests/polymarket_book_ema_crossover.py"),
+]
 PMXT_JOINT_BOOK_RUNNERS = [Path("backtests/polymarket_book_joint_portfolio_runner.py")]
 TELONEX_JOINT_BOOK_RUNNERS = [Path("backtests/polymarket_telonex_book_joint_portfolio_runner.py")]
 PMXT_BOOK_OPTIMIZER_RUNNERS = [Path("backtests/polymarket_book_ema_optimizer.py")]
@@ -242,6 +246,41 @@ def test_pmxt_single_market_book_runners_build_inline_experiment(
     assert experiment.replays[0].end_time
     assert experiment.initial_cash == 100.0
     assert experiment.min_price_range == 0.005
+
+
+def test_buy_sell_random_runner_builds_pmxt_book_experiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experiment = _capture_script_experiment(
+        monkeypatch, Path("backtests/polymarket_book_buy_sell_random.py")
+    )
+
+    assert experiment.name == "polymarket_book_buy_sell_random"
+    assert experiment.data.platform == "polymarket"
+    assert experiment.data.data_type == "book"
+    assert experiment.data.vendor == "pmxt"
+    assert experiment.data.sources == (
+        "local:/Volumes/LaCie/pmxt_data",
+        "archive:r2v2.pmxt.dev",
+        "archive:r2.pmxt.dev",
+    )
+    assert len(experiment.replays) == 1
+    assert experiment.replays[0].market_slug == "human-moon-landing-in-2026"
+    assert experiment.replays[0].token_index == 0
+    assert experiment.strategy_configs[0]["strategy_path"] == (
+        "strategies:BookBuySellRandomStrategy"
+    )
+    assert experiment.strategy_configs[0]["config_path"] == ("strategies:BookBuySellRandomConfig")
+    assert experiment.strategy_configs[0]["config"]["trade_size"] == Decimal("5")
+    assert experiment.strategy_configs[0]["config"]["interval_seconds"] == (
+        3.0 * 24.0 * 60.0 * 60.0
+    )
+    assert experiment.strategy_configs[0]["config"]["random_seed"] == 7
+    assert experiment.report.summary_report is True
+    assert (
+        experiment.report.summary_report_path
+        == "output/polymarket_book_buy_sell_random_summary.html"
+    )
 
 
 @pytest.mark.parametrize("relative_path", PMXT_JOINT_BOOK_RUNNERS)

--- a/tests/test_backtest_script_entrypoints.py
+++ b/tests/test_backtest_script_entrypoints.py
@@ -37,6 +37,7 @@ EXPECTED_PUBLIC_RUNNER_PATHS = [
     Path("backtests/polymarket_book_joint_portfolio_runner.py"),
     Path("backtests/polymarket_btc_5m_late_favorite_taker_hold.py"),
     Path("backtests/polymarket_btc_5m_pair_arbitrage.py"),
+    Path("backtests/polymarket_profile_replay_verification.py"),
     Path("backtests/polymarket_telonex_book_joint_portfolio_runner.py"),
     Path("backtests/telonex_book_joint_portfolio_runner.ipynb"),
 ]
@@ -45,6 +46,7 @@ PMXT_SINGLE_MARKET_BOOK_RUNNERS = [Path("backtests/polymarket_book_ema_crossover
 PMXT_JOINT_BOOK_RUNNERS = [Path("backtests/polymarket_book_joint_portfolio_runner.py")]
 TELONEX_JOINT_BOOK_RUNNERS = [Path("backtests/polymarket_telonex_book_joint_portfolio_runner.py")]
 PMXT_BOOK_OPTIMIZER_RUNNERS = [Path("backtests/polymarket_book_ema_optimizer.py")]
+PMXT_PROFILE_REPLAY_RUNNERS = [Path("backtests/polymarket_profile_replay_verification.py")]
 
 SCRIPT_ENTRYPOINT_PATHS = [
     Path("scripts/pmxt_download_raws.py"),
@@ -75,6 +77,7 @@ def _capture_script_experiment(monkeypatch: pytest.MonkeyPatch, relative_path: P
     from prediction_market_extensions.backtesting import _experiments
 
     captured: dict[str, object] = {}
+    monkeypatch.setenv("POLYMARKET_PROFILE_REPLAY_SOURCE", "snapshot")
 
     def capture_run_experiment(experiment):  # type: ignore[no-untyped-def]
         captured["experiment"] = experiment
@@ -351,6 +354,42 @@ def test_btc_5m_late_favorite_taker_runner_builds_pmxt_book_replays(
     assert (
         experiment.report.summary_report_path
         == "output/polymarket_btc_5m_late_favorite_taker_hold_summary.html"
+    )
+    assert experiment.return_summary_series is True
+
+
+@pytest.mark.parametrize("relative_path", PMXT_PROFILE_REPLAY_RUNNERS)
+def test_profile_replay_runner_builds_pmxt_book_verification_experiment(
+    monkeypatch: pytest.MonkeyPatch, relative_path: Path
+) -> None:
+    experiment = _capture_script_experiment(monkeypatch, relative_path)
+
+    assert experiment.name == "polymarket_profile_replay_verification"
+    assert experiment.data.platform == "polymarket"
+    assert experiment.data.data_type == "book"
+    assert experiment.data.vendor == "pmxt"
+    assert experiment.data.sources == (
+        "local:/Volumes/LaCie/pmxt_data",
+        "archive:r2v2.pmxt.dev",
+        "archive:r2.pmxt.dev",
+    )
+    assert len(experiment.replays) == 1
+    assert experiment.replays[0].market_slug == "btc-updown-5m-1777241400"
+    assert experiment.replays[0].token_index == 1
+    assert experiment.replays[0].metadata["profile_replay_key"] == ("btc-updown-5m-1777241400:1")
+    assert experiment.strategy_configs[0]["strategy_path"] == (
+        "strategies:BookProfileReplayStrategy"
+    )
+    assert experiment.strategy_configs[0]["config_path"] == "strategies:BookProfileReplayConfig"
+    assert (
+        experiment.strategy_configs[0]["config"]["selection_key"]
+        == "__SIM_METADATA__:profile_replay_key"
+    )
+    assert experiment.strategy_configs[0]["config"]["lead_time_seconds"] == 1.0
+    assert experiment.report.summary_report is True
+    assert (
+        experiment.report.summary_report_path
+        == "output/polymarket_profile_replay_verification_summary.html"
     )
     assert experiment.return_summary_series is True
 

--- a/tests/test_backtest_utils.py
+++ b/tests/test_backtest_utils.py
@@ -45,14 +45,24 @@ def test_compute_binary_settlement_pnl_returns_none_without_fills() -> None:
     assert compute_binary_settlement_pnl([], 1.0) is None
 
 
-def test_compute_binary_settlement_pnl_marks_no_contracts_to_inverse_outcome() -> None:
+def test_compute_binary_settlement_pnl_marks_no_contracts_with_token_level_outcome() -> None:
+    fill_events = [
+        {"action": "buy", "side": "no", "price": 0.30, "quantity": 10, "commission": 0.0}
+    ]
+
+    pnl = compute_binary_settlement_pnl(fill_events, 1.0)
+
+    assert pnl == 7.0
+
+
+def test_compute_binary_settlement_pnl_marks_no_contract_loss_with_token_level_outcome() -> None:
     fill_events = [
         {"action": "buy", "side": "no", "price": 0.30, "quantity": 10, "commission": 0.0}
     ]
 
     pnl = compute_binary_settlement_pnl(fill_events, 0.0)
 
-    assert pnl == 7.0
+    assert pnl == -3.0
 
 
 class _QuoteStub:

--- a/tests/test_binary_pair_arbitrage.py
+++ b/tests/test_binary_pair_arbitrage.py
@@ -18,19 +18,18 @@ PAIR = (LEG_ONE, LEG_TWO)
 
 class _PairArbHarness(BookBinaryPairArbitrageStrategy):
     def __init__(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        super().__init__(
-            BookBinaryPairArbitrageConfig(
-                instrument_ids=PAIR,
-                trade_size=Decimal("5"),
-                min_net_edge=0.02,
-                max_total_cost=0.99,
-                max_leg_price=0.99,
-                max_spread=0.05,
-                max_expected_slippage=0.02,
-                min_visible_size=1.0,
-                **kwargs,
-            )
-        )
+        config = {
+            "instrument_ids": PAIR,
+            "trade_size": Decimal("5"),
+            "min_net_edge": 0.02,
+            "max_total_cost": 0.99,
+            "max_leg_price": 0.99,
+            "max_spread": 0.05,
+            "max_expected_slippage": 0.02,
+            "min_visible_size": 1.0,
+        }
+        config.update(kwargs)
+        super().__init__(BookBinaryPairArbitrageConfig(**config))
         self.states = {
             LEG_ONE: (0.45, 10.0, 0.01),
             LEG_TWO: (0.52, 10.0, 0.01),
@@ -38,6 +37,7 @@ class _PairArbHarness(BookBinaryPairArbitrageStrategy):
         self.avg_prices = {LEG_ONE: 0.45, LEG_TWO: 0.52}
         self.fee_rates = {LEG_ONE: Decimal("0"), LEG_TWO: Decimal("0")}
         self.submissions: list[dict[str, object]] = []
+        self.has_position = False
 
     def _best_ask_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None:
         return self.states.get(instrument_id)
@@ -59,7 +59,7 @@ class _PairArbHarness(BookBinaryPairArbitrageStrategy):
 
     def _pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool:
         _ = pair
-        return False
+        return self.has_position
 
     def _submit_pair_entry(
         self,
@@ -100,3 +100,46 @@ def test_pair_arbitrage_rejects_entries_without_required_edge() -> None:
     strategy._evaluate_pair(PAIR)
 
     assert strategy.submissions == []
+
+
+def test_pair_arbitrage_rejects_average_fill_above_leg_cap() -> None:
+    strategy = _PairArbHarness(max_leg_price=0.53, max_expected_slippage=0.10)
+    strategy.states[LEG_TWO] = (0.52, 10.0, 0.01)
+    strategy.avg_prices[LEG_TWO] = 0.54
+
+    strategy._evaluate_pair(PAIR)
+
+    assert strategy.submissions == []
+
+
+def test_pair_arbitrage_denied_orders_do_not_consume_entry_quota() -> None:
+    strategy = _PairArbHarness(max_entries_per_pair=1, reentry_cooldown_updates=10)
+    strategy._pair_by_instrument = {LEG_ONE: PAIR, LEG_TWO: PAIR}
+    strategy._pending_by_pair = {PAIR: 2}
+    strategy._entries_by_pair = {PAIR: 1}
+    strategy._cooldown_by_pair = {PAIR: 10}
+
+    strategy.on_order_denied(SimpleNamespace(instrument_id=LEG_ONE))
+    assert strategy._entries_by_pair[PAIR] == 1
+    assert strategy._cooldown_by_pair[PAIR] == 10
+
+    strategy.on_order_denied(SimpleNamespace(instrument_id=LEG_TWO))
+
+    assert strategy._pending_by_pair[PAIR] == 0
+    assert strategy._entries_by_pair[PAIR] == 0
+    assert strategy._cooldown_by_pair[PAIR] == 0
+
+
+def test_pair_arbitrage_one_leg_fill_keeps_entry_quota_consumed() -> None:
+    strategy = _PairArbHarness(max_entries_per_pair=1, reentry_cooldown_updates=10)
+    strategy._pair_by_instrument = {LEG_ONE: PAIR, LEG_TWO: PAIR}
+    strategy._pending_by_pair = {PAIR: 1}
+    strategy._entries_by_pair = {PAIR: 1}
+    strategy._cooldown_by_pair = {PAIR: 10}
+    strategy.has_position = True
+
+    strategy.on_order_denied(SimpleNamespace(instrument_id=LEG_TWO))
+
+    assert strategy._pending_by_pair[PAIR] == 0
+    assert strategy._entries_by_pair[PAIR] == 1
+    assert strategy._cooldown_by_pair[PAIR] == 10

--- a/tests/test_book_strategy_configs.py
+++ b/tests/test_book_strategy_configs.py
@@ -10,6 +10,7 @@ from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
 from strategies import (
     BookBreakoutConfig,
+    BookBuySellRandomConfig,
     BookDeepValueHoldConfig,
     BookEMACrossoverConfig,
     BookFinalPeriodMomentumConfig,
@@ -29,6 +30,7 @@ INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
     "config_cls",
     [
         BookBreakoutConfig,
+        BookBuySellRandomConfig,
         BookDeepValueHoldConfig,
         BookEMACrossoverConfig,
         BookFinalPeriodMomentumConfig,

--- a/tests/test_buy_sell_random_strategy.py
+++ b/tests/test_buy_sell_random_strategy.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
+
+from strategies import BookBuySellRandomConfig, BookBuySellRandomStrategy
+
+INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
+
+
+class _ImmediateRandomHarness(BookBuySellRandomStrategy):
+    def __init__(self, config: BookBuySellRandomConfig) -> None:
+        super().__init__(config)
+        self.entries = 0
+        self.exits = 0
+        self.entry_contexts: list[tuple[float | None, float | None]] = []
+        self._position = False
+
+    def _random_offset_ns(self) -> int:
+        return 0
+
+    def _in_position(self) -> bool:
+        return self._position
+
+    def _submit_entry(
+        self, *, reference_price: float | None = None, visible_size: float | None = None
+    ) -> None:
+        self.entries += 1
+        self.entry_contexts.append((reference_price, visible_size))
+        self._pending = True
+
+    def _submit_exit(self) -> None:
+        self.exits += 1
+        self._pending = True
+
+    def fill_entry(self, price: float, qty: float = 1.0) -> None:
+        self._position = True
+        self.on_order_filled(SimpleNamespace(order_side=OrderSide.BUY, last_px=price, last_qty=qty))
+
+    def fill_exit(self, price: float, qty: float = 1.0) -> None:
+        self._position = False
+        self.on_order_filled(
+            SimpleNamespace(order_side=OrderSide.SELL, last_px=price, last_qty=qty)
+        )
+
+
+def test_buy_sell_random_alternates_buy_then_sell_on_random_schedule() -> None:
+    strategy = _ImmediateRandomHarness(
+        BookBuySellRandomConfig(
+            instrument_id=INSTRUMENT_ID,
+            trade_size=Decimal(1),
+            interval_seconds=3.0,
+            random_seed=1,
+        )
+    )
+
+    strategy._on_book_signal(
+        bid=0.40,
+        ask=0.42,
+        bid_size=10.0,
+        ask_size=11.0,
+        current_ts_ns=1_000_000_000,
+    )
+    assert strategy.entries == 1
+    assert strategy.exits == 0
+    assert strategy.entry_contexts == [(0.42, 11.0)]
+
+    strategy.fill_entry(0.42)
+    strategy._on_book_signal(
+        bid=0.43,
+        ask=0.45,
+        bid_size=9.0,
+        ask_size=10.0,
+        current_ts_ns=2_000_000_000,
+    )
+
+    assert strategy.entries == 1
+    assert strategy.exits == 1
+
+
+def test_buy_sell_random_waits_for_next_interval_after_unfilled_attempt() -> None:
+    strategy = _ImmediateRandomHarness(
+        BookBuySellRandomConfig(
+            instrument_id=INSTRUMENT_ID,
+            trade_size=Decimal(1),
+            interval_seconds=3.0,
+            random_seed=1,
+        )
+    )
+
+    strategy._on_book_signal(
+        bid=0.40,
+        ask=0.42,
+        bid_size=10.0,
+        ask_size=11.0,
+        current_ts_ns=1_000_000_000,
+    )
+    assert strategy.entries == 1
+    strategy.on_order_expired(SimpleNamespace())
+
+    strategy._on_book_signal(
+        bid=0.40,
+        ask=0.42,
+        bid_size=10.0,
+        ask_size=11.0,
+        current_ts_ns=2_000_000_000,
+    )
+    assert strategy.entries == 1
+
+    strategy._on_book_signal(
+        bid=0.40,
+        ask=0.42,
+        bid_size=10.0,
+        ask_size=11.0,
+        current_ts_ns=4_000_000_000,
+    )
+    assert strategy.entries == 2
+
+
+def test_buy_sell_random_respects_entry_price_filter() -> None:
+    strategy = _ImmediateRandomHarness(
+        BookBuySellRandomConfig(
+            instrument_id=INSTRUMENT_ID,
+            trade_size=Decimal(1),
+            interval_seconds=3.0,
+            random_seed=1,
+            max_entry_price=0.50,
+        )
+    )
+
+    strategy._on_book_signal(
+        bid=0.60,
+        ask=0.62,
+        bid_size=10.0,
+        ask_size=11.0,
+        current_ts_ns=1_000_000_000,
+    )
+
+    assert strategy.entries == 0

--- a/tests/test_downsample_html_size.py
+++ b/tests/test_downsample_html_size.py
@@ -129,8 +129,7 @@ class TestDownsample:
 
         eq_ds, _, _, _ = _downsample(eq, fills_df, market_df, max_points=3000)
 
-        # Allow small overshoot from must-keep points (fills, peaks, endpoints)
-        assert len(eq_ds) <= 3100
+        assert len(eq_ds) <= 3000
 
     def test_small_eq_not_touched(self) -> None:
         n = 500
@@ -186,7 +185,7 @@ class TestDownsample:
 
         eq_ds, fills_ds, _, _ = _downsample(eq, fills_df, market_df, max_points=2000)
 
-        assert len(eq_ds) <= 2100
+        assert len(eq_ds) <= 2000
         assert len(fills_ds) == 1
         bar = int(fills_ds.iloc[0]["bar"])
         assert 0 <= bar < len(eq_ds)
@@ -283,6 +282,112 @@ class TestDownsample:
         eq_ds, _, _, _ = _downsample(eq, fills_df, market_df, max_points=2000)
 
         assert 999.0 in eq_ds["equity"].values
+
+    def test_position_count_change_timestamp_preserved(self) -> None:
+        n = 20_000
+        settlement_idx = 12_345
+        datetimes = pd.date_range("2026-01-01", periods=n, freq="s")
+        cash = np.full(n, 100.0)
+        equity = np.full(n, 100.0)
+        num_positions = np.ones(n, dtype=int)
+        cash[settlement_idx:] = 105.0
+        equity[settlement_idx:] = 105.0
+        num_positions[settlement_idx:] = 0
+        eq = pd.DataFrame(
+            {
+                "datetime": datetimes,
+                "cash": cash,
+                "equity": equity,
+                "drawdown_pct": np.zeros(n),
+                "num_positions": num_positions,
+            }
+        )
+        fills_df = pd.DataFrame(
+            columns=[
+                "datetime",
+                "market_id",
+                "action",
+                "side",
+                "price",
+                "quantity",
+                "commission",
+                "bar",
+            ]
+        )
+        market_df = pd.DataFrame(index=eq.index)
+
+        eq_ds, _, _, _ = _downsample(eq, fills_df, market_df, max_points=5000)
+
+        assert len(eq_ds) <= 5000
+        assert datetimes[settlement_idx] in set(eq_ds["datetime"])
+
+    def test_market_price_extrema_preserved(self) -> None:
+        n = 10_007
+        spike_idx = 4_321
+        eq = pd.DataFrame(
+            {
+                "datetime": pd.date_range("2026-01-01", periods=n, freq="s"),
+                "cash": np.full(n, 100.0),
+                "equity": np.full(n, 100.0),
+                "drawdown_pct": np.zeros(n),
+                "num_positions": np.zeros(n, dtype=int),
+            }
+        )
+        fills_df = pd.DataFrame(
+            columns=[
+                "datetime",
+                "market_id",
+                "action",
+                "side",
+                "price",
+                "quantity",
+                "commission",
+                "bar",
+            ]
+        )
+        prices = np.full(n, 0.50)
+        prices[spike_idx] = 0.99
+        market_df = pd.DataFrame({"spiky-market": prices}, index=eq.index)
+
+        _, _, market_ds, _ = _downsample(eq, fills_df, market_df, max_points=1000)
+
+        assert float(market_ds["spiky-market"].max()) == 0.99
+
+    def test_allocation_extrema_preserved(self) -> None:
+        n = 10_007
+        spike_idx = 4_321
+        eq = pd.DataFrame(
+            {
+                "datetime": pd.date_range("2026-01-01", periods=n, freq="s"),
+                "cash": np.full(n, 100.0),
+                "equity": np.full(n, 100.0),
+                "drawdown_pct": np.zeros(n),
+                "num_positions": np.zeros(n, dtype=int),
+            }
+        )
+        fills_df = pd.DataFrame(
+            columns=[
+                "datetime",
+                "market_id",
+                "action",
+                "side",
+                "price",
+                "quantity",
+                "commission",
+                "bar",
+            ]
+        )
+        market_df = pd.DataFrame(index=eq.index)
+        exposure = np.zeros(n)
+        exposure[spike_idx] = 25.0
+        alloc_df = pd.DataFrame(
+            {"market-exposure": exposure, "Cash": np.full(n, 100.0)}, index=eq.index
+        )
+
+        _, _, _, alloc_ds = _downsample(eq, fills_df, market_df, max_points=1000, alloc_df=alloc_df)
+
+        assert alloc_ds is not None
+        assert float(alloc_ds["market-exposure"].max()) == 25.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_execution_slippage.py
+++ b/tests/test_execution_slippage.py
@@ -165,7 +165,7 @@ def test_reduce_only_sell_uses_exit_slippage_even_when_tagged_entry_side() -> No
         _make_order(
             OrderSideEnum.SELL,
             reduce_only=True,
-            tags=[format_order_intent_tag("exit")],
+            tags=[format_order_intent_tag("entry")],
         ),
         best_bid=0.50,
         best_ask=0.50,

--- a/tests/test_info_sanitization.py
+++ b/tests/test_info_sanitization.py
@@ -81,6 +81,37 @@ def test_polymarket_token_winner_is_redacted_in_simulation_info() -> None:
     assert infer_realized_outcome_from_metadata(metadata, "No") == 0.0
 
 
+def test_nested_resolution_fields_are_redacted_in_simulation_info() -> None:
+    market_info = {
+        "condition_id": "0x" + "1" * 64,
+        "events": [
+            {
+                "title": "Nested event",
+                "result": "yes",
+                "settlement_value": 1.0,
+                "tokens": [
+                    {"outcome": "Yes", "winner": True, "token_id": "1"},
+                    {"outcome": "No", "winner": False, "token_id": "2"},
+                ],
+            }
+        ],
+        "nested": {
+            "uma_resolution_status": "resolved",
+            "payload": {"expiration_value": 1.0, "safe": "kept"},
+        },
+    }
+
+    sanitized = sanitize_info_for_simulation(market_info)
+
+    event = sanitized["events"][0]
+    assert "result" not in event
+    assert "settlement_value" not in event
+    assert all("winner" not in token for token in event["tokens"])
+    assert "uma_resolution_status" not in sanitized["nested"]
+    assert "expiration_value" not in sanitized["nested"]["payload"]
+    assert sanitized["nested"]["payload"]["safe"] == "kept"
+
+
 def test_sanitize_does_not_mutate_caller_payload() -> None:
     market = _kalshi_market()
     snapshot = dict(market)

--- a/tests/test_joint_portfolio_artifacts.py
+++ b/tests/test_joint_portfolio_artifacts.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pandas as pd
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
 
 from prediction_market_extensions.adapters.prediction_market import (
     LoadedReplay,
@@ -137,6 +138,18 @@ def test_market_artifacts_are_keyed_by_instrument_id_for_shared_slug(monkeypatch
     }
 
 
+def test_market_artifact_filter_accepts_instrument_id_objects() -> None:
+    instrument_id = InstrumentId(Symbol("PM-A-YES"), Venue("POLYMARKET"))
+    report = pd.DataFrame({"instrument_id": [instrument_id], "last_qty": [5]})
+
+    filtered = PredictionMarketArtifactBuilder._filter_report_rows(
+        report, instrument_id=str(instrument_id)
+    )
+
+    assert len(filtered) == 1
+    assert filtered.iloc[0]["last_qty"] == 5
+
+
 def test_single_summary_dense_prices_are_keyed_by_instrument_id(monkeypatch) -> None:
     start = datetime(2026, 3, 14, 17, 57, tzinfo=UTC)
     price_points = [(start, 0.40), (start + timedelta(minutes=1), 0.50)]
@@ -232,12 +245,22 @@ def test_build_result_marks_open_positions_to_settlement(monkeypatch) -> None:
     )
 
     loaded_sim = _loaded_replay(market_id="market-a", instrument_id="PM-A-YES.POLYMARKET")
-    loaded_sim = loaded_sim.__class__(**{**loaded_sim.__dict__, "realized_outcome": 1.0})
+    loaded_sim = loaded_sim.__class__(
+        **{
+            **loaded_sim.__dict__,
+            "instrument": SimpleNamespace(id=loaded_sim.instrument.id, expiration_ns=1_000),
+            "realized_outcome": 1.0,
+        }
+    )
 
     result = builder.build_result(
         loaded_sim=loaded_sim,
         fills_report=pd.DataFrame({"instrument_id": ["PM-A-YES.POLYMARKET"]}),
         positions_report=pd.DataFrame({"instrument_id": ["PM-A-YES.POLYMARKET"]}),
+        run_state={
+            "simulated_through": "1970-01-01T00:00:00.000001+00:00",
+            "planned_end": "1970-01-01T00:00:00.000001+00:00",
+        },
     )
 
     assert result["market_exit_pnl"] == -1.25

--- a/tests/test_legacy_plot_fill_markers.py
+++ b/tests/test_legacy_plot_fill_markers.py
@@ -174,7 +174,7 @@ def test_allocation_zeroes_settled_position_on_price_feed_final_bar() -> None:
     assert allocation["Cash"].tolist() == pytest.approx([995.25, 1000.25])
 
 
-def test_market_pnl_panel_plots_one_final_marker_per_market(tmp_path) -> None:
+def test_market_pnl_panel_plots_one_final_value_for_each_fill_marker(tmp_path) -> None:
     pytest.importorskip("bokeh")
     from bokeh.models import ColumnDataSource
 
@@ -249,8 +249,11 @@ def test_market_pnl_panel_plots_one_final_marker_per_market(tmp_path) -> None:
     ]
 
     assert len(marker_sources) == 1
-    assert marker_sources[0].data["market_id"].tolist() == ["repeat-market"]
-    assert marker_sources[0].data["pnl_long"].tolist() == pytest.approx([2.0])
+    assert marker_sources[0].data["market_id"].tolist() == [
+        "repeat-market",
+        "repeat-market",
+    ]
+    assert marker_sources[0].data["pnl_long"].tolist() == pytest.approx([2.0, 2.0])
 
 
 def test_dense_adapter_replays_no_token_buy_as_long_token_quantity() -> None:
@@ -959,6 +962,89 @@ def test_market_pnl_panel_uses_resolved_market_pnl_for_fill_markers(tmp_path) ->
     assert pnl_source.data["pnl_long"].tolist() == [4.75]
     assert np.isnan(pnl_source.data["pnl_short"][0])
     assert pnl_source.data["positive"].tolist() == ["1"]
+
+
+def test_market_pnl_panel_keeps_each_fill_marker_when_market_pnl_is_known(tmp_path) -> None:
+    pytest.importorskip("bokeh")
+    from bokeh.models import ColumnDataSource
+
+    start = datetime(2026, 3, 14, 18, tzinfo=UTC)
+    result = BacktestResult(
+        equity_curve=[
+            PortfolioSnapshot(
+                timestamp=start,
+                cash=99.75,
+                total_equity=100.0,
+                unrealized_pnl=0.25,
+                num_positions=1,
+            ),
+            PortfolioSnapshot(
+                timestamp=start.replace(minute=1),
+                cash=99.00,
+                total_equity=100.5,
+                unrealized_pnl=1.5,
+                num_positions=1,
+            ),
+            PortfolioSnapshot(
+                timestamp=start.replace(minute=2),
+                cash=104.75,
+                total_equity=104.75,
+                unrealized_pnl=0.0,
+                num_positions=0,
+            ),
+        ],
+        fills=[
+            Fill(
+                order_id="fill-1",
+                market_id="winning-market",
+                action=OrderAction.BUY,
+                side=Side.YES,
+                price=0.05,
+                quantity=5.0,
+                timestamp=start,
+            ),
+            Fill(
+                order_id="fill-2",
+                market_id="winning-market",
+                action=OrderAction.BUY,
+                side=Side.YES,
+                price=0.10,
+                quantity=5.0,
+                timestamp=start.replace(minute=1),
+            ),
+        ],
+        metrics={},
+        strategy_name="resolved-pnl-marker",
+        platform=Platform.POLYMARKET,
+        start_time=start,
+        end_time=start.replace(minute=2),
+        initial_cash=100.0,
+        final_equity=104.75,
+        num_markets_traded=1,
+        num_markets_resolved=1,
+        market_prices={
+            "winning-market": [
+                (start, 0.05),
+                (start.replace(minute=1), 0.10),
+                (start.replace(minute=2), 1.0),
+            ]
+        },
+        market_pnls={"winning-market": 4.75},
+    )
+
+    layout = plotting.plot(
+        result,
+        filename=str(tmp_path / "resolved_pnl_marker_per_fill.html"),
+        open_browser=False,
+        progress=False,
+        plot_panels=(PANEL_MARKET_PNL,),
+    )
+
+    sources = list(layout.select({"type": ColumnDataSource}))
+    pnl_source = next(source for source in sources if "pnl_long" in source.data)
+    assert pnl_source.data["market_id"].tolist() == ["winning-market", "winning-market"]
+    assert pnl_source.data["pnl_long"].tolist() == [4.75, 4.75]
+    assert pnl_source.data["positive"].tolist() == ["1", "1"]
 
 
 def test_build_dataframes_does_not_compute_percent_returns_from_negative_initial_cash() -> None:

--- a/tests/test_legacy_plot_fill_markers.py
+++ b/tests/test_legacy_plot_fill_markers.py
@@ -19,6 +19,7 @@ from prediction_market_extensions.analysis.legacy_backtesting.models import (
     PANEL_BRIER_ADVANTAGE,
     PANEL_DRAWDOWN,
     PANEL_EQUITY,
+    PANEL_MARKET_PNL,
     PANEL_TOTAL_BRIER_ADVANTAGE,
     PANEL_TOTAL_CASH_EQUITY,
     PANEL_TOTAL_DRAWDOWN,
@@ -72,6 +73,241 @@ def test_select_display_markets_prioritizes_filled_markets_when_limited() -> Non
     )
 
     assert display_markets == ["filled-market"]
+
+
+def test_allocation_values_no_token_at_its_own_price() -> None:
+    start = pd.Timestamp("2026-03-14T18:00:00")
+    eq = pd.DataFrame(
+        {
+            "datetime": [start, start + pd.Timedelta(minutes=1)],
+            "cash": [97.0, 97.0],
+            "equity": [100.0, 101.0],
+            "drawdown_pct": [0.0, 0.0],
+        }
+    )
+    fills_df = pd.DataFrame(
+        {
+            "datetime": [start],
+            "market_id": ["no-token"],
+            "action": ["buy"],
+            "side": ["no"],
+            "price": [0.30],
+            "quantity": [10.0],
+            "commission": [0.0],
+            "bar": [0],
+        }
+    )
+
+    allocation = plotting._build_allocation_data(
+        eq,
+        fills_df,
+        {"no-token": [(start, 0.30), (start + pd.Timedelta(minutes=1), 0.40)]},
+    )
+
+    assert allocation["no-token"].tolist() == pytest.approx([3.0, 4.0])
+
+
+def test_allocation_preserves_short_liability_sign() -> None:
+    start = pd.Timestamp("2026-04-01T00:00:00")
+    eq = pd.DataFrame(
+        {
+            "datetime": [start, start + pd.Timedelta(minutes=1)],
+            "cash": [106.0, 106.0],
+            "equity": [100.0, 100.0],
+            "drawdown_pct": [0.0, 0.0],
+        }
+    )
+    fills_df = pd.DataFrame(
+        {
+            "datetime": [start],
+            "market_id": ["short-yes-market"],
+            "action": ["sell"],
+            "side": ["yes"],
+            "price": [0.60],
+            "quantity": [10.0],
+            "commission": [0.0],
+            "bar": [0],
+        }
+    )
+
+    allocation = plotting._build_allocation_data(
+        eq,
+        fills_df,
+        {"short-yes-market": [(start, 0.60), (start + pd.Timedelta(minutes=1), 0.60)]},
+    )
+
+    assert allocation["short-yes-market"].tolist() == pytest.approx([-6.0, -6.0])
+    assert allocation["Cash"].tolist() == pytest.approx([106.0, 106.0])
+
+
+def test_allocation_zeroes_settled_position_on_price_feed_final_bar() -> None:
+    start = pd.Timestamp("2026-04-01T00:00:00")
+    settlement = start + pd.Timedelta(minutes=5)
+    eq = pd.DataFrame(
+        {
+            "datetime": [start, settlement],
+            "cash": [995.25, 1000.25],
+            "equity": [1000.0, 1000.25],
+            "drawdown_pct": [0.0, 0.0],
+        }
+    )
+    fills_df = pd.DataFrame(
+        {
+            "datetime": [start],
+            "market_id": ["yes-winner"],
+            "action": ["buy"],
+            "side": ["yes"],
+            "price": [0.95],
+            "quantity": [5.0],
+            "commission": [0.0],
+            "bar": [0],
+        }
+    )
+
+    allocation = plotting._build_allocation_data(
+        eq,
+        fills_df,
+        {"yes-winner": [(start, 0.95), (settlement, 0.95)]},
+    )
+
+    assert allocation["yes-winner"].tolist() == pytest.approx([4.75, 0.0])
+    assert allocation["Cash"].tolist() == pytest.approx([995.25, 1000.25])
+
+
+def test_market_pnl_panel_plots_one_final_marker_per_market(tmp_path) -> None:
+    pytest.importorskip("bokeh")
+    from bokeh.models import ColumnDataSource
+
+    start = datetime(2026, 4, 1, tzinfo=UTC)
+    result = BacktestResult(
+        equity_curve=[
+            PortfolioSnapshot(
+                timestamp=start,
+                cash=99.0,
+                total_equity=100.0,
+                unrealized_pnl=1.0,
+                num_positions=1,
+            ),
+            PortfolioSnapshot(
+                timestamp=start.replace(minute=1),
+                cash=98.0,
+                total_equity=102.0,
+                unrealized_pnl=4.0,
+                num_positions=1,
+            ),
+        ],
+        fills=[
+            Fill(
+                order_id="fill-1",
+                market_id="repeat-market",
+                action=OrderAction.BUY,
+                side=Side.YES,
+                price=0.40,
+                quantity=2.0,
+                timestamp=start,
+            ),
+            Fill(
+                order_id="fill-2",
+                market_id="repeat-market",
+                action=OrderAction.BUY,
+                side=Side.YES,
+                price=0.45,
+                quantity=2.0,
+                timestamp=start.replace(minute=1),
+            ),
+        ],
+        metrics={},
+        strategy_name="market-pnl-repeat",
+        platform=Platform.POLYMARKET,
+        start_time=start,
+        end_time=start.replace(minute=1),
+        initial_cash=100.0,
+        final_equity=102.0,
+        num_markets_traded=1,
+        num_markets_resolved=1,
+        market_prices={
+            "repeat-market": [
+                (start, 0.40),
+                (start.replace(minute=1), 0.45),
+            ]
+        },
+        market_pnls={"repeat-market": 2.0},
+    )
+
+    layout = plotting.plot(
+        result,
+        filename=str(tmp_path / "market_pnl_repeat.html"),
+        open_browser=False,
+        progress=False,
+        plot_panels=("market_pnl",),
+    )
+
+    marker_sources = [
+        source
+        for source in layout.select({"type": ColumnDataSource})
+        if {"pnl_long", "pnl_short", "market_id"}.issubset(source.data)
+    ]
+
+    assert len(marker_sources) == 1
+    assert marker_sources[0].data["market_id"].tolist() == ["repeat-market"]
+    assert marker_sources[0].data["pnl_long"].tolist() == pytest.approx([2.0])
+
+
+def test_dense_adapter_replays_no_token_buy_as_long_token_quantity() -> None:
+    assert adapter._signed_quantity("buy", "no", 10.0) == pytest.approx(10.0)
+    assert adapter._signed_quantity("sell", "no", 4.0) == pytest.approx(-4.0)
+
+
+def test_monthly_returns_use_prior_month_end_for_sparse_equity(tmp_path) -> None:
+    pytest.importorskip("bokeh")
+    from bokeh.models import ColumnDataSource
+
+    snapshots = [
+        ("2026-01-31T23:59:00Z", 100.0),
+        ("2026-02-28T23:59:00Z", 110.0),
+        ("2026-03-31T23:59:00Z", 99.0),
+    ]
+    result = BacktestResult(
+        equity_curve=[
+            PortfolioSnapshot(
+                timestamp=pd.Timestamp(ts).to_pydatetime(),
+                cash=equity,
+                total_equity=equity,
+                unrealized_pnl=0.0,
+                num_positions=0,
+            )
+            for ts, equity in snapshots
+        ],
+        fills=[],
+        metrics={},
+        strategy_name="monthly-sparse",
+        platform=Platform.POLYMARKET,
+        start_time=pd.Timestamp(snapshots[0][0]).to_pydatetime(),
+        end_time=pd.Timestamp(snapshots[-1][0]).to_pydatetime(),
+        initial_cash=100.0,
+        final_equity=99.0,
+        num_markets_traded=0,
+        num_markets_resolved=0,
+        market_prices={},
+    )
+
+    layout = plotting.plot(
+        result,
+        filename=str(tmp_path / "monthly_sparse.html"),
+        open_browser=False,
+        progress=False,
+        plot_panels=("monthly_returns",),
+    )
+
+    source = next(
+        source
+        for source in layout.select({"type": ColumnDataSource})
+        if {"month", "year", "ret"}.issubset(source.data)
+    )
+    returns_by_month = dict(zip(source.data["month"], source.data["ret"], strict=True))
+
+    assert returns_by_month["Feb"] == pytest.approx(0.10)
+    assert returns_by_month["Mar"] == pytest.approx(-0.10)
 
 
 def test_yes_price_plot_renders_market_with_prices_but_no_fills(tmp_path) -> None:
@@ -662,6 +898,104 @@ def test_zero_fill_zero_cash_report_panels_do_not_crash(tmp_path) -> None:
 
     assert layout is not None
     assert output_path.exists()
+
+
+def test_market_pnl_panel_uses_resolved_market_pnl_for_fill_markers(tmp_path) -> None:
+    pytest.importorskip("bokeh")
+    from bokeh.models import ColumnDataSource
+
+    start = datetime(2026, 3, 14, 18, tzinfo=UTC)
+    result = BacktestResult(
+        equity_curve=[
+            PortfolioSnapshot(
+                timestamp=start,
+                cash=99.75,
+                total_equity=100.0,
+                unrealized_pnl=0.25,
+                num_positions=1,
+            ),
+            PortfolioSnapshot(
+                timestamp=start.replace(minute=1),
+                cash=104.75,
+                total_equity=104.75,
+                unrealized_pnl=0.0,
+                num_positions=0,
+            ),
+        ],
+        fills=[
+            Fill(
+                order_id="fill-1",
+                market_id="winning-market",
+                action=OrderAction.BUY,
+                side=Side.YES,
+                price=0.05,
+                quantity=5.0,
+                timestamp=start,
+            )
+        ],
+        metrics={},
+        strategy_name="resolved-pnl-marker",
+        platform=Platform.POLYMARKET,
+        start_time=start,
+        end_time=start.replace(minute=1),
+        initial_cash=100.0,
+        final_equity=104.75,
+        num_markets_traded=1,
+        num_markets_resolved=1,
+        market_prices={"winning-market": [(start, 0.05), (start.replace(minute=1), 1.0)]},
+        market_pnls={"winning-market": 4.75},
+    )
+
+    layout = plotting.plot(
+        result,
+        filename=str(tmp_path / "resolved_pnl_marker.html"),
+        open_browser=False,
+        progress=False,
+        plot_panels=(PANEL_MARKET_PNL,),
+    )
+
+    sources = list(layout.select({"type": ColumnDataSource}))
+    pnl_source = next(source for source in sources if "pnl_long" in source.data)
+    assert pnl_source.data["pnl_long"].tolist() == [4.75]
+    assert np.isnan(pnl_source.data["pnl_short"][0])
+    assert pnl_source.data["positive"].tolist() == ["1"]
+
+
+def test_build_dataframes_does_not_compute_percent_returns_from_negative_initial_cash() -> None:
+    start = datetime(2026, 3, 14, 18, tzinfo=UTC)
+    result = BacktestResult(
+        equity_curve=[
+            PortfolioSnapshot(
+                timestamp=start,
+                cash=-100.0,
+                total_equity=-100.0,
+                unrealized_pnl=0.0,
+                num_positions=0,
+            ),
+            PortfolioSnapshot(
+                timestamp=start.replace(minute=1),
+                cash=-90.0,
+                total_equity=-90.0,
+                unrealized_pnl=0.0,
+                num_positions=0,
+            ),
+        ],
+        fills=[],
+        metrics={},
+        strategy_name="negative-initial",
+        platform=Platform.POLYMARKET,
+        start_time=start,
+        end_time=start.replace(minute=1),
+        initial_cash=-100.0,
+        final_equity=-90.0,
+        num_markets_traded=0,
+        num_markets_resolved=1,
+    )
+
+    eq, _, _, _ = plotting._build_dataframes(result)
+
+    assert eq["equity_pct"].tolist() == [1.0, 1.0]
+    assert eq["return_pct"].tolist() == [0.0, 0.0]
 
 
 def test_total_rolling_sharpe_uses_equity_timestamps(

--- a/tests/test_legacy_runtime_defaults.py
+++ b/tests/test_legacy_runtime_defaults.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+from nautilus_trader.model.currencies import USDC_POS
+from nautilus_trader.model.enums import BookType
+from nautilus_trader.model.identifiers import Venue
+
+from prediction_market_extensions.adapters.prediction_market import research as legacy_research
+from prediction_market_extensions.backtesting import _backtest_runtime as runtime_module
+
+EXPECTED_LATENCY_NANOS = {
+    "base_latency_nanos": 75_000_000,
+    "insert_latency_nanos": 85_000_000,
+    "update_latency_nanos": 80_000_000,
+    "cancel_latency_nanos": 80_000_000,
+}
+
+
+class _TraderStub:
+    def generate_order_fills_report(self) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    def generate_positions_report(self) -> pd.DataFrame:
+        return pd.DataFrame()
+
+
+class _EngineResultStub:
+    backtest_end: int | None = 0
+
+
+class _EngineStub:
+    instances: list[_EngineStub] = []
+
+    def __init__(self, *, config: object) -> None:
+        self.config = config
+        self.venues: list[dict[str, object]] = []
+        self.data_batches: list[list[object]] = []
+        self.strategies: list[object] = []
+        self.trader = _TraderStub()
+        type(self).instances.append(self)
+
+    def add_venue(self, **kwargs: object) -> None:
+        self.venues.append(kwargs)
+
+    def add_instrument(self, instrument: object) -> None:
+        self.instrument = instrument
+
+    def add_data(self, records: object) -> None:
+        self.data_batches.append(list(records))  # type: ignore[arg-type]
+
+    def add_strategy(self, strategy: object) -> None:
+        self.strategies.append(strategy)
+
+    def run(self) -> None:
+        self.ran = True
+
+    def get_result(self) -> _EngineResultStub:
+        return _EngineResultStub()
+
+    def reset(self) -> None:
+        self.reset_called = True
+
+    def dispose(self) -> None:
+        self.dispose_called = True
+
+
+class _StrategyStub:
+    def submit_order(self, order: object) -> None:
+        self.last_order = order
+
+
+def _empty_brier_inputs(*args: object, **kwargs: object) -> tuple[pd.Series, pd.Series, pd.Series]:
+    del args, kwargs
+    return pd.Series(dtype=float), pd.Series(dtype=float), pd.Series(dtype=float)
+
+
+def _settlement_marker(result: dict[str, Any]) -> dict[str, Any]:
+    result["settlement_probe_applied"] = True
+    return result
+
+
+def _latency_values(latency_model: object) -> dict[str, int]:
+    return {
+        name: int(getattr(latency_model, name))
+        for name in (
+            "base_latency_nanos",
+            "insert_latency_nanos",
+            "update_latency_nanos",
+            "cancel_latency_nanos",
+        )
+    }
+
+
+def _run_helper(monkeypatch, module: object, **overrides: object):  # type: ignore[no-untyped-def]
+    _EngineStub.instances = []
+    monkeypatch.setattr(module, "BacktestEngine", _EngineStub)
+    monkeypatch.setattr(module, "extract_realized_pnl", lambda positions: 0.0)
+    monkeypatch.setattr(module, "extract_price_points", lambda records, price_attr: [])
+    monkeypatch.setattr(module, "infer_realized_outcome", lambda instrument: 1.0)
+    monkeypatch.setattr(module, "build_brier_inputs", _empty_brier_inputs)
+    monkeypatch.setattr(module, "build_market_prices", lambda points, resample_rule=None: [])
+    monkeypatch.setattr(module, "apply_binary_settlement_pnl", _settlement_marker)
+
+    strategy = _StrategyStub()
+    result = module.run_market_backtest(
+        market_id="demo-market",
+        instrument=SimpleNamespace(id="DEMO.POLYMARKET", outcome="Yes", expiration_ns=2),
+        data=[
+            SimpleNamespace(ts_init=0, ts_event=0),
+            SimpleNamespace(ts_init=1, ts_event=1),
+        ],
+        strategy=strategy,
+        strategy_name="demo",
+        output_prefix="tmp/test",
+        platform="polymarket",
+        venue=Venue("POLYMARKET"),
+        base_currency=USDC_POS,
+        fee_model=object(),
+        initial_cash=100.0,
+        probability_window=3,
+        price_attr="price",
+        count_key="book_events",
+        **overrides,
+    )
+    return result, _EngineStub.instances[0], strategy
+
+
+def _assert_legacy_book_defaults(engine: _EngineStub, strategy: _StrategyStub) -> None:
+    venue_kwargs = engine.venues[0]
+    assert venue_kwargs["book_type"] == BookType.L2_MBP
+    assert venue_kwargs["liquidity_consumption"] is True
+    assert venue_kwargs["queue_position"] is True
+    assert venue_kwargs["fill_model"] is None
+    assert venue_kwargs["bar_execution"] is False
+    assert venue_kwargs["trade_execution"] is True
+
+    latency_model = venue_kwargs["latency_model"]
+    assert latency_model is not None
+    assert _latency_values(latency_model) == EXPECTED_LATENCY_NANOS
+
+    assert engine.config.logging.log_level == "INFO"
+    assert engine.config.risk_engine.bypass is False
+    assert getattr(strategy.submit_order, "__name__", "") == "guarded_submit_order"
+
+
+def test_backtest_runtime_run_market_backtest_uses_repo_l2_defaults(monkeypatch) -> None:
+    result, engine, strategy = _run_helper(monkeypatch, runtime_module)
+
+    _assert_legacy_book_defaults(engine, strategy)
+    assert result["settlement_probe_applied"] is True
+
+
+def test_research_run_market_backtest_uses_repo_l2_defaults(monkeypatch) -> None:
+    result, engine, strategy = _run_helper(monkeypatch, legacy_research)
+
+    _assert_legacy_book_defaults(engine, strategy)
+    assert result["settlement_probe_applied"] is True
+
+
+def test_legacy_run_market_backtest_allows_explicit_zero_latency(monkeypatch) -> None:
+    _, runtime_engine, _ = _run_helper(monkeypatch, runtime_module, latency_model=None)
+    _, research_engine, _ = _run_helper(monkeypatch, legacy_research, latency_model=None)
+
+    assert runtime_engine.venues[0]["latency_model"] is None
+    assert research_engine.venues[0]["latency_model"] is None

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import csv
 import json
+import math
 import warnings
 from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -37,6 +40,13 @@ def _result_for_score(score: float) -> dict[str, object]:
         "terminated_early": False,
         "equity_series": [(0, 100.0), (1, 100.0 + score)],
     }
+
+
+def _strict_json_loads(text: str) -> object:
+    def _reject_constant(value: str) -> None:
+        raise ValueError(f"non-strict JSON constant {value}")
+
+    return json.loads(text, parse_constant=_reject_constant)
 
 
 def _make_config(
@@ -136,6 +146,34 @@ def test_sample_parameter_sets_is_deterministic_and_unique(tmp_path: Path) -> No
 
     full_grid_config = replace(config, max_trials=10)
     assert optimizer._sample_parameter_sets(full_grid_config) == candidates
+
+
+def test_parameter_candidates_preserve_typed_distinct_values(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (Path("models/calibration.json"), "models/calibration.json")},
+        max_trials=10,
+    )
+
+    candidates = optimizer._parameter_candidates(config.parameter_grid)
+
+    assert candidates == [
+        (("edge", Path("models/calibration.json")),),
+        (("edge", "models/calibration.json"),),
+    ]
+
+
+def test_discrete_search_rejects_string_values(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="parameter_grid"):
+        _make_config(tmp_path, parameter_grid={"edge": "abc"})  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="parameter_space"):
+        _make_config(
+            tmp_path,
+            parameter_grid={},
+            parameter_space={"edge": {"type": "categorical", "choices": "abc"}},
+            sampler="random",
+        )
 
 
 def test_replace_search_placeholders_binds_nested_payloads() -> None:
@@ -328,6 +366,45 @@ def test_tpe_step_rejects_log_sampling(tmp_path: Path) -> None:
         )
 
 
+def test_tpe_int_space_rejects_silent_bound_truncation(tmp_path: Path) -> None:
+    for spec, match in (
+        ({"type": "int", "low": 1.5, "high": 8}, "int low must be an integer"),
+        ({"type": "int", "low": 1, "high": 8.5}, "int high must be an integer"),
+        ({"type": "int", "low": 1, "high": 10, "step": 4}, "divisible by step"),
+    ):
+        with pytest.raises(ValueError, match=match):
+            _make_config(
+                tmp_path,
+                strategy_spec={
+                    "strategy_path": "strategies:DemoStrategy",
+                    "config_path": "strategies:DemoConfig",
+                    "config": {"lookback": "__SEARCH__:lookback"},
+                },
+                parameter_grid={},
+                parameter_space={"lookback": spec},
+                sampler="tpe",
+            )
+
+
+def test_tpe_float_space_rejects_silent_bound_adjustment(tmp_path: Path) -> None:
+    for spec, match in (
+        ({"type": "float", "low": 0.0, "high": 1.0, "log": True}, "low > 0"),
+        ({"type": "float", "low": 0.0, "high": 1.0, "step": 0.3}, "divisible by step"),
+    ):
+        with pytest.raises(ValueError, match=match):
+            _make_config(
+                tmp_path,
+                strategy_spec={
+                    "strategy_path": "strategies:DemoStrategy",
+                    "config_path": "strategies:DemoConfig",
+                    "config": {"edge": "__SEARCH__:edge"},
+                },
+                parameter_grid={},
+                parameter_space={"edge": spec},
+                sampler="tpe",
+            )
+
+
 def test_optimizer_reruns_only_top_k_train_candidates_on_holdout_and_selects_by_holdout(
     tmp_path: Path,
 ) -> None:
@@ -395,6 +472,310 @@ def test_optimizer_keeps_failed_trials_visible_on_leaderboard(tmp_path: Path) ->
     assert failed_row.train_median_score == config.invalid_score
 
 
+def test_optimizer_makes_any_invalid_train_window_fatal(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_windows=(),
+        train_windows=(
+            _window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),
+            _window("train-b", "2026-01-02T00:00:00Z", "2026-01-02T02:00:00Z"),
+            _window("train-c", "2026-01-03T00:00:00Z", "2026-01-03T02:00:00Z"),
+        ),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        window_name = backtest.replays[0].metadata["optimization_window"]
+        if edge == 1 and window_name == "train-b":
+            raise RuntimeError("simulated missing train window")
+        return _result_for_score(1_000.0 if edge == 1 else 10.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.train_median_score == config.invalid_score
+
+
+def test_optimizer_does_not_rescue_invalid_train_candidate_on_holdout(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_top_k=2,
+        train_windows=(
+            _window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),
+            _window("train-b", "2026-01-02T00:00:00Z", "2026-01-02T02:00:00Z"),
+        ),
+        holdout_windows=(_window("holdout-a", "2026-01-03T00:00:00Z", "2026-01-03T02:00:00Z"),),
+    )
+    calls: list[tuple[int, str]] = []
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        window_name = backtest.replays[0].metadata["optimization_window"]
+        calls.append((edge, window_name))
+        if edge == 1 and window_name == "train-b":
+            raise RuntimeError("simulated missing train window")
+        if window_name.startswith("holdout"):
+            return _result_for_score(1_000.0 if edge == 1 else 10.0)
+        return _result_for_score(100.0 if edge == 1 else 20.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.train_median_score == config.invalid_score
+    assert invalid_row.holdout_scores == ()
+    assert (1, "holdout-a") not in calls
+
+
+def test_optimizer_makes_any_invalid_holdout_window_fatal(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_top_k=2,
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+        holdout_windows=(
+            _window("holdout-a", "2026-01-04T00:00:00Z", "2026-01-04T02:00:00Z"),
+            _window("holdout-b", "2026-01-05T00:00:00Z", "2026-01-05T02:00:00Z"),
+            _window("holdout-c", "2026-01-06T00:00:00Z", "2026-01-06T02:00:00Z"),
+        ),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        window_name = backtest.replays[0].metadata["optimization_window"]
+        if window_name.startswith("train"):
+            return _result_for_score(20.0 if edge == 1 else 19.0)
+        if edge == 1 and window_name == "holdout-b":
+            raise RuntimeError("simulated missing holdout window")
+        return _result_for_score(1_000.0 if edge == 1 else 10.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.holdout_median_score == config.invalid_score
+
+
+def test_optimizer_maps_nonfinite_metrics_to_invalid_score(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2, 3, 4)},
+        max_trials=4,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            return _result_for_score(float("nan"))
+        if edge == 2:
+            return _result_for_score(float("inf"))
+        if edge == 3:
+            result = _result_for_score(1_000.0)
+            result["equity_series"] = [
+                ("2026-01-01T00:00:00Z", float("nan")),
+                ("2026-01-01T00:01:00Z", float("inf")),
+            ]
+            return result
+        return _result_for_score(1.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 4}
+    invalid_rows = [
+        row
+        for row in summary.leaderboard
+        if dict(row.params) in ({"edge": 1}, {"edge": 2}, {"edge": 3})
+    ]
+    assert len(invalid_rows) == 3
+    assert all(row.train_scores == (config.invalid_score,) for row in invalid_rows)
+
+
+def test_optimizer_maps_empty_and_wrong_result_counts_to_invalid_score(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2, 3)},
+        max_trials=3,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> object:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            return []
+        if edge == 2:
+            return [_result_for_score(1.0), _result_for_score(2.0)]
+        return _result_for_score(3.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 3}
+    invalid_rows = [
+        row for row in summary.leaderboard if dict(row.params) in ({"edge": 1}, {"edge": 2})
+    ]
+    assert len(invalid_rows) == 2
+    assert all(row.train_scores == (config.invalid_score,) for row in invalid_rows)
+
+
+def test_optimizer_requires_equity_series_for_scoring(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2, 3)},
+        max_trials=3,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            result = _result_for_score(1_000.0)
+            result.pop("equity_series")
+            return result
+        if edge == 2:
+            result = _result_for_score(900.0)
+            result["equity_series"] = []
+            return result
+        return _result_for_score(3.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 3}
+    invalid_rows = [
+        row for row in summary.leaderboard if dict(row.params) in ({"edge": 1}, {"edge": 2})
+    ]
+    assert len(invalid_rows) == 2
+    assert all(row.train_scores == (config.invalid_score,) for row in invalid_rows)
+
+
+def test_optimizer_rejects_duplicate_multi_replay_result_identifiers(tmp_path: Path) -> None:
+    replays = (
+        BookReplay(market_slug="market-one", token_index=0),
+        BookReplay(market_slug="market-two", token_index=0),
+    )
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+    config = replace(config, base_replays=replays, base_replay=config.base_replay)
+
+    def _market_result(score: float, slug: str) -> dict[str, object]:
+        result = _result_for_score(score)
+        result["slug"] = slug
+        result["token_index"] = 0
+        return result
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> list[dict[str, object]]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            return [_market_result(100.0, "market-one"), _market_result(100.0, "market-one")]
+        return [_market_result(10.0, "market-one"), _market_result(10.0, "market-two")]
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.train_scores == (config.invalid_score,)
+
+
+def test_optimizer_rejects_missing_multi_replay_result_identifiers(
+    tmp_path: Path,
+) -> None:
+    replays = (
+        BookReplay(market_slug="market-one", token_index=0),
+        BookReplay(market_slug="market-two", token_index=0),
+    )
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+    config = replace(config, base_replays=replays, base_replay=config.base_replay)
+
+    def _market_result(score: float, slug: str | None) -> dict[str, object]:
+        result = _result_for_score(score)
+        if slug is not None:
+            result["slug"] = slug
+            result["token_index"] = 0
+        return result
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> list[dict[str, object]]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            return [_market_result(100.0, None), _market_result(100.0, None)]
+        return [_market_result(10.0, "market-one"), _market_result(10.0, "market-two")]
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.train_scores == (config.invalid_score,)
+
+
+def test_optimizer_treats_backtest_realism_invalid_as_invalid_score(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            result = _result_for_score(1_000.0)
+            result["backtest_realism_invalid"] = True
+            return result
+        return _result_for_score(10.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.train_scores == (config.invalid_score,)
+    assert invalid_row.train_median_pnl == 1_000.0
+
+
+def test_random_sampler_accepts_all_categorical_parameter_space(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        parameter_grid={},
+        parameter_space={"edge": {"type": "categorical", "choices": (2, 1)}},
+        sampler="random",
+        max_trials=2,
+        holdout_windows=(),
+    )
+
+    assert optimizer._parameter_candidates(config.parameter_grid) == [
+        (("edge", 2),),
+        (("edge", 1),),
+    ]
+
+
+def test_random_sampler_rejects_continuous_parameter_space(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="sampler='random'"):
+        _make_config(
+            tmp_path,
+            parameter_grid={},
+            parameter_space={"edge": {"type": "float", "low": 0.001, "high": 0.01}},
+            sampler="random",
+        )
+
+
 def test_run_parameter_optimization_writes_artifacts(tmp_path: Path) -> None:
     config = _make_config(
         tmp_path,
@@ -426,6 +807,77 @@ def test_run_parameter_optimization_writes_artifacts(tmp_path: Path) -> None:
     assert set(payload["best_candidate"]["params"]) == {"edge"}
 
 
+def test_run_parameter_optimization_serializes_json_safe_params(tmp_path: Path) -> None:
+    config = _make_config(
+        tmp_path,
+        name="optimizer_json_safe_params",
+        parameter_grid={
+            "edge": (
+                Path("models/calibration.json"),
+                datetime(2026, 1, 1, 12, 30, tzinfo=UTC),
+            )
+        },
+        max_trials=2,
+        holdout_windows=(),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        value = backtest.strategy_configs[0]["config"]["edge"]
+        return _result_for_score(2.0 if isinstance(value, datetime) else 1.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    payload = json.loads(Path(summary.summary_json_path).read_text(encoding="utf-8"))
+    assert payload["selected_params"] == {"edge": "2026-01-01T12:30:00+00:00"}
+    assert payload["best_candidate"]["params"] == {"edge": "2026-01-01T12:30:00+00:00"}
+    csv_text = Path(summary.leaderboard_csv_path).read_text(encoding="utf-8")
+    assert '"models/calibration.json"' in csv_text
+    assert '"2026-01-01T12:30:00+00:00"' in csv_text
+
+
+def test_run_parameter_optimization_serializes_nonfinite_params_as_strict_json(
+    tmp_path: Path,
+) -> None:
+    config = _make_config(
+        tmp_path,
+        name="optimizer_nonfinite_json_safe_params",
+        parameter_grid={
+            "edge": (
+                Path("models/calibration.json"),
+                datetime(2026, 1, 1, 12, 30, tzinfo=UTC),
+                float("nan"),
+                float("inf"),
+            )
+        },
+        max_trials=4,
+        holdout_windows=(),
+    )
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> dict[str, object]:
+        value = backtest.strategy_configs[0]["config"]["edge"]
+        if isinstance(value, float) and math.isnan(value):
+            return _result_for_score(4.0)
+        if isinstance(value, float) and math.isinf(value):
+            return _result_for_score(3.0)
+        if isinstance(value, datetime):
+            return _result_for_score(2.0)
+        return _result_for_score(1.0)
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    summary_text = Path(summary.summary_json_path).read_text(encoding="utf-8")
+    payload = _strict_json_loads(summary_text)
+    assert payload["selected_params"] == {"edge": "nan"}  # type: ignore[index]
+    assert "NaN" not in summary_text
+    assert "Infinity" not in summary_text
+
+    with Path(summary.leaderboard_csv_path).open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    params = [_strict_json_loads(row["params_json"]) for row in rows]
+    assert {"edge": "nan"} in params
+    assert {"edge": "inf"} in params
+
+
 def test_joint_portfolio_drawdown_captures_diversification() -> None:
     # Two anti-correlated equity curves: market A dips while B rises, and
     # vice versa. Joint portfolio drawdown should be much smaller than the
@@ -451,6 +903,198 @@ def test_joint_portfolio_drawdown_captures_diversification() -> None:
     assert joint == pytest.approx(0.0, abs=1e-9)
 
 
+def test_joint_portfolio_drawdown_rejects_nonfinite_values() -> None:
+    for value in (float("nan"), float("inf"), -float("inf")):
+        joint = optimizer._joint_portfolio_drawdown(
+            [
+                [
+                    ("2026-01-01T00:00:00Z", 100.0),
+                    ("2026-01-01T01:00:00Z", value),
+                    ("2026-01-01T02:00:00Z", 90.0),
+                ]
+            ]
+        )
+
+        assert not math.isfinite(joint)
+
+
+def test_optimizer_rejects_malformed_joint_equity_timestamps(tmp_path: Path) -> None:
+    replays = (
+        BookReplay(market_slug="market-one", token_index=0),
+        BookReplay(market_slug="market-two", token_index=0),
+    )
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1,)},
+        max_trials=1,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+    config = replace(config, base_replays=replays, base_replay=config.base_replay)
+
+    def _market_result(score: float, slug: str, equity_series: object) -> dict[str, object]:
+        result = _result_for_score(score)
+        result["slug"] = slug
+        result["token_index"] = 0
+        result["equity_series"] = equity_series
+        return result
+
+    evaluation = optimizer._evaluate_window(
+        config=config,
+        evaluator=lambda _backtest: [
+            _market_result(100.0, "market-one", [("not-a-timestamp", 100.0)]),
+            _market_result(
+                100.0,
+                "market-two",
+                [
+                    ("2026-01-01T00:00:00Z", 100.0),
+                    ("2026-01-01T01:00:00Z", 90.0),
+                ],
+            ),
+        ],
+        trial_id=1,
+        params=(("edge", 1),),
+        window=config.train_windows[0],
+    )
+
+    assert evaluation.status == "invalid_nonfinite_metric"
+    assert evaluation.score == config.invalid_score
+    assert evaluation.error == "max_drawdown_currency is non-finite: nan"
+
+
+def test_optimizer_uses_returned_joint_portfolio_equity_series_for_drawdown(
+    tmp_path: Path,
+) -> None:
+    replays = (
+        BookReplay(market_slug="market-one", token_index=0),
+        BookReplay(market_slug="market-two", token_index=0),
+    )
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+    config = replace(config, base_replays=replays, base_replay=config.base_replay)
+
+    def _market_result(
+        score: float,
+        *,
+        slug: str,
+        equity_series: object,
+        joint_portfolio_equity_series: object | None = None,
+    ) -> dict[str, object]:
+        result = _result_for_score(score)
+        result["slug"] = slug
+        result["token_index"] = 0
+        result["equity_series"] = equity_series
+        if joint_portfolio_equity_series is not None:
+            result["joint_portfolio_equity_series"] = joint_portfolio_equity_series
+        return result
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> list[dict[str, object]]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            return [
+                _market_result(
+                    3.0,
+                    slug="market-one",
+                    equity_series=[
+                        ("2026-01-01T00:00:00Z", 100.0),
+                        ("2026-01-01T01:00:00Z", 70.0),
+                        ("2026-01-01T02:00:00Z", 103.0),
+                    ],
+                    joint_portfolio_equity_series=[
+                        ("2026-01-01T00:00:00Z", 200.0),
+                        ("2026-01-01T01:00:00Z", 200.0),
+                        ("2026-01-01T02:00:00Z", 206.0),
+                    ],
+                ),
+                _market_result(
+                    3.0,
+                    slug="market-two",
+                    equity_series=[
+                        ("2026-01-01T00:00:00Z", 100.0),
+                        ("2026-01-01T01:00:00Z", 70.0),
+                        ("2026-01-01T02:00:00Z", 103.0),
+                    ],
+                ),
+            ]
+        return [
+            _market_result(
+                2.0,
+                slug="market-one",
+                equity_series=[("2026-01-01T00:00:00Z", 100.0)],
+            ),
+            _market_result(
+                2.0,
+                slug="market-two",
+                equity_series=[("2026-01-01T00:00:00Z", 100.0)],
+            ),
+        ]
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 1}
+    best_row = summary.best_row
+    assert best_row.train_median_pnl == pytest.approx(6.0)
+    assert best_row.train_median_drawdown == pytest.approx(0.0)
+    assert best_row.train_scores == (6.0,)
+
+
+def test_optimizer_rejects_nonfinite_returned_joint_portfolio_equity_series(
+    tmp_path: Path,
+) -> None:
+    replays = (
+        BookReplay(market_slug="market-one", token_index=0),
+        BookReplay(market_slug="market-two", token_index=0),
+    )
+    config = _make_config(
+        tmp_path,
+        parameter_grid={"edge": (1, 2)},
+        max_trials=2,
+        holdout_windows=(),
+        train_windows=(_window("train-a", "2026-01-01T00:00:00Z", "2026-01-01T02:00:00Z"),),
+    )
+    config = replace(config, base_replays=replays, base_replay=config.base_replay)
+
+    def _market_result(
+        score: float,
+        *,
+        slug: str,
+        joint_portfolio_equity_series: object | None = None,
+    ) -> dict[str, object]:
+        result = _result_for_score(score)
+        result["slug"] = slug
+        result["token_index"] = 0
+        if joint_portfolio_equity_series is not None:
+            result["joint_portfolio_equity_series"] = joint_portfolio_equity_series
+        return result
+
+    def _evaluator(backtest: PredictionMarketBacktest) -> list[dict[str, object]]:
+        edge = backtest.strategy_configs[0]["config"]["edge"]
+        if edge == 1:
+            return [
+                _market_result(
+                    1_000.0,
+                    slug="market-one",
+                    joint_portfolio_equity_series=[
+                        ("2026-01-01T00:00:00Z", 200.0),
+                        ("2026-01-01T01:00:00Z", float("nan")),
+                    ],
+                ),
+                _market_result(1_000.0, slug="market-two"),
+            ]
+        return [_market_result(1.0, slug="market-one"), _market_result(1.0, slug="market-two")]
+
+    summary = optimizer.run_parameter_optimization(config, evaluator=_evaluator)
+
+    assert dict(summary.selected_params) == {"edge": 2}
+    invalid_row = next(row for row in summary.leaderboard if dict(row.params) == {"edge": 1})
+    assert invalid_row.train_scores == (config.invalid_score,)
+
+
 def test_joint_portfolio_drawdown_tracks_concurrent_losses() -> None:
     # Two correlated curves that drop at the same time should produce a
     # joint drawdown equal to the sum of individual drawdowns.
@@ -461,6 +1105,22 @@ def test_joint_portfolio_drawdown_tracks_concurrent_losses() -> None:
     ]
     joint = optimizer._joint_portfolio_drawdown([series, series])
     assert joint == pytest.approx(40.0)
+
+
+def test_joint_portfolio_drawdown_backfills_later_market_starts() -> None:
+    market_a = [
+        ("2026-01-01T00:00:00Z", 100.0),
+        ("2026-01-01T01:00:00Z", 90.0),
+        ("2026-01-01T02:00:00Z", 90.0),
+    ]
+    market_b = [
+        ("2026-01-01T01:00:00Z", 100.0),
+        ("2026-01-01T02:00:00Z", 100.0),
+    ]
+
+    joint = optimizer._joint_portfolio_drawdown([market_a, market_b])
+
+    assert joint == pytest.approx(10.0)
 
 
 def test_parameter_search_config_accepts_base_replays_for_multi_market(

--- a/tests/test_pmxt_data_source.py
+++ b/tests/test_pmxt_data_source.py
@@ -277,6 +277,55 @@ def test_runner_loader_emits_scan_progress_for_local_raw_mirror(monkeypatch, tmp
     }
 
 
+def test_runner_loader_ignores_stale_filtered_cache_without_source_metadata(tmp_path) -> None:
+    cache_dir = tmp_path / "cache"
+    raw_root = tmp_path / "raw"
+    loader = _make_loader(cache_dir=cache_dir, raw_root=raw_root, disable_remote_archive=True)
+    hour = pd.Timestamp("2026-03-21T12:00:00Z")
+    raw_path = raw_root / RunnerPolymarketPMXTDataLoader._archive_relative_path_for_hour(hour)
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.table(
+            {
+                "market_id": ["condition-123"],
+                "update_type": ["book_snapshot"],
+                "data": ['{"token_id":"token-yes-123","payload":"corrected"}'],
+            }
+        ),
+        raw_path,
+    )
+    stale_cache_path = loader._cache_path_for_hour(hour)
+    assert stale_cache_path is not None
+    stale_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.table(
+            {
+                "update_type": ["book_snapshot"],
+                "data": ['{"token_id":"token-yes-123","payload":"stale"}'],
+            }
+        ),
+        stale_cache_path,
+    )
+
+    batches = loader._load_market_batches(hour, batch_size=1_000)
+
+    assert batches is not None
+    assert pa.Table.from_batches(batches).to_pylist() == [
+        {
+            "update_type": "book_snapshot",
+            "data": '{"token_id":"token-yes-123","payload":"corrected"}',
+        }
+    ]
+    cached = loader._load_cached_market_table(hour)
+    assert cached is not None
+    assert cached.to_pylist() == [
+        {
+            "update_type": "book_snapshot",
+            "data": '{"token_id":"token-yes-123","payload":"corrected"}',
+        }
+    ]
+
+
 def test_runner_loader_honors_per_entry_explicit_source_order(monkeypatch) -> None:
     loader = _make_loader()
     loader._pmxt_ordered_source_entries = (
@@ -527,3 +576,69 @@ def test_runner_loader_uses_timeout_for_remote_payload_and_head(monkeypatch) -> 
     assert requests[1][0].get_method() == "HEAD"
     assert requests[0][1] == 30
     assert requests[1][1] == 30
+
+
+def test_runner_loader_remote_cache_fingerprint_uses_archive_head_metadata(
+    monkeypatch,
+) -> None:
+    loader = _make_loader()
+    hour = pd.Timestamp("2026-03-21T12:00:00Z")
+    requests: list[tuple[Request, float | None]] = []
+    etags = ['"raw-v1"', '"raw-v2"']
+
+    class FakeResponse:
+        def __init__(self, etag: str) -> None:
+            self.headers = {
+                "Content-Length": "1234",
+                "ETag": etag,
+                "Last-Modified": "Tue, 21 Apr 2026 12:00:00 GMT",
+            }
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def fake_urlopen(request, timeout=None):
+        requests.append((request, timeout))
+        return FakeResponse(etags.pop(0))
+
+    monkeypatch.setattr(pmxt_module, "urlopen", fake_urlopen)
+
+    first = loader._remote_source_fingerprint_for_hour("https://archive.vendor.test", hour)
+    second = loader._remote_source_fingerprint_for_hour("https://archive.vendor.test", hour)
+
+    assert first["url"] == (
+        "https://archive.vendor.test/polymarket_orderbook_2026-03-21T12.parquet"
+    )
+    assert first["content_length"] == 1234
+    assert first["etag"] == '"raw-v1"'
+    assert second["etag"] == '"raw-v2"'
+    assert first != second
+    assert [request.get_method() for request, _ in requests] == ["HEAD", "HEAD"]
+    assert [timeout for _, timeout in requests] == [30, 30]
+
+
+def test_runner_loader_local_fingerprint_tracks_same_size_same_mtime_correction(
+    tmp_path,
+) -> None:
+    path = tmp_path / "hour.parquet"
+    path.write_bytes(b"price=0.41")
+    first_stat = path.stat()
+    first = RunnerPolymarketPMXTDataLoader._local_file_fingerprint(path)
+
+    time.sleep(0.01)
+    path.write_bytes(b"price=0.67")
+    os.utime(path, ns=(first_stat.st_atime_ns, first_stat.st_mtime_ns))
+    second_stat = path.stat()
+    if second_stat.st_ctime_ns == first_stat.st_ctime_ns:
+        pytest.skip("filesystem did not expose ctime change for same-size rewrite")
+    second = RunnerPolymarketPMXTDataLoader._local_file_fingerprint(path)
+
+    assert first is not None
+    assert second is not None
+    assert first["size"] == second["size"]
+    assert first["mtime_ns"] == second["mtime_ns"]
+    assert first["ctime_ns"] != second["ctime_ns"]
+    assert first != second

--- a/tests/test_polymarket_fees.py
+++ b/tests/test_polymarket_fees.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 from nautilus_trader.core.rust.model import OrderType
 from nautilus_trader.model.currencies import USDC_POS
+from nautilus_trader.model.enums import LiquiditySide
 from nautilus_trader.model.objects import Currency
 
 from prediction_market_extensions.adapters.polymarket.loaders import PolymarketDataLoader
@@ -125,9 +126,39 @@ def test_infer_maker_rebate_rate_can_use_documented_fee_rate() -> None:
     assert rate == Decimal("0.20")
 
 
-def test_limit_orders_receive_polymarket_maker_rebate_credit() -> None:
+def test_unknown_limit_liquidity_does_not_assume_maker_rebate() -> None:
     commission = PolymarketFeeModel().get_commission(
         SimpleNamespace(order_type=OrderType.LIMIT),
+        fill_qty=100,
+        fill_px=0.5,
+        instrument=SimpleNamespace(
+            info={"tags": ["Sports"]},
+            taker_fee=Decimal("0.003"),
+            quote_currency=USDC_POS,
+        ),
+    )
+
+    assert commission.as_double() == 0.075
+
+
+def test_limit_fills_with_taker_liquidity_pay_taker_fee() -> None:
+    commission = PolymarketFeeModel().get_commission(
+        SimpleNamespace(order_type=OrderType.LIMIT, liquidity_side=LiquiditySide.TAKER),
+        fill_qty=100,
+        fill_px=0.5,
+        instrument=SimpleNamespace(
+            info={"tags": ["Sports"]},
+            taker_fee=Decimal("0.003"),
+            quote_currency=USDC_POS,
+        ),
+    )
+
+    assert commission.as_double() == 0.075
+
+
+def test_limit_fills_with_maker_liquidity_receive_maker_rebate_credit() -> None:
+    commission = PolymarketFeeModel().get_commission(
+        SimpleNamespace(order_type=OrderType.LIMIT, liquidity_side=LiquiditySide.MAKER),
         fill_qty=100,
         fill_px=0.5,
         instrument=SimpleNamespace(
@@ -142,7 +173,7 @@ def test_limit_orders_receive_polymarket_maker_rebate_credit() -> None:
 
 def test_limit_order_maker_rebates_can_be_disabled() -> None:
     commission = PolymarketFeeModel(maker_rebates_enabled=False).get_commission(
-        SimpleNamespace(order_type=OrderType.LIMIT),
+        SimpleNamespace(order_type=OrderType.LIMIT, liquidity_side=LiquiditySide.MAKER),
         fill_qty=100,
         fill_px=0.5,
         instrument=SimpleNamespace(

--- a/tests/test_polymarket_pmxt_cache.py
+++ b/tests/test_polymarket_pmxt_cache.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
+from nautilus_trader.adapters.polymarket.common.parsing import parse_polymarket_instrument
 
 from prediction_market_extensions.adapters.polymarket import pmxt as pmxt_module
 from prediction_market_extensions.adapters.polymarket.pmxt import PolymarketPMXTDataLoader
@@ -108,7 +109,11 @@ def test_load_market_table_prefers_cached_table(tmp_path):
             "data": ['{"token_id":"token-yes-123","payload":"cached"}'],
         }
     )
-    loader._write_market_cache(hour, cached_table)
+    loader._write_market_cache(
+        hour,
+        cached_table,
+        metadata=loader._cache_metadata_for_hour(hour),
+    )
 
     def _fail_remote(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise AssertionError("remote load should not run when cache exists")
@@ -346,6 +351,40 @@ def test_timestamp_to_ns_preserves_decimal_precision() -> None:
     assert PolymarketPMXTDataLoader._timestamp_to_ns(1771767624.001295) == 1_771_767_624_001_295_000
 
 
+def test_timestamp_to_ms_string_preserves_nautilus_event_precision() -> None:
+    instrument = parse_polymarket_instrument(
+        market_info={
+            "condition_id": "0x" + "1" * 64,
+            "question": "Synthetic PMXT precision market",
+            "minimum_tick_size": "0.01",
+            "minimum_order_size": "1",
+            "end_date_iso": "2026-12-31T00:00:00Z",
+            "maker_base_fee": "0",
+            "taker_base_fee": "0",
+        },
+        token_id="2" * 64,
+        outcome="Yes",
+        ts_init=0,
+    )
+    timestamp = 1771767624.001295
+    expected_ns = PolymarketPMXTDataLoader._timestamp_to_ns(timestamp)
+
+    snapshot = PolymarketPMXTDataLoader._to_book_snapshot(
+        PolymarketPMXTDataLoader._decode_book_snapshot(
+            '{"update_type":"book_snapshot","market_id":"0x1111111111111111111111111111111111111111111111111111111111111111",'
+            '"token_id":"2222222222222222222222222222222222222222222222222222222222222222",'
+            '"side":"YES","best_bid":"0.49","best_ask":"0.51","timestamp":1771767624.001295,'
+            '"bids":[["0.49","10"]],"asks":[["0.51","10"]]}'
+        )
+    )
+    deltas = snapshot.parse_to_snapshot(instrument=instrument, ts_init=expected_ns)
+    assert deltas is not None
+    deltas = PolymarketPMXTDataLoader._retimestamp_deltas(deltas, ts_event=expected_ns)
+
+    assert snapshot.timestamp == "1771767624001.295000"
+    assert int(deltas.ts_event) == expected_ns
+
+
 def test_to_book_snapshot_normalizes_book_level_ordering() -> None:
     snapshot = PolymarketPMXTDataLoader._to_book_snapshot(
         PolymarketPMXTDataLoader._decode_book_snapshot(
@@ -565,6 +604,237 @@ def test_load_order_book_deltas_sorts_payloads_before_book_mutation(monkeypatch,
     loader.load_order_book_deltas(hour, hour + pd.Timedelta(hours=1))
 
     assert processed == ["book_snapshot", "price_change"]
+
+
+def test_load_order_book_deltas_skips_exact_duplicate_price_changes(monkeypatch, tmp_path):
+    loader = _make_loader(tmp_path)
+    loader._instrument = SimpleNamespace(id="POLYMARKET.TEST")
+    hour = pd.Timestamp("2026-03-16T12:00:00Z")
+    processed: list[str] = []
+    price_change_payload = (
+        '{"update_type":"price_change","market_id":"condition-123",'
+        '"token_id":"token-yes-123","side":"YES","best_bid":"0.50",'
+        '"best_ask":"0.52","timestamp":2.0,"change_price":"0.52",'
+        '"change_size":"5","change_side":"SELL"}'
+    )
+
+    class _FakeOrderBook:
+        def __init__(self, instrument_id, book_type):  # type: ignore[no-untyped-def]
+            self.instrument_id = instrument_id
+            self.book_type = book_type
+
+    monkeypatch.setattr(pmxt_module, "OrderBook", _FakeOrderBook)
+    loader._archive_hours = lambda _start, _end: [hour]  # type: ignore[method-assign]
+    loader._iter_market_batches = (  # type: ignore[method-assign]
+        lambda hours, *, batch_size: iter(
+            [
+                (
+                    hour,
+                    [
+                        pa.record_batch(
+                            [
+                                pa.array(["book_snapshot", "price_change", "price_change"]),
+                                pa.array(
+                                    [
+                                        (
+                                            '{"update_type":"book_snapshot",'
+                                            '"market_id":"condition-123",'
+                                            '"token_id":"token-yes-123",'
+                                            '"side":"YES","best_bid":"0.49",'
+                                            '"best_ask":"0.51","timestamp":1.0,'
+                                            '"bids":[["0.49","10"]],'
+                                            '"asks":[["0.51","10"]]}'
+                                        ),
+                                        price_change_payload,
+                                        price_change_payload,
+                                    ]
+                                ),
+                            ],
+                            names=["update_type", "data"],
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+    def _process_book_snapshot(  # type: ignore[no-untyped-def]
+        payload_text,
+        *,
+        token_id,
+        instrument,
+        local_book,
+        has_snapshot,
+        events,
+        start_ns,
+        end_ns,
+        include_order_book,
+    ):
+        del payload_text, token_id, instrument, has_snapshot, events, start_ns, end_ns
+        del include_order_book
+        processed.append("book_snapshot")
+        return local_book, True
+
+    def _process_price_change(  # type: ignore[no-untyped-def]
+        payload_text,
+        *,
+        token_id,
+        instrument,
+        local_book,
+        has_snapshot,
+        events,
+        start_ns,
+        end_ns,
+        include_order_book,
+    ):
+        del payload_text, token_id, instrument, has_snapshot, events, start_ns, end_ns
+        del include_order_book
+        processed.append("price_change")
+        return local_book
+
+    monkeypatch.setattr(loader, "_process_book_snapshot", _process_book_snapshot)
+    monkeypatch.setattr(loader, "_process_price_change", _process_price_change)
+
+    loader.load_order_book_deltas(hour, hour + pd.Timedelta(hours=1))
+
+    assert processed == ["book_snapshot", "price_change"]
+
+
+def test_load_order_book_deltas_anchors_pre_window_snapshot_state(monkeypatch, tmp_path):
+    loader = _make_loader(tmp_path)
+    loader._instrument = SimpleNamespace(id="POLYMARKET.TEST")
+    hour = pd.Timestamp("2026-03-16T12:00:00Z")
+
+    class _FakeOrderBook:
+        def __init__(self, instrument_id, book_type):  # type: ignore[no-untyped-def]
+            self.instrument_id = instrument_id
+            self.book_type = book_type
+            self.applied = []
+
+        def apply_deltas(self, deltas):  # type: ignore[no-untyped-def]
+            self.applied.append(deltas)
+
+        def to_deltas_c(self, ts_event, ts_init):  # type: ignore[no-untyped-def]
+            return _FakeOrderBookDeltas(
+                ts_event=int(ts_event),
+                ts_init=int(ts_init),
+                is_snapshot=True,
+                label="anchor",
+            )
+
+    class _FakeOrderBookDeltas:
+        def __init__(
+            self,
+            *,
+            ts_event: int,
+            ts_init: int,
+            is_snapshot: bool,
+            label: str,
+        ) -> None:
+            self.ts_event = ts_event
+            self.ts_init = ts_init
+            self.is_snapshot = is_snapshot
+            self.label = label
+
+    monkeypatch.setattr(pmxt_module, "OrderBook", _FakeOrderBook)
+    loader._archive_hours = lambda _start, _end: [hour]  # type: ignore[method-assign]
+    loader._iter_market_batches = (  # type: ignore[method-assign]
+        lambda hours, *, batch_size: iter(
+            [
+                (
+                    hour,
+                    [
+                        pa.record_batch(
+                            [
+                                pa.array(["book_snapshot", "price_change"]),
+                                pa.array(
+                                    [
+                                        (
+                                            '{"update_type":"book_snapshot",'
+                                            '"market_id":"condition-123",'
+                                            '"token_id":"token-yes-123",'
+                                            '"side":"YES","best_bid":"0.49",'
+                                            '"best_ask":"0.51","timestamp":1.0,'
+                                            '"bids":[["0.49","10"]],'
+                                            '"asks":[["0.51","10"]]}'
+                                        ),
+                                        (
+                                            '{"update_type":"price_change",'
+                                            '"market_id":"condition-123",'
+                                            '"token_id":"token-yes-123",'
+                                            '"side":"YES","best_bid":"0.50",'
+                                            '"best_ask":"0.52","timestamp":2.0,'
+                                            '"change_price":"0.52",'
+                                            '"change_size":"5","change_side":"SELL"}'
+                                        ),
+                                    ]
+                                ),
+                            ],
+                            names=["update_type", "data"],
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+    def _process_book_snapshot(  # type: ignore[no-untyped-def]
+        payload_text,
+        *,
+        token_id,
+        instrument,
+        local_book,
+        has_snapshot,
+        events,
+        start_ns,
+        end_ns,
+        include_order_book,
+    ):
+        del payload_text, token_id, instrument, has_snapshot, end_ns
+        snapshot = _FakeOrderBookDeltas(
+            ts_event=1_000_000_000,
+            ts_init=1_000_000_000,
+            is_snapshot=True,
+            label="pre-window-snapshot",
+        )
+        local_book.apply_deltas(snapshot)
+        if snapshot.ts_event >= start_ns and include_order_book:
+            events.append(snapshot)
+        return local_book, True
+
+    def _process_price_change(  # type: ignore[no-untyped-def]
+        payload_text,
+        *,
+        token_id,
+        instrument,
+        local_book,
+        has_snapshot,
+        events,
+        start_ns,
+        end_ns,
+        include_order_book,
+    ):
+        del payload_text, token_id, instrument, has_snapshot
+        delta = _FakeOrderBookDeltas(
+            ts_event=2_000_000_000,
+            ts_init=2_000_000_000,
+            is_snapshot=False,
+            label="in-window-delta",
+        )
+        local_book.apply_deltas(delta)
+        if start_ns <= delta.ts_event <= end_ns and include_order_book:
+            events.append(delta)
+        return local_book
+
+    monkeypatch.setattr(loader, "_process_book_snapshot", _process_book_snapshot)
+    monkeypatch.setattr(loader, "_process_price_change", _process_price_change)
+
+    data = loader.load_order_book_deltas(
+        pd.Timestamp(1_500_000_000, unit="ns", tz="UTC"),
+        pd.Timestamp(3_000_000_000, unit="ns", tz="UTC"),
+    )
+
+    assert [(record.label, record.is_snapshot) for record in data] == [("anchor", True)]
 
 
 def test_load_order_book_deltas_skips_stale_cross_hour_payloads(monkeypatch, tmp_path):

--- a/tests/test_polymarket_pmxt_runner.py
+++ b/tests/test_polymarket_pmxt_runner.py
@@ -54,8 +54,13 @@ def test_pmxt_runner_uses_l2_execution_settings(monkeypatch):
     assert backtest.data.platform == "polymarket"
     assert backtest.data.data_type == "book"
     assert backtest.data.vendor == "pmxt"
-    assert backtest.execution.queue_position is False
-    assert backtest.execution.build_latency_model() is None
+    assert backtest.execution.queue_position is True
+    latency_model = backtest.execution.build_latency_model()
+    assert latency_model is not None
+    assert latency_model.base_latency_nanos == 75_000_000
+    assert latency_model.insert_latency_nanos == 85_000_000
+    assert latency_model.update_latency_nanos == 80_000_000
+    assert latency_model.cancel_latency_nanos == 80_000_000
 
 
 def test_pmxt_runner_forwards_queue_position_and_latency(monkeypatch):

--- a/tests/test_prediction_market_execution.py
+++ b/tests/test_prediction_market_execution.py
@@ -111,6 +111,31 @@ def test_prediction_market_backtest_build_engine_forwards_execution(monkeypatch)
     assert engine.config.risk_engine.bypass is False
 
 
+def test_prediction_market_backtest_default_execution_is_not_zero_latency(monkeypatch):
+    monkeypatch.setattr(backtest_module, "BacktestEngine", _EngineStub)
+
+    backtest = PredictionMarketBacktest(
+        name="demo",
+        data=MarketDataConfig(platform="polymarket", data_type="book", vendor="pmxt"),
+        replays=(BookReplay(market_slug="demo-market"),),
+        strategy_factory=lambda instrument_id: SimpleNamespace(instrument_id=instrument_id),
+        initial_cash=100.0,
+        probability_window=16,
+    )
+
+    engine = backtest._build_engine()
+
+    assert len(engine.venues) == 1
+    venue_kwargs = engine.venues[0]
+    assert venue_kwargs["queue_position"] is True
+    latency_model = venue_kwargs["latency_model"]
+    assert latency_model is not None
+    assert latency_model.base_latency_nanos == 75_000_000
+    assert latency_model.insert_latency_nanos == 85_000_000
+    assert latency_model.update_latency_nanos == 80_000_000
+    assert latency_model.cancel_latency_nanos == 80_000_000
+
+
 def test_emit_engine_status_uses_nautilus_message_bus() -> None:
     msgbus = _FakeMessageBus()
     logger = _FakeLogger()

--- a/tests/test_prediction_market_order_guard.py
+++ b/tests/test_prediction_market_order_guard.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from nautilus_trader.model.enums import OrderSide, OrderType
+
+from prediction_market_extensions.backtesting._prediction_market_order_guard import (
+    PredictionMarketOrderGuard,
+)
+
+
+class _Money:
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def as_double(self) -> float:
+        return self._value
+
+
+class _Account:
+    def __init__(self, free: float) -> None:
+        self._free = free
+
+    def balance_free(self, currency: object) -> _Money:
+        del currency
+        return _Money(self._free)
+
+
+class _Portfolio:
+    def __init__(self, *, free: float, positions: dict[object, Decimal] | None = None) -> None:
+        self._account = _Account(free)
+        self._positions = positions or {}
+
+    def account(self, *, venue: object) -> _Account:
+        del venue
+        return self._account
+
+    def net_position(self, instrument_id: object) -> Decimal:
+        return self._positions.get(instrument_id, Decimal("0"))
+
+
+class _Cache:
+    def __init__(self, instruments: dict[object, object], prices: dict[object, float]) -> None:
+        self._instruments = instruments
+        self._prices = prices
+        self._orders: dict[object, object] = {}
+
+    def instrument(self, instrument_id: object) -> object:
+        return self._instruments[instrument_id]
+
+    def order_book(self, instrument_id: object) -> object:
+        price = self._prices[instrument_id]
+        return SimpleNamespace(best_ask_price=lambda: price, best_bid_price=lambda: price)
+
+    def order(self, client_order_id: object) -> object | None:
+        return self._orders.get(client_order_id)
+
+
+class _Strategy:
+    def __init__(
+        self,
+        *,
+        instruments: dict[object, object],
+        prices: dict[object, float],
+        free: float,
+        positions: dict[object, Decimal] | None = None,
+    ) -> None:
+        self.cache = _Cache(instruments, prices)
+        self.portfolio = _Portfolio(free=free, positions=positions)
+        self.submitted: list[object] = []
+        self.denied: list[object] = []
+        self.filled: list[object] = []
+        self.reset_count = 0
+
+    def submit_order(self, order: object) -> None:
+        self.submitted.append(order)
+        self.cache._orders[getattr(order, "client_order_id")] = order
+
+    def on_order_denied(self, event: object) -> None:
+        self.denied.append(event)
+
+    def on_order_filled(self, event: object) -> None:
+        self.filled.append(event)
+
+    def on_reset(self) -> None:
+        self.reset_count += 1
+
+
+class _ReentrantFillStrategy(_Strategy):
+    def __init__(self, *, reentrant_order: object, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.reentrant_order = reentrant_order
+
+    def on_order_filled(self, event: object) -> None:
+        super().on_order_filled(event)
+        order = self.reentrant_order
+        self.reentrant_order = None
+        if order is not None:
+            self.submit_order(order)
+
+
+def _instrument(instrument_id: object, *, currency: str = "USDC") -> object:
+    return SimpleNamespace(
+        id=SimpleNamespace(venue="POLYMARKET"),
+        instrument_id=instrument_id,
+        quote_currency=currency,
+        taker_fee=Decimal("0"),
+        maker_fee=Decimal("0"),
+        outcome="Yes",
+    )
+
+
+def _order(
+    client_order_id: str,
+    *,
+    instrument_id: object,
+    side: OrderSide,
+    quantity: float,
+    price: float | None = None,
+    order_type: OrderType = OrderType.MARKET,
+) -> object:
+    return SimpleNamespace(
+        client_order_id=client_order_id,
+        instrument_id=instrument_id,
+        side=side,
+        order_type=order_type,
+        quantity=Decimal(str(quantity)),
+        price=None if price is None else Decimal(str(price)),
+        has_price=lambda: price is not None,
+        ts_init=0,
+    )
+
+
+def test_order_guard_denies_naked_prediction_market_sell() -> None:
+    instrument_id = "market-a"
+    strategy = _Strategy(
+        instruments={instrument_id: _instrument(instrument_id)},
+        prices={instrument_id: 0.50},
+        free=100.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    strategy.submit_order(
+        _order(
+            "sell-1",
+            instrument_id=instrument_id,
+            side=OrderSide.SELL,
+            quantity=5.0,
+            price=0.50,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert strategy.submitted == []
+    assert len(strategy.denied) == 1
+    assert "SELL quantity" in strategy.denied[0].reason
+    assert guard.warnings
+
+
+def test_order_guard_reserves_buy_cash_across_instruments() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.60, market_b: 0.60},
+        free=5.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    strategy.submit_order(
+        _order(
+            "buy-a",
+            instrument_id=market_a,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    strategy.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in strategy.submitted] == ["buy-a"]
+    assert len(strategy.denied) == 1
+    assert "BUY cash cost" in strategy.denied[0].reason
+
+
+def test_order_guard_reserves_buy_cash_across_strategies() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    instruments = {market_a: _instrument(market_a), market_b: _instrument(market_b)}
+    guard = PredictionMarketOrderGuard()
+    first = _Strategy(instruments=instruments, prices={market_a: 0.60, market_b: 0.60}, free=5.0)
+    second = _Strategy(instruments=instruments, prices={market_a: 0.60, market_b: 0.60}, free=5.0)
+    guard.install(first)
+    guard.install(second)
+
+    first.submit_order(
+        _order(
+            "buy-a",
+            instrument_id=market_a,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    second.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in first.submitted] == ["buy-a"]
+    assert second.submitted == []
+    assert len(second.denied) == 1
+    assert "BUY cash cost" in second.denied[0].reason
+
+
+def test_order_guard_releases_buy_cash_reservation_when_order_closes() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.60, market_b: 0.60},
+        free=5.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    first_order = _order(
+        "buy-a",
+        instrument_id=market_a,
+        side=OrderSide.BUY,
+        quantity=5.0,
+        price=0.60,
+        order_type=OrderType.LIMIT,
+    )
+    first_order.is_closed = lambda: True
+    strategy.submit_order(first_order)
+    strategy.on_order_filled(SimpleNamespace(client_order_id="buy-a"))
+    strategy.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in strategy.submitted] == ["buy-a", "buy-b"]
+    assert strategy.denied == []
+
+
+def test_order_guard_releases_closed_reservation_before_fill_handler_reenters() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _ReentrantFillStrategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.60, market_b: 0.60},
+        free=5.0,
+        reentrant_order=_order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        ),
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    first_order = _order(
+        "buy-a",
+        instrument_id=market_a,
+        side=OrderSide.BUY,
+        quantity=5.0,
+        price=0.60,
+        order_type=OrderType.LIMIT,
+    )
+    first_order.is_closed = lambda: True
+    strategy.submit_order(first_order)
+    strategy.on_order_filled(SimpleNamespace(client_order_id="buy-a"))
+
+    assert [order.client_order_id for order in strategy.submitted] == ["buy-a", "buy-b"]
+    assert strategy.denied == []
+
+
+def test_order_guard_reduces_buy_cash_reservation_after_partial_fill() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.50, market_b: 0.50},
+        free=10.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    first_order = _order(
+        "buy-a",
+        instrument_id=market_a,
+        side=OrderSide.BUY,
+        quantity=10.0,
+        price=0.50,
+        order_type=OrderType.LIMIT,
+    )
+    first_order.is_closed = lambda: False
+    strategy.submit_order(first_order)
+    strategy.portfolio._account._free = 7.5
+    strategy.on_order_filled(
+        SimpleNamespace(
+            client_order_id="buy-a",
+            instrument_id=market_a,
+            order_side=OrderSide.BUY,
+            last_qty=Decimal("5"),
+            last_px=Decimal("0.50"),
+        )
+    )
+    strategy.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=8.0,
+            price=0.50,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in strategy.submitted] == ["buy-a", "buy-b"]
+    assert strategy.denied == []
+
+
+def test_order_guard_reduces_sell_inventory_reservation_after_partial_fill() -> None:
+    market_a = "market-a"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a)},
+        prices={market_a: 0.50},
+        free=10.0,
+        positions={market_a: Decimal("10")},
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    first_order = _order(
+        "sell-a",
+        instrument_id=market_a,
+        side=OrderSide.SELL,
+        quantity=8.0,
+        price=0.50,
+        order_type=OrderType.LIMIT,
+    )
+    first_order.is_closed = lambda: False
+    strategy.submit_order(first_order)
+    strategy.portfolio._positions[market_a] = Decimal("6")
+    strategy.on_order_filled(
+        SimpleNamespace(
+            client_order_id="sell-a",
+            instrument_id=market_a,
+            order_side=OrderSide.SELL,
+            last_qty=Decimal("4"),
+            last_px=Decimal("0.50"),
+        )
+    )
+    strategy.submit_order(
+        _order(
+            "sell-b",
+            instrument_id=market_a,
+            side=OrderSide.SELL,
+            quantity=2.0,
+            price=0.50,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in strategy.submitted] == ["sell-a", "sell-b"]
+    assert strategy.denied == []
+
+
+def test_order_guard_updates_buy_cash_reservation_after_partial_fill() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.60, market_b: 0.60},
+        free=5.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    first_order = _order(
+        "buy-a",
+        instrument_id=market_a,
+        side=OrderSide.BUY,
+        quantity=5.0,
+        price=0.60,
+        order_type=OrderType.LIMIT,
+    )
+    first_order.leaves_qty = Decimal("2")
+    first_order.is_closed = lambda: False
+    strategy.submit_order(first_order)
+    strategy.portfolio._account._free = 3.2
+    strategy.on_order_filled(SimpleNamespace(client_order_id="buy-a"))
+    strategy.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=3.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in strategy.submitted] == ["buy-a", "buy-b"]
+    assert strategy.denied == []
+
+
+def test_order_guard_clears_strategy_reservations_on_reset() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.60, market_b: 0.60},
+        free=5.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    strategy.submit_order(
+        _order(
+            "buy-a",
+            instrument_id=market_a,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    strategy.on_reset()
+    strategy.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert strategy.reset_count == 1
+    assert [order.client_order_id for order in strategy.submitted] == ["buy-a", "buy-b"]
+    assert strategy.denied == []
+
+
+def test_order_guard_duplicate_ids_across_strategies_do_not_overwrite_reservations() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    market_c = "market-c"
+    instruments = {
+        market_a: _instrument(market_a),
+        market_b: _instrument(market_b),
+        market_c: _instrument(market_c),
+    }
+    prices = {market_a: 0.60, market_b: 0.60, market_c: 0.60}
+    guard = PredictionMarketOrderGuard()
+    first = _Strategy(instruments=instruments, prices=prices, free=7.0)
+    second = _Strategy(instruments=instruments, prices=prices, free=7.0)
+    third = _Strategy(instruments=instruments, prices=prices, free=7.0)
+    guard.install(first)
+    guard.install(second)
+    guard.install(third)
+
+    first.submit_order(
+        _order(
+            "same-client-id",
+            instrument_id=market_a,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    second.submit_order(
+        _order(
+            "same-client-id",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    third.submit_order(
+        _order(
+            "unique-third-id",
+            instrument_id=market_c,
+            side=OrderSide.BUY,
+            quantity=2.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in first.submitted] == ["same-client-id"]
+    assert [order.client_order_id for order in second.submitted] == ["same-client-id"]
+    assert third.submitted == []
+    assert len(third.denied) == 1
+    assert "BUY cash cost" in third.denied[0].reason
+
+
+def test_order_guard_duplicate_id_denial_does_not_release_original_reservation() -> None:
+    market_a = "market-a"
+    market_b = "market-b"
+    strategy = _Strategy(
+        instruments={market_a: _instrument(market_a), market_b: _instrument(market_b)},
+        prices={market_a: 0.60, market_b: 0.60},
+        free=5.0,
+    )
+    guard = PredictionMarketOrderGuard()
+    guard.install(strategy)
+
+    strategy.submit_order(
+        _order(
+            "same-client-id",
+            instrument_id=market_a,
+            side=OrderSide.BUY,
+            quantity=5.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    strategy.submit_order(
+        _order(
+            "same-client-id",
+            instrument_id=market_a,
+            side=OrderSide.BUY,
+            quantity=1.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+    strategy.submit_order(
+        _order(
+            "buy-b",
+            instrument_id=market_b,
+            side=OrderSide.BUY,
+            quantity=4.0,
+            price=0.60,
+            order_type=OrderType.LIMIT,
+        )
+    )
+
+    assert [order.client_order_id for order in strategy.submitted] == ["same-client-id"]
+    assert len(strategy.denied) == 2
+    assert "duplicate open client_order_id" in strategy.denied[0].reason
+    assert "BUY cash cost" in strategy.denied[1].reason

--- a/tests/test_prediction_market_report_timestamps.py
+++ b/tests/test_prediction_market_report_timestamps.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import math
+import re
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
@@ -11,6 +13,41 @@ from prediction_market_extensions.adapters.prediction_market.research import (
     save_aggregate_backtest_report,
     save_joint_portfolio_backtest_report,
 )
+
+
+def _bokeh_column_source_shapes(html: str, required_key: str) -> list[dict[str, int]]:
+    match = re.search(
+        r'<script type="application/json"[^>]*>\s*(\{.*?\})\s*</script>',
+        html,
+        re.S,
+    )
+    assert match is not None
+    document = json.loads(match.group(1))
+    shapes: list[dict[str, int]] = []
+
+    def visit(value: object) -> None:
+        if isinstance(value, dict):
+            if value.get("name") == "ColumnDataSource":
+                data = value.get("attributes", {}).get("data")
+                if isinstance(data, dict) and data.get("type") == "map":
+                    source_shapes: dict[str, int] = {}
+                    for key, encoded in data.get("entries", []):
+                        if isinstance(encoded, dict) and encoded.get("type") == "ndarray":
+                            shape = encoded.get("shape") or []
+                            if shape:
+                                source_shapes[str(key)] = int(shape[0])
+                        elif isinstance(encoded, list):
+                            source_shapes[str(key)] = len(encoded)
+                    if required_key in source_shapes:
+                        shapes.append(source_shapes)
+            for item in value.values():
+                visit(item)
+        elif isinstance(value, list):
+            for item in value:
+                visit(item)
+
+    visit(document)
+    return shapes
 
 
 def test_save_aggregate_backtest_report_accepts_mixed_iso_timestamp_precision(tmp_path) -> None:
@@ -78,6 +115,81 @@ def test_save_aggregate_backtest_report_accepts_mixed_iso_timestamp_precision(tm
     html = output_path.read_text(encoding="utf-8")
     assert "mixed timestamp precision chart" in html
     assert "market-mixed" in html
+
+
+def test_save_aggregate_backtest_report_html_contains_fill_and_pnl_markers(tmp_path) -> None:
+    pytest.importorskip("bokeh")
+
+    output_path = tmp_path / "aggregate_fill_markers.html"
+    results = [
+        {
+            "slug": "marker-market",
+            "book_events": 10,
+            "fills": 2,
+            "pnl": 2.0,
+            "price_series": [
+                ("2026-03-14T17:57:40+00:00", 0.40),
+                ("2026-03-14T17:58:40+00:00", 0.45),
+            ],
+            "fill_events": [
+                {
+                    "order_id": "fill-buy",
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.40,
+                    "quantity": 5.0,
+                    "timestamp": "2026-03-14T17:57:40+00:00",
+                    "commission": 0.0,
+                },
+                {
+                    "order_id": "fill-sell",
+                    "action": "sell",
+                    "side": "yes",
+                    "price": 0.45,
+                    "quantity": 5.0,
+                    "timestamp": "2026-03-14T17:58:40+00:00",
+                    "commission": 0.0,
+                },
+            ],
+            "pnl_series": [
+                ("2026-03-14T17:57:40+00:00", 0.0),
+                ("2026-03-14T17:58:40+00:00", 2.0),
+            ],
+            "equity_series": [
+                ("2026-03-14T17:57:40+00:00", 100.0),
+                ("2026-03-14T17:58:40+00:00", 102.0),
+            ],
+            "cash_series": [
+                ("2026-03-14T17:57:40+00:00", 98.0),
+                ("2026-03-14T17:58:40+00:00", 102.0),
+            ],
+        }
+    ]
+
+    report_path = save_aggregate_backtest_report(
+        results=results,
+        output_path=output_path,
+        title="aggregate marker chart",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("market_pnl", "yes_price"),
+    )
+
+    assert report_path == str(output_path.resolve())
+    html = output_path.read_text(encoding="utf-8")
+    assert "YES Price" in html
+    assert "Fills (" in html
+    assert "fill_color" in html
+    assert "Profit / Loss" in html
+    assert "pnl_long" in html
+    assert "pnl_short" in html
+    assert "triangle" in html
+    assert "inverted_triangle" in html
+    assert html.count("marker-market") >= 2
+    pnl_sources = _bokeh_column_source_shapes(html, "pnl_long")
+    fill_sources = _bokeh_column_source_shapes(html, "fill_color")
+    assert any(source["pnl_long"] == 2 for source in pnl_sources)
+    assert any(source["fill_color"] == 2 for source in fill_sources)
 
 
 def test_save_aggregate_backtest_report_uses_initial_capital_basis(
@@ -286,6 +398,106 @@ def test_save_aggregate_backtest_report_marks_zero_capital_return_unavailable(
 
     result_kwargs = captured_results[0]
     assert math.isnan(result_kwargs["metrics"]["total_return"])
+
+
+def test_save_joint_portfolio_backtest_report_html_contains_fill_and_pnl_markers(
+    tmp_path,
+) -> None:
+    pytest.importorskip("bokeh")
+
+    output_path = tmp_path / "joint_fill_markers.html"
+    results = [
+        {
+            "sim_label": "joint-win",
+            "book_events": 10,
+            "fills": 1,
+            "pnl": 3.0,
+            "price_series": [
+                ("2026-03-14T17:57:40+00:00", 0.20),
+                ("2026-03-14T17:58:40+00:00", 1.00),
+            ],
+            "fill_events": [
+                {
+                    "order_id": "fill-win",
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.20,
+                    "quantity": 5.0,
+                    "timestamp": "2026-03-14T17:57:40+00:00",
+                    "commission": 0.0,
+                }
+            ],
+            "equity_series": [
+                ("2026-03-14T17:57:40+00:00", 100.0),
+                ("2026-03-14T17:58:40+00:00", 103.0),
+            ],
+            "cash_series": [
+                ("2026-03-14T17:57:40+00:00", 99.0),
+                ("2026-03-14T17:58:40+00:00", 103.0),
+            ],
+            "joint_portfolio_equity_series": [
+                ("2026-03-14T17:57:40+00:00", 100.0),
+                ("2026-03-14T17:58:40+00:00", 101.0),
+            ],
+            "joint_portfolio_cash_series": [
+                ("2026-03-14T17:57:40+00:00", 98.5),
+                ("2026-03-14T17:58:40+00:00", 101.0),
+            ],
+        },
+        {
+            "sim_label": "joint-loss",
+            "book_events": 10,
+            "fills": 1,
+            "pnl": -2.0,
+            "price_series": [
+                ("2026-03-14T17:57:50+00:00", 0.40),
+                ("2026-03-14T17:58:50+00:00", 0.00),
+            ],
+            "fill_events": [
+                {
+                    "order_id": "fill-loss",
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.40,
+                    "quantity": 5.0,
+                    "timestamp": "2026-03-14T17:57:50+00:00",
+                    "commission": 0.0,
+                }
+            ],
+            "equity_series": [
+                ("2026-03-14T17:57:50+00:00", 100.0),
+                ("2026-03-14T17:58:50+00:00", 98.0),
+            ],
+            "cash_series": [
+                ("2026-03-14T17:57:50+00:00", 98.0),
+                ("2026-03-14T17:58:50+00:00", 98.0),
+            ],
+        },
+    ]
+
+    report_path = save_joint_portfolio_backtest_report(
+        results=results,
+        output_path=output_path,
+        title="joint marker chart",
+        market_key="sim_label",
+        pnl_label="PnL (USDC)",
+        plot_panels=("market_pnl", "yes_price"),
+    )
+
+    assert report_path == str(output_path.resolve())
+    html = output_path.read_text(encoding="utf-8")
+    assert "YES Price" in html
+    assert "Fills (" in html
+    assert "fill_color" in html
+    assert "Profit / Loss" in html
+    assert "pnl_long" in html
+    assert "pnl_short" in html
+    assert "joint-win" in html
+    assert "joint-loss" in html
+    pnl_sources = _bokeh_column_source_shapes(html, "pnl_long")
+    fill_sources = _bokeh_column_source_shapes(html, "fill_color")
+    assert any(source["pnl_long"] == 2 for source in pnl_sources)
+    assert any(source["fill_color"] == 2 for source in fill_sources)
 
 
 def test_save_joint_portfolio_backtest_report_uses_initial_capital_basis(

--- a/tests/test_prediction_market_report_timestamps.py
+++ b/tests/test_prediction_market_report_timestamps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
@@ -77,6 +78,290 @@ def test_save_aggregate_backtest_report_accepts_mixed_iso_timestamp_precision(tm
     html = output_path.read_text(encoding="utf-8")
     assert "mixed timestamp precision chart" in html
     assert "market-mixed" in html
+
+
+def test_save_aggregate_backtest_report_uses_initial_capital_basis(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research,
+        "_configure_summary_report_downsampling",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    save_aggregate_backtest_report(
+        results=[
+            {
+                "slug": "first-point-after-fill",
+                "book_events": 2,
+                "fills": 2,
+                "pnl": 1.0,
+                "equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 100.5),
+                    ("2026-04-01T00:02:00+00:00", 101.0),
+                ],
+                "cash_series": [
+                    ("2026-04-01T00:01:00+00:00", 100.5),
+                    ("2026-04-01T00:02:00+00:00", 101.0),
+                ],
+                "pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.5),
+                    ("2026-04-01T00:02:00+00:00", 1.0),
+                ],
+            }
+        ],
+        output_path=tmp_path / "aggregate_initial_basis.html",
+        title="aggregate initial basis",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("total_equity", "total_cash_equity"),
+    )
+
+    assert len(captured_results) == 1
+    result_kwargs = captured_results[0]
+    assert result_kwargs["initial_cash"] == pytest.approx(100.0)
+    assert result_kwargs["final_equity"] == pytest.approx(101.0)
+    assert result_kwargs["metrics"]["total_return"] == pytest.approx(0.01)
+    assert result_kwargs["equity_curve"][0].total_equity == pytest.approx(100.0)
+
+
+def test_save_aggregate_backtest_report_uses_initial_cash_for_pnl_only_series(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research,
+        "_configure_summary_report_downsampling",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    save_aggregate_backtest_report(
+        results=[
+            {
+                "slug": "pnl-only",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 25.0,
+                "initial_cash": 1000.0,
+                "pnl_series": [
+                    ("2026-04-01T00:00:00+00:00", 0.0),
+                    ("2026-04-01T00:01:00+00:00", 25.0),
+                ],
+            }
+        ],
+        output_path=tmp_path / "aggregate_pnl_only.html",
+        title="aggregate pnl only",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("total_equity", "total_cash_equity"),
+    )
+
+    result_kwargs = captured_results[0]
+    assert result_kwargs["initial_cash"] == pytest.approx(1000.0)
+    assert result_kwargs["final_equity"] == pytest.approx(1025.0)
+    assert result_kwargs["metrics"]["total_return"] == pytest.approx(0.025)
+
+
+def test_save_aggregate_backtest_report_marks_zero_capital_return_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research,
+        "_configure_summary_report_downsampling",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    save_aggregate_backtest_report(
+        results=[
+            {
+                "slug": "zero-capital",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 10.0,
+                "initial_cash": 0.0,
+                "equity_series": [
+                    ("2026-04-01T00:00:00+00:00", 0.0),
+                    ("2026-04-01T00:01:00+00:00", 10.0),
+                ],
+            }
+        ],
+        output_path=tmp_path / "aggregate_zero_capital.html",
+        title="aggregate zero capital",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("total_equity", "total_cash_equity"),
+    )
+
+    result_kwargs = captured_results[0]
+    assert math.isnan(result_kwargs["metrics"]["total_return"])
+
+
+def test_save_joint_portfolio_backtest_report_uses_initial_capital_basis(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research,
+        "_configure_summary_report_downsampling",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    save_joint_portfolio_backtest_report(
+        results=[
+            {
+                "slug": "joint-first-point-after-fill",
+                "book_events": 2,
+                "fills": 1,
+                "pnl": 1.0,
+                "joint_portfolio_equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 200.5),
+                    ("2026-04-01T00:02:00+00:00", 201.0),
+                ],
+                "joint_portfolio_cash_series": [
+                    ("2026-04-01T00:01:00+00:00", 200.5),
+                    ("2026-04-01T00:02:00+00:00", 201.0),
+                ],
+                "joint_portfolio_pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.5),
+                    ("2026-04-01T00:02:00+00:00", 1.0),
+                ],
+            }
+        ],
+        output_path=tmp_path / "joint_initial_basis.html",
+        title="joint initial basis",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("total_equity", "total_cash_equity"),
+    )
+
+    assert len(captured_results) == 1
+    result_kwargs = captured_results[0]
+    assert result_kwargs["initial_cash"] == pytest.approx(200.0)
+    assert result_kwargs["final_equity"] == pytest.approx(201.0)
+    assert result_kwargs["metrics"]["total_return"] == pytest.approx(0.005)
+    assert result_kwargs["equity_curve"][0].total_equity == pytest.approx(200.0)
 
 
 def test_save_joint_portfolio_backtest_report_accepts_mixed_iso_timestamp_precision(
@@ -1022,6 +1307,599 @@ def test_save_joint_portfolio_backtest_report_keeps_market_overlays_when_needed(
         "total_brier_advantage": total_brier_panel,
         "brier_advantage": market_brier_panel,
     }
+
+
+def test_summary_brier_panels_exclude_settlement_and_post_settlement_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    total_brier_panel = object()
+    market_brier_panel = object()
+    t_pre = "2026-04-01T00:00:00+00:00"
+    t_settle = "2026-04-01T00:01:00+00:00"
+    t_post = "2026-04-01T00:02:00+00:00"
+
+    def _capture_total(frame):
+        captured["total"] = frame.copy()
+        return total_brier_panel
+
+    def _capture_market(frames, **kwargs):
+        captured["market"] = {key: frame.copy() for key, frame in frames.items()}
+        return market_brier_panel
+
+    monkeypatch.setattr(research.legacy_plot_adapter, "_build_total_brier_panel", _capture_total)
+    monkeypatch.setattr(research, "_build_summary_brier_panel", _capture_market)
+
+    panels = research._build_summary_brier_extra_panels(
+        results=[
+            {
+                "slug": "settlement-brier",
+                "fills": 0,
+                "pnl": 0.0,
+                "user_probability_series": [(t_pre, 0.55), (t_settle, 0.55), (t_post, 0.55)],
+                "market_probability_series": [(t_pre, 0.60), (t_settle, 1.0), (t_post, 1.0)],
+                "outcome_series": [(t_pre, 1.0), (t_settle, 1.0), (t_post, 1.0)],
+                "settlement_pnl_applied": True,
+                "settlement_series_time": t_settle,
+            }
+        ],
+        market_key="slug",
+        resolved_plot_panels=("total_brier_advantage", "brier_advantage"),
+        max_points_per_market=400,
+    )
+
+    expected_advantage = (0.60 - 1.0) ** 2 - (0.55 - 1.0) ** 2
+    total_frame = captured["total"]
+    market_frame = captured["market"]["settlement-brier"]
+
+    assert panels == {
+        "total_brier_advantage": total_brier_panel,
+        "brier_advantage": market_brier_panel,
+    }
+    assert len(total_frame) == 1
+    assert len(market_frame) == 1
+    assert total_frame["cumulative_brier_advantage"].iloc[-1] == pytest.approx(expected_advantage)
+    assert market_frame["cumulative_brier_advantage"].iloc[-1] == pytest.approx(expected_advantage)
+
+
+def test_save_joint_portfolio_backtest_report_disambiguates_duplicate_market_labels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+                Side=SimpleNamespace(YES="yes", NO="no"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    save_joint_portfolio_backtest_report(
+        results=[
+            {
+                "slug": "same-market",
+                "instrument_id": "PM-SAME-YES.POLYMARKET",
+                "outcome": "Yes",
+                "fills": 0,
+                "pnl": 1.0,
+                "price_series": [
+                    ("2026-03-14T17:57:40+00:00", 0.40),
+                    ("2026-03-14T17:58:40+00:00", 0.42),
+                ],
+                "equity_series": [
+                    ("2026-03-14T17:57:40+00:00", 100.0),
+                    ("2026-03-14T17:58:40+00:00", 101.0),
+                ],
+                "cash_series": [
+                    ("2026-03-14T17:57:40+00:00", 96.0),
+                    ("2026-03-14T17:58:40+00:00", 96.0),
+                ],
+                "joint_portfolio_equity_series": [
+                    ("2026-03-14T17:57:40+00:00", 100.0),
+                    ("2026-03-14T17:58:40+00:00", 103.0),
+                ],
+                "joint_portfolio_cash_series": [
+                    ("2026-03-14T17:57:40+00:00", 96.0),
+                    ("2026-03-14T17:58:40+00:00", 96.0),
+                ],
+            },
+            {
+                "slug": "same-market",
+                "instrument_id": "PM-SAME-NO.POLYMARKET",
+                "outcome": "No",
+                "fills": 0,
+                "pnl": 2.0,
+                "price_series": [
+                    ("2026-03-14T17:57:40+00:00", 0.60),
+                    ("2026-03-14T17:58:40+00:00", 0.58),
+                ],
+                "equity_series": [
+                    ("2026-03-14T17:57:40+00:00", 100.0),
+                    ("2026-03-14T17:58:40+00:00", 102.0),
+                ],
+                "cash_series": [
+                    ("2026-03-14T17:57:40+00:00", 99.0),
+                    ("2026-03-14T17:58:40+00:00", 99.0),
+                ],
+            },
+        ],
+        output_path=tmp_path / "joint_duplicate_labels.html",
+        title="joint duplicate labels",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("yes_price", "equity", "cash_equity"),
+    )
+
+    result_kwargs = captured_results[0]
+    expected_labels = {"same-market (Yes)", "same-market (No)"}
+    assert set(result_kwargs["market_prices"]) == expected_labels
+    assert set(result_kwargs["overlay_series"]["equity"]) == expected_labels
+    assert set(result_kwargs["overlay_series"]["cash"]) == expected_labels
+    assert result_kwargs["market_pnls"] == {
+        "same-market (Yes)": 1.0,
+        "same-market (No)": 2.0,
+    }
+
+
+def test_save_joint_portfolio_backtest_report_stops_counting_settled_market_active(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    times = [
+        "2026-03-14T12:00:00+00:00",
+        "2026-03-14T12:01:00+00:00",
+        "2026-03-14T12:02:00+00:00",
+        "2026-03-14T12:03:00+00:00",
+    ]
+    save_joint_portfolio_backtest_report(
+        results=[
+            {
+                "slug": "settled-market",
+                "fills": 1,
+                "pnl": 1.0,
+                "settlement_pnl_applied": True,
+                "settlement_series_time": times[1],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+                "joint_portfolio_equity_series": [(ts, 200.0) for ts in times],
+                "joint_portfolio_cash_series": [(ts, 200.0) for ts in times],
+            },
+            {
+                "slug": "open-market",
+                "fills": 1,
+                "pnl": 0.0,
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+            },
+        ],
+        output_path=tmp_path / "joint_settled_active_count.html",
+        title="joint settled active count",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("equity", "cash_equity"),
+    )
+
+    snapshots = captured_results[0]["equity_curve"]
+    counts_by_time = {
+        snapshot.timestamp.replace(tzinfo=UTC).isoformat(): snapshot.num_positions
+        for snapshot in snapshots
+    }
+    assert counts_by_time == {
+        times[0]: 2,
+        times[1]: 1,
+        times[2]: 1,
+        times[3]: 1,
+    }
+    settled_overlay = captured_results[0]["overlay_series"]["equity"]["settled-market"]
+    assert settled_overlay.iloc[0] == pytest.approx(100.0)
+    assert settled_overlay.iloc[1] == pytest.approx(100.0)
+    assert settled_overlay.iloc[2:].isna().all()
+
+
+def test_save_joint_portfolio_backtest_report_starts_active_count_at_first_fill(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    times = [
+        "2026-03-14T12:00:00+00:00",
+        "2026-03-14T12:01:00+00:00",
+        "2026-03-14T12:02:00+00:00",
+    ]
+    save_joint_portfolio_backtest_report(
+        results=[
+            {
+                "slug": "filled-after-start",
+                "fills": 1,
+                "pnl": 1.0,
+                "settlement_pnl_applied": True,
+                "settlement_series_time": times[2],
+                "fill_events": [
+                    {
+                        "action": "buy",
+                        "side": "yes",
+                        "price": 0.5,
+                        "quantity": 1.0,
+                        "timestamp": times[1],
+                    }
+                ],
+                "price_series": [(ts, 0.5) for ts in times],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+                "joint_portfolio_equity_series": [(ts, 100.0) for ts in times],
+                "joint_portfolio_cash_series": [(ts, 100.0) for ts in times],
+            }
+        ],
+        output_path=tmp_path / "joint_fill_start_active_count.html",
+        title="joint fill start active count",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("equity", "cash_equity"),
+    )
+
+    snapshots = captured_results[0]["equity_curve"]
+    counts_by_time = {
+        snapshot.timestamp.replace(tzinfo=UTC).isoformat(): snapshot.num_positions
+        for snapshot in snapshots
+    }
+    assert counts_by_time[times[0]] == 0
+    assert counts_by_time[times[1]] == 1
+    assert counts_by_time[times[2]] == 0
+
+
+def test_save_joint_portfolio_backtest_report_does_not_count_no_fill_market_as_position(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    times = [
+        "2026-03-14T12:00:00+00:00",
+        "2026-03-14T12:01:00+00:00",
+        "2026-03-14T12:02:00+00:00",
+    ]
+    save_joint_portfolio_backtest_report(
+        results=[
+            {
+                "slug": "traded-market",
+                "fills": 1,
+                "pnl": 1.0,
+                "settlement_pnl_applied": True,
+                "settlement_series_time": times[1],
+                "fill_events": [
+                    {
+                        "action": "buy",
+                        "side": "yes",
+                        "price": 0.5,
+                        "quantity": 1.0,
+                        "timestamp": times[0],
+                    }
+                ],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+                "joint_portfolio_equity_series": [(ts, 200.0) for ts in times],
+                "joint_portfolio_cash_series": [(ts, 200.0) for ts in times],
+            },
+            {
+                "slug": "no-fill-market",
+                "fills": 0,
+                "pnl": 0.0,
+                "fill_events": [],
+                "price_series": [(ts, 0.5) for ts in times],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+            },
+        ],
+        output_path=tmp_path / "joint_no_fill_position_count.html",
+        title="joint no-fill position count",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("equity", "cash_equity"),
+    )
+
+    snapshots = captured_results[0]["equity_curve"]
+    counts_by_time = {
+        snapshot.timestamp.replace(tzinfo=UTC).isoformat(): snapshot.num_positions
+        for snapshot in snapshots
+    }
+    assert counts_by_time == {
+        times[0]: 1,
+        times[1]: 0,
+        times[2]: 0,
+    }
+
+
+def test_save_aggregate_backtest_report_does_not_count_no_fill_market_as_position(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "_build_summary_brier_extra_panels",
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    times = [
+        "2026-03-14T12:00:00+00:00",
+        "2026-03-14T12:01:00+00:00",
+        "2026-03-14T12:02:00+00:00",
+    ]
+    save_aggregate_backtest_report(
+        results=[
+            {
+                "slug": "traded-market",
+                "fills": 1,
+                "pnl": 1.0,
+                "settlement_pnl_applied": True,
+                "settlement_series_time": times[1],
+                "fill_events": [
+                    {
+                        "action": "buy",
+                        "side": "yes",
+                        "price": 0.5,
+                        "quantity": 1.0,
+                        "timestamp": times[0],
+                    }
+                ],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+                "pnl_series": [(ts, 0.0) for ts in times],
+            },
+            {
+                "slug": "no-fill-market",
+                "fills": 0,
+                "pnl": 0.0,
+                "fill_events": [],
+                "price_series": [(ts, 0.5) for ts in times],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+                "pnl_series": [(ts, 0.0) for ts in times],
+            },
+        ],
+        output_path=tmp_path / "aggregate_no_fill_position_count.html",
+        title="aggregate no-fill position count",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("equity", "cash_equity"),
+    )
+
+    snapshots = captured_results[0]["equity_curve"]
+    counts_by_time = {
+        snapshot.timestamp.replace(tzinfo=UTC).isoformat(): snapshot.num_positions
+        for snapshot in snapshots
+    }
+    assert counts_by_time[times[0]] == 1
+    assert counts_by_time[times[1]] == 0
+    assert counts_by_time[times[2]] == 0
+
+
+def test_save_aggregate_backtest_report_starts_active_count_at_first_fill(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured_results: list[dict[str, object]] = []
+
+    class _BacktestResult:
+        def __init__(self, **kwargs) -> None:
+            captured_results.append(kwargs)
+
+    def _snapshot(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_load_legacy_modules",
+        lambda: (
+            SimpleNamespace(
+                BacktestResult=_BacktestResult,
+                PortfolioSnapshot=_snapshot,
+                Platform=SimpleNamespace(POLYMARKET="POLYMARKET"),
+            ),
+            SimpleNamespace(plot=lambda *args, **kwargs: object()),
+        ),
+    )
+    monkeypatch.setattr(
+        research.legacy_plot_adapter,
+        "_apply_layout_overrides",
+        lambda layout, initial_cash, **kwargs: layout,
+    )
+    monkeypatch.setattr(
+        research,
+        "_build_summary_brier_extra_panels",
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(
+        research,
+        "save_legacy_backtest_layout",
+        lambda layout, output_path, title: str(output_path),
+    )
+
+    times = [
+        "2026-03-14T12:00:00+00:00",
+        "2026-03-14T12:01:00+00:00",
+        "2026-03-14T12:02:00+00:00",
+    ]
+    save_aggregate_backtest_report(
+        results=[
+            {
+                "slug": "filled-after-start",
+                "fills": 1,
+                "pnl": 1.0,
+                "settlement_pnl_applied": True,
+                "settlement_series_time": times[2],
+                "fill_events": [
+                    {
+                        "action": "buy",
+                        "side": "yes",
+                        "price": 0.5,
+                        "quantity": 1.0,
+                        "timestamp": times[1],
+                    }
+                ],
+                "price_series": [(ts, 0.5) for ts in times],
+                "equity_series": [(ts, 100.0) for ts in times],
+                "cash_series": [(ts, 100.0) for ts in times],
+                "pnl_series": [(ts, 0.0) for ts in times],
+            }
+        ],
+        output_path=tmp_path / "aggregate_fill_start_active_count.html",
+        title="aggregate fill start active count",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("equity", "cash_equity"),
+    )
+
+    snapshots = captured_results[0]["equity_curve"]
+    counts_by_time = {
+        snapshot.timestamp.replace(tzinfo=UTC).isoformat(): snapshot.num_positions
+        for snapshot in snapshots
+    }
+    assert counts_by_time[times[0]] == 0
+    assert counts_by_time[times[1]] == 1
+    assert counts_by_time[times[2]] == 0
 
 
 def test_save_joint_portfolio_backtest_report_renders_market_overlay_labels(tmp_path) -> None:

--- a/tests/test_prediction_market_report_timestamps.py
+++ b/tests/test_prediction_market_report_timestamps.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import base64
+import gzip
 import json
 import math
 import re
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from prediction_market_extensions.adapters.prediction_market import research
@@ -15,7 +18,21 @@ from prediction_market_extensions.adapters.prediction_market.research import (
 )
 
 
-def _bokeh_column_source_shapes(html: str, required_key: str) -> list[dict[str, int]]:
+def _decode_bokeh_value(value: object) -> object:
+    if isinstance(value, dict) and value.get("type") == "ndarray":
+        array = value.get("array")
+        if isinstance(array, dict) and array.get("type") == "bytes":
+            raw = gzip.decompress(base64.b64decode(str(array["data"])))
+            dtype = np.dtype(str(value["dtype"])).newbyteorder(
+                ">" if value.get("order") == "big" else "<"
+            )
+            return np.frombuffer(raw, dtype=dtype).reshape(value["shape"]).tolist()
+        if isinstance(array, list):
+            return array
+    return value
+
+
+def _bokeh_column_sources(html: str, required_key: str) -> list[dict[str, object]]:
     match = re.search(
         r'<script type="application/json"[^>]*>\s*(\{.*?\})\s*</script>',
         html,
@@ -23,23 +40,19 @@ def _bokeh_column_source_shapes(html: str, required_key: str) -> list[dict[str, 
     )
     assert match is not None
     document = json.loads(match.group(1))
-    shapes: list[dict[str, int]] = []
+    sources: list[dict[str, object]] = []
 
     def visit(value: object) -> None:
         if isinstance(value, dict):
             if value.get("name") == "ColumnDataSource":
                 data = value.get("attributes", {}).get("data")
                 if isinstance(data, dict) and data.get("type") == "map":
-                    source_shapes: dict[str, int] = {}
-                    for key, encoded in data.get("entries", []):
-                        if isinstance(encoded, dict) and encoded.get("type") == "ndarray":
-                            shape = encoded.get("shape") or []
-                            if shape:
-                                source_shapes[str(key)] = int(shape[0])
-                        elif isinstance(encoded, list):
-                            source_shapes[str(key)] = len(encoded)
-                    if required_key in source_shapes:
-                        shapes.append(source_shapes)
+                    source = {
+                        str(key): _decode_bokeh_value(encoded)
+                        for key, encoded in data.get("entries", [])
+                    }
+                    if required_key in source:
+                        sources.append(source)
             for item in value.values():
                 visit(item)
         elif isinstance(value, list):
@@ -47,6 +60,18 @@ def _bokeh_column_source_shapes(html: str, required_key: str) -> list[dict[str, 
                 visit(item)
 
     visit(document)
+    return sources
+
+
+def _bokeh_column_source_shapes(html: str, required_key: str) -> list[dict[str, int]]:
+    shapes: list[dict[str, int]] = []
+    for source in _bokeh_column_sources(html, required_key):
+        source_shapes: dict[str, int] = {}
+        for key, decoded in source.items():
+            if isinstance(decoded, list):
+                source_shapes[key] = len(decoded)
+        if required_key in source_shapes:
+            shapes.append(source_shapes)
     return shapes
 
 
@@ -190,6 +215,77 @@ def test_save_aggregate_backtest_report_html_contains_fill_and_pnl_markers(tmp_p
     fill_sources = _bokeh_column_source_shapes(html, "fill_color")
     assert any(source["pnl_long"] == 2 for source in pnl_sources)
     assert any(source["fill_color"] == 2 for source in fill_sources)
+
+
+def test_save_aggregate_backtest_report_html_preserves_fill_values_and_sides(tmp_path) -> None:
+    pytest.importorskip("bokeh")
+
+    output_path = tmp_path / "aggregate_exact_fill_markers.html"
+    results = [
+        {
+            "slug": "marker-market",
+            "book_events": 10,
+            "fills": 1,
+            "pnl": -0.25,
+            "price_series": [
+                ("2026-03-14T17:57:00+00:00", 0.20),
+                ("2026-03-14T17:58:00+00:00", 0.30),
+            ],
+            "fill_events": [
+                {
+                    "order_id": "fill-buy-no",
+                    "market_id": "raw-opaque-instrument",
+                    "action": "buy",
+                    "side": "no",
+                    "price": 0.05,
+                    "quantity": 5.0,
+                    "timestamp": "2026-03-14T17:57:30+00:00",
+                    "commission": 0.0,
+                },
+            ],
+            "pnl_series": [
+                ("2026-03-14T17:57:00+00:00", 0.0),
+                ("2026-03-14T17:58:00+00:00", -0.25),
+            ],
+            "equity_series": [
+                ("2026-03-14T17:57:00+00:00", 100.0),
+                ("2026-03-14T17:58:00+00:00", 99.75),
+            ],
+            "cash_series": [
+                ("2026-03-14T17:57:00+00:00", 100.0),
+                ("2026-03-14T17:58:00+00:00", 99.75),
+            ],
+        }
+    ]
+
+    report_path = save_aggregate_backtest_report(
+        results=results,
+        output_path=output_path,
+        title="aggregate exact marker chart",
+        market_key="slug",
+        pnl_label="PnL (USDC)",
+        plot_panels=("yes_price",),
+    )
+
+    assert report_path == str(output_path.resolve())
+    html = output_path.read_text(encoding="utf-8")
+    fill_source = next(
+        source
+        for source in _bokeh_column_sources(html, "fill_color")
+        if source.get("market_id") == ["marker-market"]
+    )
+    assert fill_source["action"] == ["buy"]
+    assert fill_source["side"] == ["no"]
+    assert fill_source["price"] == pytest.approx([0.05])
+    assert fill_source["quantity"] == pytest.approx([5.0])
+
+    price_source = next(
+        source
+        for source in _bokeh_column_sources(html, "price_marker-market")
+        if "price_marker-market" in source
+    )
+    fill_bar = int(fill_source["index"][0])  # type: ignore[index]
+    assert price_source["price_marker-market"][fill_bar] == pytest.approx(0.05)  # type: ignore[index]
 
 
 def test_save_aggregate_backtest_report_uses_initial_capital_basis(

--- a/tests/test_prediction_market_summary_stats.py
+++ b/tests/test_prediction_market_summary_stats.py
@@ -112,3 +112,335 @@ def test_print_backtest_summary_aligns_count_header_with_values(capsys) -> None:
 
     assert count_value_end == count_header_end
     assert fills_value_end == fills_header_end
+
+
+def test_print_backtest_summary_disambiguates_duplicate_market_labels(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "same-market",
+                "outcome": "Yes",
+                "book_events": 10,
+                "fills": 1,
+                "pnl": 1.0,
+                "fill_events": [],
+            },
+            {
+                "slug": "same-market",
+                "outcome": "No",
+                "book_events": 11,
+                "fills": 1,
+                "pnl": -0.5,
+                "fill_events": [],
+            },
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+
+    assert "same-market (Yes)" in output
+    assert "same-market (No)" in output
+
+
+def test_print_backtest_summary_disambiguates_duplicate_labels_by_realized_outcome(
+    capsys,
+) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "same-market",
+                "realized_outcome": "yes",
+                "book_events": 10,
+                "fills": 0,
+                "pnl": 1.0,
+                "fill_events": [],
+            },
+            {
+                "slug": "same-market",
+                "realized_outcome": "no",
+                "book_events": 11,
+                "fills": 0,
+                "pnl": -0.5,
+                "fill_events": [],
+            },
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+
+    assert "same-market (yes)" in output
+    assert "same-market (no)" in output
+
+
+def test_print_backtest_summary_uses_cash_series_when_equity_is_missing(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "cash-only",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 5.0,
+                "fill_events": [],
+                "cash_series": [
+                    ("2026-04-01T00:00:00+00:00", 100.0),
+                    ("2026-04-01T00:01:00+00:00", 105.0),
+                ],
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    row = next(line for line in output.splitlines() if line.startswith("cash-only"))
+    total_line = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "+5.00%" in row
+    assert "+5.00%" in total_line
+
+
+def test_print_backtest_summary_uses_explicit_initial_cash_for_pnl_only_series(
+    capsys,
+) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "pnl-only",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 25.0,
+                "initial_cash": 1000.0,
+                "fill_events": [],
+                "pnl_series": [
+                    ("2026-04-01T00:00:00+00:00", 0.0),
+                    ("2026-04-01T00:01:00+00:00", 25.0),
+                ],
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    row = next(line for line in output.splitlines() if line.startswith("pnl-only"))
+    total_line = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "+2.50%" in row
+    assert "+2.50%" in total_line
+
+
+def test_print_backtest_summary_returns_na_for_non_positive_initial_capital(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "negative-capital",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 10.0,
+                "initial_cash": -100.0,
+                "fill_events": [],
+                "equity_series": [
+                    ("2026-04-01T00:00:00+00:00", -100.0),
+                    ("2026-04-01T00:01:00+00:00", -90.0),
+                ],
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    row = next(line for line in output.splitlines() if line.startswith("negative-capital"))
+
+    assert " n/a " in row
+
+
+def test_print_backtest_summary_total_return_sums_per_market_equity(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "summary-a",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 10.0,
+                "fill_events": [],
+                "equity_series": [
+                    ("2026-04-01T00:00:00+00:00", 100.0),
+                    ("2026-04-01T00:01:00+00:00", 110.0),
+                ],
+            },
+            {
+                "slug": "summary-b",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 0.0,
+                "fill_events": [],
+                "equity_series": [
+                    ("2026-04-01T00:00:00+00:00", 100.0),
+                    ("2026-04-01T00:01:00+00:00", 100.0),
+                ],
+            },
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    total_line = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "+5.00%" in total_line
+
+
+def test_print_backtest_summary_total_return_uses_initial_capital_basis(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "after-fill-first-point",
+                "book_events": 2,
+                "fills": 2,
+                "pnl": 1.0,
+                "fill_events": [],
+                "equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 100.5),
+                    ("2026-04-01T00:02:00+00:00", 101.0),
+                ],
+                "pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.5),
+                    ("2026-04-01T00:02:00+00:00", 1.0),
+                ],
+            },
+            {
+                "slug": "idle",
+                "book_events": 2,
+                "fills": 0,
+                "pnl": 0.0,
+                "fill_events": [],
+                "equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 100.0),
+                    ("2026-04-01T00:02:00+00:00", 100.0),
+                ],
+                "pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.0),
+                    ("2026-04-01T00:02:00+00:00", 0.0),
+                ],
+            },
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    total_line = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "+0.50%" in total_line
+
+
+def test_print_backtest_summary_market_row_uses_initial_capital_basis(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "after-fill-first-point",
+                "book_events": 2,
+                "fills": 2,
+                "pnl": 1.0,
+                "fill_events": [],
+                "equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 100.5),
+                    ("2026-04-01T00:02:00+00:00", 101.0),
+                ],
+                "pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.5),
+                    ("2026-04-01T00:02:00+00:00", 1.0),
+                ],
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    row = next(line for line in output.splitlines() if line.startswith("after-fill-first-point"))
+
+    assert "+1.00%" in row
+
+
+def test_print_backtest_summary_joint_total_uses_initial_capital_basis(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "joint-after-fill-first-point",
+                "book_events": 2,
+                "fills": 1,
+                "pnl": 1.0,
+                "fill_events": [],
+                "joint_portfolio_equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 100.5),
+                    ("2026-04-01T00:02:00+00:00", 101.0),
+                ],
+                "joint_portfolio_pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.5),
+                    ("2026-04-01T00:02:00+00:00", 1.0),
+                ],
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    total_line = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "+1.00%" in total_line
+
+
+def test_print_backtest_summary_joint_total_return_uses_initial_capital_basis(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "joint-after-fill",
+                "book_events": 2,
+                "fills": 1,
+                "pnl": 1.0,
+                "fill_events": [],
+                "joint_portfolio_equity_series": [
+                    ("2026-04-01T00:01:00+00:00", 200.5),
+                    ("2026-04-01T00:02:00+00:00", 201.0),
+                ],
+                "joint_portfolio_pnl_series": [
+                    ("2026-04-01T00:01:00+00:00", 0.5),
+                    ("2026-04-01T00:02:00+00:00", 1.0),
+                ],
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (USDC)",
+    )
+
+    output = capsys.readouterr().out
+    total_line = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "+0.50%" in total_line

--- a/tests/test_profile_replay.py
+++ b/tests/test_profile_replay.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.identifiers import InstrumentId, Symbol, Venue
+
+from prediction_market_extensions.backtesting import profile_replay
+from prediction_market_extensions.backtesting.profile_replay import (
+    ProfileTradeGroup,
+    append_profile_replay_diagnostics,
+    build_profile_replays,
+    fetch_profile_trades,
+    normalize_profile_trades,
+    profile_actual_pnl,
+    profile_replay_key,
+    profile_trades_by_key,
+    select_profile_trade_groups,
+)
+from strategies.profile_replay import BookProfileReplayConfig, BookProfileReplayStrategy
+
+INSTRUMENT_ID = InstrumentId(Symbol("PM-TEST-YES"), Venue("POLYMARKET"))
+
+
+def _payload(
+    *,
+    slug: str = "btc-updown-5m-1777241400",
+    outcome_index: int = 1,
+    side: str,
+    size: float,
+    price: float,
+    timestamp: int,
+    transaction_hash: str = "0x1",
+) -> dict[str, object]:
+    return {
+        "side": side,
+        "size": size,
+        "price": price,
+        "timestamp": timestamp,
+        "slug": slug,
+        "outcome": "Down" if outcome_index == 1 else "Up",
+        "outcomeIndex": outcome_index,
+        "title": "Bitcoin Up or Down",
+        "transactionHash": transaction_hash,
+    }
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_fetch_profile_trades_sends_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request: object, *, timeout: float) -> _FakeResponse:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            b'[{"slug":"btc-updown-5m-1777241400","outcomeIndex":1,'
+            b'"side":"BUY","size":1,"price":0.5,"timestamp":1777241401}]'
+        )
+
+    monkeypatch.setattr(profile_replay, "urlopen", fake_urlopen)
+
+    trades = fetch_profile_trades(user="0xabc", limit=12, timeout_seconds=3.0)
+
+    request = captured["request"]
+    assert "user=0xabc" in request.full_url
+    assert "limit=12" in request.full_url
+    assert request.get_header("User-agent") == profile_replay.PROFILE_REPLAY_USER_AGENT
+    assert captured["timeout"] == 3.0
+    assert len(trades) == 1
+
+
+def test_select_profile_trade_groups_rejects_groups_requiring_prior_inventory() -> None:
+    trades = normalize_profile_trades(
+        [
+            _payload(side="SELL", size=5, price=0.51, timestamp=100, transaction_hash="0xsell"),
+            _payload(side="BUY", size=5, price=0.49, timestamp=101, transaction_hash="0xbuy"),
+        ]
+    )
+
+    groups = select_profile_trade_groups(trades, max_groups=1)
+
+    assert groups == ()
+
+
+def test_build_profile_replays_infers_btc_window_from_slug() -> None:
+    trades = normalize_profile_trades(
+        [_payload(side="BUY", size=10, price=0.5, timestamp=1777241444)]
+    )
+    group = ProfileTradeGroup("btc-updown-5m-1777241400", 1, trades)
+
+    replays = build_profile_replays(
+        [group],
+        profile_user="0xabc",
+        lead_time_seconds=2,
+        start_buffer_seconds=10,
+        end_buffer_seconds=20,
+    )
+
+    assert len(replays) == 1
+    assert replays[0].market_slug == "btc-updown-5m-1777241400"
+    assert replays[0].token_index == 1
+    assert replays[0].start_time == pd.Timestamp(1777241400 - 12, unit="s", tz="UTC")
+    assert replays[0].end_time == pd.Timestamp(1777241400 + 300 + 20, unit="s", tz="UTC")
+    assert replays[0].metadata["profile_replay_key"] == "btc-updown-5m-1777241400:1"
+
+
+def test_profile_actual_pnl_includes_binary_settlement_value() -> None:
+    trades = normalize_profile_trades(
+        [
+            _payload(side="BUY", size=10, price=0.40, timestamp=100, transaction_hash="0xbuy"),
+            _payload(side="SELL", size=4, price=0.60, timestamp=101, transaction_hash="0xsell"),
+        ]
+    )
+
+    winning = profile_actual_pnl(trades, realized_outcome=1.0)
+    losing = profile_actual_pnl(trades, realized_outcome=0.0)
+
+    assert winning["profile_trade_cashflow"] == pytest.approx(-1.6)
+    assert winning["profile_open_quantity"] == pytest.approx(6.0)
+    assert winning["profile_actual_pnl"] == pytest.approx(4.4)
+    assert losing["profile_actual_pnl"] == pytest.approx(-1.6)
+
+
+def test_append_profile_replay_diagnostics_compares_actual_and_backtest_pnl() -> None:
+    trades = normalize_profile_trades([_payload(side="BUY", size=10, price=0.40, timestamp=100)])
+    group = ProfileTradeGroup("btc-updown-5m-1777241400", 1, trades)
+
+    enriched = append_profile_replay_diagnostics(
+        [
+            {
+                "profile_replay_key": group.key,
+                "realized_outcome": 1.0,
+                "pnl": 5.5,
+            }
+        ],
+        [group],
+    )
+
+    assert enriched[0]["profile_actual_pnl"] == pytest.approx(6.0)
+    assert enriched[0]["profile_pnl_error"] == pytest.approx(-0.5)
+
+
+def test_profile_trades_by_key_preserves_trade_schedule_payload() -> None:
+    trades = normalize_profile_trades(
+        [
+            _payload(
+                side="BUY",
+                size=1.25,
+                price=0.50,
+                timestamp=100,
+                transaction_hash="0xbuy",
+            )
+        ]
+    )
+    group = ProfileTradeGroup("btc-updown-5m-1777241400", 1, trades)
+
+    trades_by_key = profile_trades_by_key([group])
+
+    assert set(trades_by_key) == {profile_replay_key(slug=group.slug, outcome_index=1)}
+    assert trades_by_key[group.key] == [
+        {
+            "side": "BUY",
+            "size": 1.25,
+            "price": 0.5,
+            "timestamp_ns": trades[0].timestamp_ns,
+            "transaction_hash": "0xbuy",
+        }
+    ]
+
+
+class _ScheduleHarness(BookProfileReplayStrategy):
+    def __init__(self, config: BookProfileReplayConfig) -> None:
+        super().__init__(config)
+        self.submitted: list[object] = []
+
+    def _submit_scheduled_order(self, scheduled_order: object) -> None:
+        self.submitted.append(scheduled_order)
+
+
+def test_profile_replay_strategy_submits_orders_only_after_lead_time() -> None:
+    strategy = _ScheduleHarness(
+        BookProfileReplayConfig(
+            instrument_id=INSTRUMENT_ID,
+            selection_key="profile",
+            trades_by_key={
+                "profile": [
+                    {"side": "BUY", "size": 1, "price": 0.50, "timestamp_ns": 2_000_000_000},
+                    {"side": "SELL", "size": 1, "price": 0.55, "timestamp_ns": 3_000_000_000},
+                ]
+            },
+            lead_time_seconds=1.0,
+        )
+    )
+
+    strategy._submit_due_orders(ts_event_ns=999_999_999)
+    assert strategy.submitted == []
+
+    strategy._submit_due_orders(ts_event_ns=1_000_000_000)
+    assert [order.side for order in strategy.submitted] == [OrderSide.BUY]
+
+    strategy._submit_due_orders(ts_event_ns=2_000_000_000)
+    assert [order.side for order in strategy.submitted] == [OrderSide.BUY, OrderSide.SELL]
+
+
+@pytest.mark.parametrize(
+    ("position", "expected"),
+    [
+        (Decimal("3.5"), 3.5),
+        (SimpleNamespace(signed_qty=Decimal("2.25")), 2.25),
+        (SimpleNamespace(signed_decimal_qty=lambda: Decimal("4.75")), 4.75),
+        (Decimal("-1"), 0.0),
+    ],
+)
+def test_profile_replay_strategy_sell_cap_handles_nautilus_position_shapes(
+    monkeypatch: pytest.MonkeyPatch, position: object, expected: float
+) -> None:
+    strategy = BookProfileReplayStrategy(
+        BookProfileReplayConfig(
+            instrument_id=INSTRUMENT_ID,
+            selection_key="profile",
+            trades_by_key={
+                "profile": [
+                    {"side": "SELL", "size": 1, "price": 0.50, "timestamp_ns": 2_000_000_000}
+                ]
+            },
+        )
+    )
+
+    monkeypatch.setattr(
+        BookProfileReplayStrategy,
+        "portfolio",
+        property(lambda self: SimpleNamespace(net_position=lambda instrument_id: position)),
+        raising=False,
+    )
+
+    assert strategy._sell_quantity_cap() == pytest.approx(expected)

--- a/tests/test_profile_replay.py
+++ b/tests/test_profile_replay.py
@@ -98,6 +98,37 @@ def test_select_profile_trade_groups_rejects_groups_requiring_prior_inventory() 
     assert groups == ()
 
 
+def test_select_profile_trade_groups_filters_by_latest_trade_time() -> None:
+    trades = normalize_profile_trades(
+        [
+            _payload(
+                slug="btc-updown-5m-1777222500",
+                side="BUY",
+                size=5,
+                price=0.50,
+                timestamp=1777222726,
+                transaction_hash="0xolder",
+            ),
+            _payload(
+                slug="btc-updown-5m-1777241400",
+                side="BUY",
+                size=5,
+                price=0.50,
+                timestamp=1777241444,
+                transaction_hash="0xnewer",
+            ),
+        ]
+    )
+
+    groups = select_profile_trade_groups(
+        trades,
+        max_groups=10,
+        max_latest_trade_time="2026-04-26T18:00:00Z",
+    )
+
+    assert [group.key for group in groups] == ["btc-updown-5m-1777222500:1"]
+
+
 def test_build_profile_replays_infers_btc_window_from_slug() -> None:
     trades = normalize_profile_trades(
         [_payload(side="BUY", size=10, price=0.5, timestamp=1777241444)]

--- a/tests/test_replay_adapter_architecture.py
+++ b/tests/test_replay_adapter_architecture.py
@@ -157,6 +157,73 @@ def test_preflight_midpoints_apply_l2_book_state(monkeypatch) -> None:
     assert replay_adapters._price_range(midpoints) == pytest.approx(0.02)
 
 
+def test_replay_records_clip_at_instrument_expiration() -> None:
+    records = (
+        SimpleNamespace(ts_event=10),
+        SimpleNamespace(ts_event=15),
+        SimpleNamespace(ts_event=16),
+    )
+
+    with pytest.warns(RuntimeWarning, match="post-expiration"):
+        clipped, metadata = replay_adapters._clip_records_at_instrument_expiration(
+            instrument=SimpleNamespace(expiration_ns=15),
+            records=records,
+            market_label="demo-market",
+        )
+
+    assert clipped == records[:2]
+    assert metadata == {
+        "post_expiration_records_dropped": 1,
+        "records_clipped_at_expiration_ns": 15,
+    }
+
+
+def test_replay_records_drop_crossed_l2_books_until_fresh_snapshot(monkeypatch) -> None:
+    class FakeDeltas:
+        def __init__(self, updates: tuple[tuple[str, float], ...], *, is_snapshot: bool) -> None:
+            self.updates = updates
+            self.is_snapshot = is_snapshot
+            self.ts_event = 0
+
+    class FakeOrderBook:
+        def __init__(self, instrument_id, book_type):  # type: ignore[no-untyped-def]
+            del instrument_id, book_type
+            self._bid: float | None = None
+            self._ask: float | None = None
+
+        def apply_deltas(self, deltas: FakeDeltas) -> None:
+            for side, price in deltas.updates:
+                if side == "bid":
+                    self._bid = price
+                else:
+                    self._ask = price
+
+        def best_bid_price(self) -> float | None:
+            return self._bid
+
+        def best_ask_price(self) -> float | None:
+            return self._ask
+
+    monkeypatch.setattr(replay_adapters, "OrderBook", FakeOrderBook)
+    crossed_snapshot = FakeDeltas((("bid", 0.55), ("ask", 0.50)), is_snapshot=True)
+    stale_delta = FakeDeltas((("ask", 0.52),), is_snapshot=False)
+    valid_snapshot = FakeDeltas((("bid", 0.49), ("ask", 0.51)), is_snapshot=True)
+
+    with pytest.warns(RuntimeWarning, match="invalid L2"):
+        sanitized, metadata = replay_adapters._drop_crossed_l2_book_records(
+            instrument=SimpleNamespace(id="POLYMARKET.TEST"),
+            records=(crossed_snapshot, stale_delta, valid_snapshot),
+            deltas_type=FakeDeltas,
+            market_label="demo-market",
+        )
+
+    assert sanitized == (valid_snapshot,)
+    assert metadata == {
+        "crossed_book_records_dropped": 1,
+        "book_delta_records_without_snapshot_dropped": 1,
+    }
+
+
 def test_trade_tick_loader_reports_api_and_cache_progress(
     monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
 ) -> None:

--- a/tests/test_reporting_regressions.py
+++ b/tests/test_reporting_regressions.py
@@ -26,6 +26,165 @@ def test_serialize_fill_events_preserves_no_side_from_instrument_id() -> None:
     assert events[0]["side"] == "no"
 
 
+def test_serialize_fill_events_uses_per_fill_quantity_and_price() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": "1",
+                "side": "BUY",
+                "last_px": 0.40,
+                "avg_px": 0.40,
+                "last_qty": 40,
+                "filled_qty": 40,
+                "commission": 0.01,
+                "commissions": 0.01,
+                "ts_last": "2026-04-01T00:00:00Z",
+                "instrument_id": "PM-TEST-YES",
+            },
+            {
+                "client_order_id": "1",
+                "side": "BUY",
+                "last_px": 0.60,
+                "avg_px": 0.52,
+                "last_qty": 60,
+                "filled_qty": 100,
+                "commission": 0.02,
+                "commissions": 0.03,
+                "ts_last": "2026-04-01T00:01:00Z",
+                "instrument_id": "PM-TEST-YES",
+            },
+        ]
+    )
+
+    events = research._serialize_fill_events(market_id="pm-test-yes", fills_report=fills_report)
+
+    assert [event["quantity"] for event in events] == [40.0, 60.0]
+    assert [event["price"] for event in events] == [0.40, 0.60]
+    assert [event["commission"] for event in events] == [0.01, 0.02]
+    assert sum(event["price"] * event["quantity"] for event in events) == 52.0
+
+
+def test_serialize_fill_events_prefers_order_side_for_trade_action() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": "1",
+                "order_side": "BUY",
+                "side": "YES",
+                "last_px": 0.45,
+                "last_qty": 5,
+                "ts_last": "2026-04-01T00:00:00Z",
+                "instrument_id": "PM-TEST-YES",
+            }
+        ]
+    )
+
+    events = research._serialize_fill_events(market_id="pm-test-yes", fills_report=fills_report)
+
+    assert events[0]["action"] == "buy"
+    assert events[0]["side"] == "yes"
+
+
+def test_serialize_fill_events_uses_yes_no_side_as_token_side() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": "1",
+                "order_side": "BUY",
+                "side": "NO",
+                "last_px": 0.10,
+                "last_qty": 5,
+                "ts_last": "2026-04-01T00:00:00Z",
+            }
+        ]
+    )
+
+    events = research._serialize_fill_events(market_id="pm-test", fills_report=fills_report)
+
+    assert events[0]["action"] == "buy"
+    assert events[0]["side"] == "no"
+
+
+def test_serialize_fill_events_does_not_use_token_side_as_trade_action() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": "1",
+                "side": "NO",
+                "last_px": 0.10,
+                "last_qty": 5,
+                "ts_last": "2026-04-01T00:00:00Z",
+            }
+        ]
+    )
+
+    events = research._serialize_fill_events(market_id="pm-test", fills_report=fills_report)
+
+    assert events[0]["action"] == "buy"
+    assert events[0]["side"] == "no"
+
+
+def test_serialize_fill_events_prefers_explicit_order_side_over_token_side_action() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": "1",
+                "action": "NO",
+                "order_side": "SELL",
+                "side": "NO",
+                "last_px": 0.10,
+                "last_qty": 5,
+                "ts_last": "2026-04-01T00:00:00Z",
+            }
+        ]
+    )
+
+    events = research._serialize_fill_events(market_id="pm-test", fills_report=fills_report)
+
+    assert events[0]["action"] == "sell"
+    assert events[0]["side"] == "no"
+
+
+def test_serialize_fill_events_handles_pandas_na_and_raw_side_action() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": pd.NA,
+                "venue_order_id": "fallback-order-id",
+                "action": "NO",
+                "order_side": pd.NA,
+                "side": "SELL",
+                "instrument_side": pd.NA,
+                "last_px": pd.NA,
+                "avg_px": 0.33,
+                "last_qty": pd.NA,
+                "filled_qty": 7,
+                "commission": pd.NA,
+                "commissions": 0.01,
+                "ts_last": pd.NA,
+                "ts_event": "2026-04-01T00:00:01Z",
+                "instrument_id": pd.NA,
+                "symbol": "PM-TEST-NO",
+            }
+        ]
+    )
+
+    events = research._serialize_fill_events(market_id="pm-test", fills_report=fills_report)
+
+    assert events == [
+        {
+            "order_id": "fallback-order-id",
+            "market_id": "pm-test",
+            "action": "sell",
+            "side": "no",
+            "price": 0.33,
+            "quantity": 7.0,
+            "timestamp": "2026-04-01T00:00:01+00:00",
+            "commission": 0.01,
+        }
+    ]
+
+
 def test_deserialize_fill_events_uses_serialized_side_when_present() -> None:
     models_module = SimpleNamespace(
         Side=SimpleNamespace(YES="yes-side", NO="no-side"),
@@ -50,3 +209,99 @@ def test_deserialize_fill_events_uses_serialized_side_when_present() -> None:
     )
 
     assert fills[0].side == "no-side"
+
+
+def test_deserialize_fill_events_does_not_treat_token_side_action_as_sell() -> None:
+    models_module = SimpleNamespace(
+        Side=SimpleNamespace(YES="yes-side", NO="no-side"),
+        OrderAction=SimpleNamespace(BUY="buy-action", SELL="sell-action"),
+        Fill=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    fills = research._deserialize_fill_events(
+        market_id="pm-test-no",
+        fill_events=[
+            {
+                "order_id": "1",
+                "action": "no",
+                "side": "no",
+                "price": 0.2,
+                "quantity": 5,
+                "timestamp": "2026-04-01T00:00:00Z",
+                "commission": 0.0,
+            }
+        ],
+        models_module=models_module,
+    )
+
+    assert fills[0].action == "buy-action"
+    assert research._fill_event_position_delta({"action": "no", "side": "no", "quantity": 5}) == 5.0
+    assert (
+        research._fill_event_position_delta(
+            {"action": "no", "order_side": "SELL", "side": "no", "quantity": 5}
+        )
+        == -5.0
+    )
+
+
+def test_deserialize_fill_events_handles_pandas_na_and_raw_side_action() -> None:
+    models_module = SimpleNamespace(
+        Side=SimpleNamespace(YES="yes-side", NO="no-side"),
+        OrderAction=SimpleNamespace(BUY="buy-action", SELL="sell-action"),
+        Fill=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    fills = research._deserialize_fill_events(
+        market_id="pm-test-no",
+        fill_events=[
+            {
+                "order_id": pd.NA,
+                "action": pd.NA,
+                "side": "no",
+                "price": pd.NA,
+                "quantity": 5,
+                "timestamp": "2026-04-01T00:00:00Z",
+                "commission": pd.NA,
+            },
+            {
+                "order_id": "malformed-action",
+                "action": "???",
+                "side": "yes",
+                "price": 0.2,
+                "quantity": 5,
+                "timestamp": "2026-04-01T00:00:01Z",
+                "commission": 0.0,
+            },
+            {
+                "order_id": "raw-side-sell",
+                "action": "NO",
+                "side": "SELL",
+                "price": 0.2,
+                "quantity": 4,
+                "timestamp": "2026-04-01T00:00:02Z",
+                "commission": 0.0,
+            },
+        ],
+        models_module=models_module,
+    )
+
+    assert [fill.action for fill in fills] == ["buy-action", "sell-action"]
+    assert [fill.order_id for fill in fills] == ["fill-1", "raw-side-sell"]
+    assert [fill.side for fill in fills] == ["no-side", "no-side"]
+    assert [fill.price for fill in fills] == [0.0, 0.2]
+    assert [fill.quantity for fill in fills] == [5.0, 4.0]
+
+
+def test_truncate_brier_series_handles_empty_range_index_series() -> None:
+    empty = pd.Series(dtype=float)
+
+    user, market, outcome = research._truncate_brier_series_at_cutoff(
+        {"settlement_observable_time": "2026-04-13T00:00:00Z"},
+        empty,
+        empty,
+        empty,
+    )
+
+    assert user.empty
+    assert market.empty
+    assert outcome.empty

--- a/tests/test_reporting_regressions.py
+++ b/tests/test_reporting_regressions.py
@@ -105,6 +105,31 @@ def test_serialize_fill_events_uses_yes_no_side_as_token_side() -> None:
     assert events[0]["side"] == "no"
 
 
+def test_serialize_fill_events_uses_default_side_for_opaque_instrument_ids() -> None:
+    fills_report = pd.DataFrame(
+        [
+            {
+                "client_order_id": "1",
+                "order_side": "BUY",
+                "side": "BUY",
+                "last_px": 0.05,
+                "last_qty": 5,
+                "ts_last": "2026-04-01T00:00:00Z",
+                "instrument_id": "opaque-token-id",
+            }
+        ]
+    )
+
+    events = research._serialize_fill_events(
+        market_id="btc-updown-5m-1777226700",
+        fills_report=fills_report,
+        default_side=research._fill_event_side_hint(outcome="Down", token_index=1),
+    )
+
+    assert events[0]["action"] == "buy"
+    assert events[0]["side"] == "no"
+
+
 def test_serialize_fill_events_does_not_use_token_side_as_trade_action() -> None:
     fills_report = pd.DataFrame(
         [

--- a/tests/test_result_policies.py
+++ b/tests/test_result_policies.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from prediction_market_extensions.backtesting._result_policies import (
+    BinarySettlementPnlPolicy,
     apply_binary_settlement_pnl,
     apply_joint_portfolio_settlement_pnl,
 )
@@ -39,6 +40,52 @@ def test_settlement_pnl_is_not_applied_when_simulated_through_is_missing() -> No
     assert result["pnl"] == 1.25
     assert result["settlement_pnl_applied"] is False
     assert "simulated_through is missing" in result["warnings"][0]
+
+
+def test_settlement_pnl_is_not_applied_without_observable_timestamp() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.0,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "price": 0.95,
+                    "quantity": 10.0,
+                    "commission": 0.0,
+                }
+            ],
+            "simulated_through": "2026-04-01T00:05:00+00:00",
+        }
+    )
+
+    assert result["pnl"] == 0.0
+    assert result["settlement_pnl_applied"] is False
+    assert "no settlement observable timestamp" in result["warnings"][0]
+
+
+def test_settlement_pnl_is_not_applied_with_market_close_but_no_observable_timestamp() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.0,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "price": 0.95,
+                    "quantity": 2.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:04:00+00:00",
+                }
+            ],
+            "market_close_time_ns": pd.Timestamp("2026-04-01T00:05:00+00:00").value,
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+        }
+    )
+
+    assert result["pnl"] == pytest.approx(0.0)
+    assert result["settlement_pnl_applied"] is False
+    assert "no settlement observable timestamp" in result["warnings"][0]
 
 
 def test_settlement_pnl_updates_summary_series_at_resolution_time() -> None:
@@ -83,6 +130,275 @@ def test_settlement_pnl_updates_summary_series_at_resolution_time() -> None:
     assert result["settlement_cash_adjustment"] == pytest.approx(5.0)
 
 
+@pytest.mark.parametrize(
+    ("commission", "expected_pnl"),
+    [
+        (0.02375, 0.22625),
+        (-0.01, 0.26),
+    ],
+)
+def test_settlement_series_adjusts_from_current_mark_to_market_anchor(
+    commission: float, expected_pnl: float
+) -> None:
+    current_mtm_pnl = -0.95 * 5.0 - commission + 0.95 * 5.0
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": current_mtm_pnl,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": commission,
+                    "timestamp": "2026-04-01T00:05:00+00:00",
+                }
+            ],
+            "simulated_through": "2026-04-01T00:05:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "price_series": [("2026-04-01T00:05:00+00:00", 0.95)],
+            "equity_series": [("2026-04-01T00:05:00+00:00", 1000.0 + current_mtm_pnl)],
+            "cash_series": [("2026-04-01T00:05:00+00:00", 1000.0 - 0.95 * 5.0 - commission)],
+            "pnl_series": [("2026-04-01T00:05:00+00:00", current_mtm_pnl)],
+        }
+    )
+
+    assert result["pnl"] == pytest.approx(expected_pnl)
+    assert result["equity_series"][-1][1] == pytest.approx(1000.0 + expected_pnl)
+    assert result["cash_series"][-1][1] == pytest.approx(1000.0 + expected_pnl)
+
+
+def test_settlement_pnl_prunes_post_settlement_fill_payload() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -0.95,
+            "fills": 2,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 1.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:04:59+00:00",
+                },
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.05,
+                    "quantity": 1.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:05:01+00:00",
+                },
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+        }
+    )
+
+    assert result["settlement_pnl_applied"] is True
+    assert result["post_settlement_fill_events_ignored"] == 1
+    assert result["fills"] == 1
+    assert result["fills_before_post_settlement_pruning"] == 2
+    assert len(result["fill_events"]) == 1
+    assert result["fill_events"][0]["price"] == pytest.approx(0.95)
+    assert "downstream reports" in result["warnings"][0]
+
+
+def test_settlement_pnl_prunes_custom_fill_payload_and_anchors_adjustment() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -4.77375,
+            "fills": 2,
+            "realized_outcome": 1.0,
+            "execution_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.02375,
+                    "timestamp": "2026-04-01T00:04:50+00:00",
+                },
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.80,
+                    "quantity": 5.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:06:00+00:00",
+                },
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "market_close_time_ns": pd.Timestamp("2026-04-01T00:05:00+00:00").value,
+            "price_series": [("2026-04-01T00:05:00+00:00", 0.95)],
+            "equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.22625),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", -4.77375),
+            ],
+        },
+        fill_events_key="execution_events",
+    )
+
+    assert result["settlement_pnl_applied"] is True
+    assert result["post_settlement_fill_events_ignored"] == 1
+    assert result["fills"] == 1
+    assert result["fills_before_post_settlement_pruning"] == 2
+    assert len(result["execution_events"]) == 1
+    assert result["settlement_equity_adjustment"] == pytest.approx(0.25)
+    assert result["settlement_cash_adjustment"] == pytest.approx(5.0)
+
+
+def test_settlement_pnl_ignores_non_mapping_fill_events() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.0,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                "malformed-fill-row",
+                {"action": "buy", "price": 0.90, "quantity": 1.0, "commission": 0.0},
+                object(),
+            ],
+            "simulated_through": "2026-04-01T00:05:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+        }
+    )
+
+    assert result["settlement_pnl_applied"] is True
+    assert result["pnl"] == pytest.approx(0.10)
+    assert result["final_signed_position"] == pytest.approx(1.0)
+
+
+def test_binary_settlement_policy_respects_custom_pnl_and_exit_keys() -> None:
+    result: dict[str, object] = {
+        "strategy_pnl": -0.123,
+        "outcome": 1.0,
+        "executions": [
+            {
+                "action": "buy",
+                "price": 0.95,
+                "quantity": 5.0,
+                "commission": 0.0,
+            }
+        ],
+        "simulated_through": "2026-04-01T00:05:00+00:00",
+        "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+    }
+    policy = BinarySettlementPnlPolicy(
+        pnl_key="strategy_pnl",
+        market_exit_pnl_key="strategy_exit_pnl",
+        fill_events_key="executions",
+        realized_outcome_key="outcome",
+    )
+
+    policy.apply([result])
+
+    assert result["strategy_pnl"] == pytest.approx(0.25)
+    assert result["strategy_exit_pnl"] == pytest.approx(-0.123)
+    assert "pnl" not in result
+    assert "market_exit_pnl" not in result
+
+
+def test_settlement_policy_flags_negative_token_inventory() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.60,
+            "realized_outcome": 0.0,
+            "fill_events": [
+                {
+                    "action": "sell",
+                    "side": "yes",
+                    "price": 0.60,
+                    "quantity": 10.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:04:00+00:00",
+                }
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+        }
+    )
+
+    assert result["backtest_realism_invalid"] is True
+    assert result["terminated_early"] is True
+    assert result["stop_reason"] == "invalid_short_position"
+    assert result["min_signed_position"] == pytest.approx(-10.0)
+    assert "Token inventory went negative" in result["warnings"][0]
+
+
+def test_settlement_policy_runs_integrity_checks_when_observable_time_is_missing() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 6.0,
+            "realized_outcome": 0.0,
+            "fill_events": [
+                {
+                    "action": "sell",
+                    "side": "yes",
+                    "price": 0.60,
+                    "quantity": 10.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:04:00+00:00",
+                }
+            ],
+        }
+    )
+
+    assert result["settlement_pnl_applied"] is False
+    assert result["backtest_realism_invalid"] is True
+    assert result["stop_reason"] == "invalid_short_position"
+    assert any("no settlement observable timestamp" in warning for warning in result["warnings"])
+    assert any("Token inventory went negative" in warning for warning in result["warnings"])
+
+
+def test_settlement_policy_flags_negative_cash_series() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -1.0,
+            "realized_outcome": None,
+            "fill_events": [],
+            "cash_series": [
+                ("2026-04-01T00:00:00+00:00", 5.0),
+                ("2026-04-01T00:01:00+00:00", -1.0),
+            ],
+        }
+    )
+
+    assert result["backtest_realism_invalid"] is True
+    assert result["terminated_early"] is True
+    assert result["stop_reason"] == "account_error"
+    assert result["min_cash"] == pytest.approx(-1.0)
+    assert "Cash balance went negative" in result["warnings"][0]
+
+
+def test_settlement_pnl_is_not_applied_when_requested_window_ends_before_resolution() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.0,
+            "realized_outcome": 1.0,
+            "fill_events": [{"action": "buy", "price": 0.95, "quantity": 5.0, "commission": 0.0}],
+            "planned_end": "2026-04-01T00:04:00+00:00",
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+        }
+    )
+
+    assert result["pnl"] == 0.0
+    assert result["settlement_pnl_applied"] is False
+    assert "requested replay window" in result["warnings"][0]
+
+
 def test_settlement_series_prefers_market_close_when_expiration_precedes_replay() -> None:
     result = apply_binary_settlement_pnl(
         {
@@ -122,6 +438,155 @@ def test_settlement_series_prefers_market_close_when_expiration_precedes_replay(
     assert result["pnl_series"][-1] == ("2026-04-26T18:05:00+00:00", pytest.approx(0.22625))
     assert result["settlement_equity_adjustment"] == pytest.approx(0.25)
     assert result["settlement_cash_adjustment"] == pytest.approx(5.0)
+
+
+def test_settlement_waits_for_market_close_after_observable_metadata() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -0.10,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.0,
+                }
+            ],
+            "simulated_through": "2026-04-01T00:03:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:01:00+00:00",
+            "market_close_time_ns": pd.Timestamp("2026-04-01T00:05:00+00:00").value,
+        }
+    )
+
+    assert result["pnl"] == pytest.approx(-0.10)
+    assert result["settlement_pnl_applied"] is False
+    assert "resolution was not observable" in result["warnings"][0]
+
+
+def test_settlement_series_waits_for_later_observable_time_after_market_close() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.0,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:04:59+00:00",
+                }
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:06:00+00:00",
+            "market_close_time_ns": pd.Timestamp("2026-04-01T00:05:00+00:00").value,
+            "equity_series": [
+                ("2026-04-01T00:04:59+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 1000.0),
+                ("2026-04-01T00:06:00+00:00", 1000.0),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:59+00:00", 995.25),
+                ("2026-04-01T00:05:00+00:00", 995.25),
+                ("2026-04-01T00:06:00+00:00", 995.25),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:59+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", 0.0),
+                ("2026-04-01T00:06:00+00:00", 0.0),
+            ],
+        }
+    )
+
+    assert result["settlement_series_time"] == "2026-04-01T00:06:00+00:00"
+    assert result["equity_series"][1] == ("2026-04-01T00:05:00+00:00", pytest.approx(1000.0))
+    assert result["equity_series"][-1] == ("2026-04-01T00:06:00+00:00", pytest.approx(1000.25))
+
+
+def test_settlement_gating_accepts_pandas_timestamp_inputs() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": 0.0,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.0,
+                }
+            ],
+            "simulated_through": pd.Timestamp("2026-04-01T00:05:00+00:00"),
+            "settlement_observable_time": pd.Timestamp("2026-04-01T00:05:00+00:00"),
+        }
+    )
+
+    assert result["settlement_pnl_applied"] is True
+    assert result["pnl"] == pytest.approx(0.25)
+
+
+def test_settlement_pnl_ignores_fills_after_settlement_cutoff() -> None:
+    result = apply_binary_settlement_pnl(
+        {
+            "pnl": -3.75,
+            "realized_outcome": 1.0,
+            "fill_events": [
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.95,
+                    "quantity": 5.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:04:59+00:00",
+                },
+                {
+                    "action": "buy",
+                    "side": "yes",
+                    "price": 0.80,
+                    "quantity": 5.0,
+                    "commission": 0.0,
+                    "timestamp": "2026-04-01T00:06:00+00:00",
+                },
+            ],
+            "simulated_through": "2026-04-01T00:06:00+00:00",
+            "settlement_observable_time": "2026-04-01T00:05:00+00:00",
+            "market_close_time_ns": pd.Timestamp("2026-04-01T00:05:00+00:00").value,
+            "price_series": [
+                ("2026-04-01T00:04:30+00:00", 0.95),
+                ("2026-04-01T00:05:00+00:00", 0.95),
+                ("2026-04-01T00:06:00+00:00", 0.0),
+            ],
+            "equity_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 1000.0),
+                ("2026-04-01T00:06:00+00:00", 996.0),
+            ],
+            "cash_series": [
+                ("2026-04-01T00:04:30+00:00", 1000.0),
+                ("2026-04-01T00:05:00+00:00", 995.25),
+                ("2026-04-01T00:06:00+00:00", 991.25),
+            ],
+            "pnl_series": [
+                ("2026-04-01T00:04:30+00:00", 0.0),
+                ("2026-04-01T00:05:00+00:00", 0.0),
+                ("2026-04-01T00:06:00+00:00", -4.0),
+            ],
+        }
+    )
+
+    assert result["pnl"] == pytest.approx(0.25)
+    assert result["post_settlement_fill_events_ignored"] == 1
+    assert "Ignored 1 fill event" in result["warnings"][0]
+    assert result["equity_series"][-2][1] == pytest.approx(1000.25)
+    assert result["equity_series"][-1][1] == pytest.approx(1000.25)
+    assert result["cash_series"][-2][1] == pytest.approx(1000.25)
+    assert result["cash_series"][-1][1] == pytest.approx(1000.25)
+    assert result["pnl_series"][-2][1] == pytest.approx(0.25)
+    assert result["pnl_series"][-1][1] == pytest.approx(0.25)
 
 
 def test_joint_portfolio_series_receive_settlement_adjustments() -> None:

--- a/tests/test_telonex_data_source.py
+++ b/tests/test_telonex_data_source.py
@@ -267,6 +267,23 @@ def test_telonex_runner_api_downloads_cache_then_clear(
     fast_cache_path = cache_path.with_name(f"{cache_path.stem}.fast.parquet")
     assert loader._telonex_last_api_source == f"telonex-cache-fast::{fast_cache_path}"
 
+    cached_entry = telonex_module.TelonexSourceEntry(
+        kind="api",
+        target="https://api.example.test",
+        api_key=None,
+    )
+    cached_frame, cached_source = loader._try_load_day_from_api_entry(
+        entry=cached_entry,
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date="2026-01-19",
+        market_slug="us-recession-by-end-of-2026",
+        token_index=0,
+        outcome=None,
+    )
+
+    assert cached_frame is not None
+    assert cached_source == f"telonex-cache-fast::{fast_cache_path}"
+
     result = subprocess.run(
         [
             "make",
@@ -492,8 +509,23 @@ def test_telonex_materialized_deltas_cache_round_trips(
     ]
 
 
-def test_telonex_api_source_skips_materialized_deltas_cache_metadata() -> None:
+def test_telonex_api_source_materialized_deltas_cache_tracks_raw_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(TELONEX_CACHE_ROOT_ENV, str(tmp_path / "cache"))
     loader = _make_polymarket_loader()
+    load_kwargs = {
+        "base_url": "https://api.example.test",
+        "channel": TELONEX_FULL_BOOK_CHANNEL,
+        "date": "2026-01-19",
+        "market_slug": "cache-test",
+        "token_index": 0,
+        "outcome": "Yes",
+    }
+    loader._write_api_cache_day(
+        payload=_book_parquet_payload(1_768_780_800_000_000),
+        **load_kwargs,
+    )
     config = telonex_module.TelonexLoaderConfig(
         channel=TELONEX_FULL_BOOK_CHANNEL,
         ordered_source_entries=(
@@ -515,20 +547,20 @@ def test_telonex_api_source_skips_materialized_deltas_cache_metadata() -> None:
         outcome="Yes",
     )
 
-    assert source is None
-    assert (
-        loader._deltas_cache_metadata_payload(
-            source=source,
-            channel=TELONEX_FULL_BOOK_CHANNEL,
-            date="2026-01-19",
-            market_slug="cache-test",
-            token_index=0,
-            outcome="Yes",
-            start=start,
-            end=end,
-        )
-        is None
+    assert source is not None
+    assert source["source_stage"] == "api"
+    metadata = loader._deltas_cache_metadata_payload(
+        source=source,
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date="2026-01-19",
+        market_slug="cache-test",
+        token_index=0,
+        outcome="Yes",
+        start=start,
+        end=end,
     )
+    assert metadata is not None
+    assert metadata["source"] == source
 
 
 def test_telonex_fast_api_cache_invalidates_when_raw_cache_changes(

--- a/tests/test_telonex_data_source.py
+++ b/tests/test_telonex_data_source.py
@@ -11,6 +11,8 @@ from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from nautilus_trader.adapters.polymarket.common.parsing import parse_polymarket_instrument
 from nautilus_trader.model.data import OrderBookDeltas
@@ -68,13 +70,13 @@ class _FakeHTTPResponse:
         return self._buffer.read(size)
 
 
-def _book_parquet_payload(timestamp_us: int) -> bytes:
+def _book_parquet_payload(timestamp_us: int, *, bid: str = "0.42", ask: str = "0.44") -> bytes:
     buffer = BytesIO()
     pd.DataFrame(
         {
             "timestamp_us": [timestamp_us],
-            "bids": [[{"price": "0.42", "size": "10"}]],
-            "asks": [[{"price": "0.44", "size": "11"}]],
+            "bids": [[{"price": bid, "size": "10"}]],
+            "asks": [[{"price": ask, "size": "11"}]],
         }
     ).to_parquet(buffer, index=False)
     return buffer.getvalue()
@@ -329,6 +331,56 @@ def test_telonex_full_book_snapshots_replay_l2_deltas() -> None:
     assert len(records) == 2
 
 
+def test_telonex_crossed_snapshot_resets_until_next_valid_full_snapshot() -> None:
+    loader = _make_polymarket_loader()
+    frame = pd.DataFrame(
+        {
+            "timestamp_us": [1_768_780_800_000_000, 1_768_780_801_000_000],
+            "bids": [
+                [{"price": "0.60", "size": "10"}],
+                [{"price": "0.34", "size": "10"}],
+            ],
+            "asks": [
+                [{"price": "0.55", "size": "11"}],
+                [{"price": "0.39", "size": "11"}],
+            ],
+        }
+    )
+
+    with pytest.warns(RuntimeWarning, match="crossed/invalid full-book"):
+        records = loader._book_events_from_frame(
+            frame,
+            start=pd.Timestamp("2026-01-19T00:00:00Z"),
+            end=pd.Timestamp("2026-01-20T00:00:00Z"),
+        )
+
+    assert len(records) == 1
+    assert records[0].is_snapshot
+    assert int(records[0].ts_event) == 1_768_780_801_000_000_000
+
+
+def test_telonex_timestamp_ms_keeps_exact_end_boundary_record() -> None:
+    loader = _make_polymarket_loader()
+    timestamp_ms = 1_768_780_800_123
+    frame = pd.DataFrame(
+        {
+            "timestamp_ms": [timestamp_ms],
+            "bids": [[{"price": "0.34", "size": "10"}]],
+            "asks": [[{"price": "0.39", "size": "11"}]],
+        }
+    )
+    event_ns = timestamp_ms * 1_000_000
+
+    records = loader._book_events_from_frame(
+        frame,
+        start=pd.Timestamp(event_ns - 1_000, unit="ns", tz="UTC"),
+        end=pd.Timestamp(event_ns, unit="ns", tz="UTC"),
+    )
+
+    assert len(records) == 1
+    assert int(records[0].ts_event) == event_ns
+
+
 def test_telonex_materialized_deltas_cache_round_trips(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -350,6 +402,16 @@ def test_telonex_materialized_deltas_cache_round_trips(
         }
     )
     records = loader._book_events_from_frame(frame, start=start, end=end)
+    metadata = loader._deltas_cache_metadata_payload(
+        source={"kind": "test"},
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date="2026-01-19",
+        market_slug="cache-test",
+        token_index=0,
+        outcome="Yes",
+        start=start,
+        end=end,
+    )
 
     loader._write_deltas_cache_day(
         records=records,
@@ -360,6 +422,7 @@ def test_telonex_materialized_deltas_cache_round_trips(
         outcome="Yes",
         start=start,
         end=end,
+        metadata=metadata,
     )
     cached_records, source = loader._load_deltas_cache_day(
         channel=TELONEX_FULL_BOOK_CHANNEL,
@@ -369,6 +432,7 @@ def test_telonex_materialized_deltas_cache_round_trips(
         outcome="Yes",
         start=start,
         end=end,
+        expected_metadata=metadata,
     )
 
     assert source.startswith("telonex-deltas-cache::")
@@ -380,6 +444,279 @@ def test_telonex_materialized_deltas_cache_round_trips(
     assert [int(record.ts_event) for record in cached_records] == [
         int(record.ts_event) for record in records
     ]
+
+
+def test_telonex_api_source_skips_materialized_deltas_cache_metadata() -> None:
+    loader = _make_polymarket_loader()
+    config = telonex_module.TelonexLoaderConfig(
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        ordered_source_entries=(
+            telonex_module.TelonexSourceEntry(
+                kind="api",
+                target="https://api.example.test",
+                api_key="test-key",
+            ),
+        ),
+    )
+    start = pd.Timestamp("2026-01-19T00:00:00Z")
+    end = pd.Timestamp("2026-01-19T23:59:59Z")
+
+    source = loader._deltas_cache_source_fingerprint(
+        config=config,
+        date="2026-01-19",
+        market_slug="cache-test",
+        token_index=0,
+        outcome="Yes",
+    )
+
+    assert source is None
+    assert (
+        loader._deltas_cache_metadata_payload(
+            source=source,
+            channel=TELONEX_FULL_BOOK_CHANNEL,
+            date="2026-01-19",
+            market_slug="cache-test",
+            token_index=0,
+            outcome="Yes",
+            start=start,
+            end=end,
+        )
+        is None
+    )
+
+
+def test_telonex_fast_api_cache_invalidates_when_raw_cache_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(TELONEX_CACHE_ROOT_ENV, str(tmp_path / "cache"))
+    loader = _make_polymarket_loader()
+    load_kwargs = {
+        "base_url": "https://api.example.test",
+        "channel": TELONEX_FULL_BOOK_CHANNEL,
+        "date": "2026-01-19",
+        "market_slug": "cache-correction-market",
+        "token_index": 0,
+        "outcome": "Yes",
+    }
+    payload_v1 = _book_parquet_payload(1_768_780_800_000_000, bid="0.42")
+    payload_v2 = _book_parquet_payload(1_768_780_800_000_000, bid="0.77")
+    frame_v1 = pd.read_parquet(BytesIO(payload_v1))
+
+    loader._write_api_cache_day(payload=payload_v1, **load_kwargs)
+    loader._write_fast_cache_day(frame=frame_v1, **load_kwargs)
+    time.sleep(0.001)
+    loader._write_api_cache_day(payload=payload_v2, **load_kwargs)
+
+    frame, source = loader._load_api_day_cached(**load_kwargs)
+
+    assert frame is not None
+    assert source.startswith("telonex-cache::")
+    assert frame.iloc[0]["bids"][0]["price"] == "0.77"
+
+
+def test_telonex_blob_source_fingerprint_tracks_part_file_changes(tmp_path: Path) -> None:
+    loader = _make_polymarket_loader()
+    local_root = tmp_path / "telonex-blob"
+    part_path = (
+        local_root
+        / "data"
+        / "channel=book_snapshot_full"
+        / "year=2026"
+        / "month=01"
+        / "part-000.parquet"
+    )
+    part_path.parent.mkdir(parents=True)
+    (local_root / "telonex.duckdb").write_bytes(b"legacy/no-manifest")
+
+    def write_part(best_bid: str) -> None:
+        pq.write_table(
+            pa.table(
+                {
+                    "market_slug": ["blob-market"],
+                    "outcome_segment": ["Yes"],
+                    "timestamp_us": [1_768_780_800_000_000],
+                    "bids": [[{"price": best_bid, "size": "10"}]],
+                    "asks": [[{"price": "0.44", "size": "11"}]],
+                    "year": [2026],
+                    "month": [1],
+                }
+            ),
+            part_path,
+        )
+
+    write_part("0.42")
+    entry = telonex_module.TelonexSourceEntry(kind="local", target=str(local_root))
+    first = loader._telonex_source_fingerprint_for_entry(
+        entry=entry,
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date="2026-01-19",
+        market_slug="blob-market",
+        token_index=0,
+        outcome="Yes",
+    )
+    time.sleep(0.001)
+    write_part("0.55")
+    second = loader._telonex_source_fingerprint_for_entry(
+        entry=entry,
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date="2026-01-19",
+        market_slug="blob-market",
+        token_index=0,
+        outcome="Yes",
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first["layout"] == "blob-legacy"
+    assert "parts" in first
+    assert first != second
+
+
+def test_telonex_local_fingerprint_tracks_same_size_same_mtime_correction(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "day.parquet"
+    path.write_bytes(b"bid=0.4200")
+    first_stat = path.stat()
+    first = RunnerPolymarketTelonexBookDataLoader._local_file_fingerprint(path)
+
+    time.sleep(0.01)
+    path.write_bytes(b"bid=0.7700")
+    os.utime(path, ns=(first_stat.st_atime_ns, first_stat.st_mtime_ns))
+    second_stat = path.stat()
+    if second_stat.st_ctime_ns == first_stat.st_ctime_ns:
+        pytest.skip("filesystem did not expose ctime change for same-size rewrite")
+    second = RunnerPolymarketTelonexBookDataLoader._local_file_fingerprint(path)
+
+    assert first is not None
+    assert second is not None
+    assert first["size"] == second["size"]
+    assert first["mtime_ns"] == second["mtime_ns"]
+    assert first["ctime_ns"] != second["ctime_ns"]
+    assert first != second
+
+
+def test_telonex_blob_empty_manifest_falls_back_to_legacy_parts(tmp_path: Path) -> None:
+    loader = _make_polymarket_loader()
+    local_root = tmp_path / "telonex-blob"
+    part_path = (
+        local_root
+        / "data"
+        / f"channel={TELONEX_FULL_BOOK_CHANNEL}"
+        / "year=2026"
+        / "month=01"
+        / "part-000.parquet"
+    )
+    part_path.parent.mkdir(parents=True)
+    con = telonex_module.duckdb.connect(str(local_root / "telonex.duckdb"))
+    try:
+        con.execute(
+            "CREATE TABLE completed_days("
+            "channel VARCHAR, market_slug VARCHAR, outcome_segment VARCHAR, "
+            "day DATE, rows BIGINT, parquet_part VARCHAR)"
+        )
+    finally:
+        con.close()
+    pd.DataFrame(
+        {
+            "market_slug": ["stale-manifest-market"],
+            "outcome_segment": ["Yes"],
+            "timestamp_us": [1_768_780_800_000_000],
+            "bids": [[{"price": "0.42", "size": "10"}]],
+            "asks": [[{"price": "0.44", "size": "11"}]],
+        }
+    ).to_parquet(part_path, index=False)
+
+    frame = loader._load_blob_range(
+        store_root=local_root,
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        market_slug="stale-manifest-market",
+        token_index=0,
+        outcome="Yes",
+        start=pd.Timestamp("2026-01-19T00:00:00Z"),
+        end=pd.Timestamp("2026-01-19T23:59:59Z"),
+    )
+    fingerprint = loader._local_blob_source_fingerprint_for_day(
+        root=local_root,
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date="2026-01-19",
+        market_slug="stale-manifest-market",
+        token_index=0,
+        outcome="Yes",
+    )
+
+    assert frame is not None
+    assert len(frame) == 1
+    assert frame.iloc[0]["bids"][0]["price"] == "0.42"
+    assert fingerprint is not None
+    assert fingerprint["layout"] == "blob-legacy"
+    assert len(fingerprint["parts"]) == 1
+
+
+def test_telonex_materialized_deltas_cache_ignores_unversioned_stale_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(TELONEX_CACHE_ROOT_ENV, str(tmp_path / "cache"))
+    loader = _make_polymarket_loader()
+    market_slug = "timestamp-cache-test"
+    date = "2026-01-19"
+    timestamp_ms = 1_768_780_800_123
+    correct_ns = timestamp_ms * 1_000_000
+    stale_ns = int(float(timestamp_ms) * 1_000_000)
+    start = pd.Timestamp(correct_ns - 1_000_000, unit="ns", tz="UTC")
+    end = pd.Timestamp(correct_ns, unit="ns", tz="UTC")
+    local_root = tmp_path / "local"
+    local_path = (
+        local_root
+        / "polymarket"
+        / market_slug
+        / "0"
+        / TELONEX_FULL_BOOK_CHANNEL
+        / f"{date}.parquet"
+    )
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    frame = pd.DataFrame(
+        {
+            "timestamp_ms": [timestamp_ms],
+            "bids": [[{"price": "0.34", "size": "10"}]],
+            "asks": [[{"price": "0.39", "size": "11"}]],
+        }
+    )
+    frame.to_parquet(local_path, index=False)
+    correct_records = loader._book_events_from_frame(frame, start=start, end=end)
+    stale_frame = loader._deltas_records_to_table(correct_records).to_pandas()
+    stale_frame["ts_event"] = stale_ns
+    stale_frame["ts_init"] = stale_ns
+    cache_path = loader._deltas_cache_path(
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        date=date,
+        market_slug=market_slug,
+        token_index=0,
+        outcome="Yes",
+        instrument_id=loader.instrument.id,
+        start=start,
+        end=end,
+    )
+    assert cache_path is not None
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_frame.to_parquet(cache_path, index=False)
+
+    loader._config = lambda: telonex_module.TelonexLoaderConfig(  # type: ignore[method-assign]
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        ordered_source_entries=(
+            telonex_module.TelonexSourceEntry(kind="local", target=str(local_root)),
+        ),
+    )
+
+    records = loader.load_order_book_deltas(
+        start,
+        end,
+        market_slug=market_slug,
+        token_index=0,
+        outcome="Yes",
+    )
+
+    assert [int(record.ts_event) for record in records] == [correct_ns]
 
 
 def test_telonex_full_book_loader_uses_local_before_api_cache(

--- a/tests/test_telonex_data_source.py
+++ b/tests/test_telonex_data_source.py
@@ -359,6 +359,52 @@ def test_telonex_crossed_snapshot_resets_until_next_valid_full_snapshot() -> Non
     assert int(records[0].ts_event) == 1_768_780_801_000_000_000
 
 
+def test_telonex_load_order_book_deltas_aggregates_invalid_snapshot_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loader = _make_polymarket_loader()
+    config = telonex_module.TelonexLoaderConfig(
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        ordered_source_entries=(
+            telonex_module.TelonexSourceEntry(kind="local", target="/tmp/local"),
+        ),
+    )
+
+    monkeypatch.setattr(loader, "_config", lambda: config)
+    monkeypatch.setattr(loader, "_load_deltas_cache_day", lambda **kwargs: (None, "none"))
+    monkeypatch.setattr(loader, "_write_deltas_cache_day", lambda **kwargs: None)
+
+    def fake_local(**kwargs: object) -> pd.DataFrame:
+        date = str(kwargs["date"])
+        base_us = pd.Timestamp(date, tz="UTC").value // 1_000
+        return pd.DataFrame(
+            {
+                "timestamp_us": [base_us, base_us + 1_000_000],
+                "bids": [
+                    [{"price": "0.60", "size": "10"}],
+                    [{"price": "0.34", "size": "10"}],
+                ],
+                "asks": [
+                    [{"price": "0.55", "size": "11"}],
+                    [{"price": "0.39", "size": "11"}],
+                ],
+            }
+        )
+
+    monkeypatch.setattr(loader, "_try_load_day_from_local", fake_local)
+
+    with pytest.warns(RuntimeWarning, match="dropped 2 crossed/invalid full-book snapshot"):
+        records = loader.load_order_book_deltas(
+            pd.Timestamp("2026-01-19", tz="UTC"),
+            pd.Timestamp("2026-01-20 23:59:59", tz="UTC"),
+            market_slug="aggregate-test",
+            token_index=0,
+            outcome="Yes",
+        )
+
+    assert len(records) == 2
+
+
 def test_telonex_timestamp_ms_keeps_exact_end_boundary_record() -> None:
     loader = _make_polymarket_loader()
     timestamp_ms = 1_768_780_800_123
@@ -770,7 +816,7 @@ def test_telonex_full_book_loader_uses_local_before_api_cache(
     monkeypatch.setattr(
         loader,
         "_book_events_from_frame",
-        lambda _frame, *, start, end, include_order_book: [SimpleNamespace(ts_event=1, ts_init=1)],
+        lambda _frame, **kwargs: [SimpleNamespace(ts_event=1, ts_init=1)],
     )
 
     records = loader.load_order_book_deltas(
@@ -835,7 +881,7 @@ def test_telonex_full_book_loader_prefetches_api_days(monkeypatch: pytest.Monkey
     monkeypatch.setattr(
         loader,
         "_book_events_from_frame",
-        lambda frame, *, start, end, include_order_book: [
+        lambda frame, **kwargs: [
             SimpleNamespace(
                 ts_event=int(frame["timestamp_us"].iloc[0]),
                 ts_init=int(frame["timestamp_us"].iloc[0]),
@@ -937,7 +983,7 @@ def test_telonex_full_book_loader_falls_back_to_api_when_blob_partition_is_incom
     monkeypatch.setattr(
         loader,
         "_book_events_from_frame",
-        lambda _frame, *, start, end, include_order_book: [SimpleNamespace(ts_event=1, ts_init=1)],
+        lambda _frame, **kwargs: [SimpleNamespace(ts_event=1, ts_init=1)],
     )
 
     with pytest.warns(UserWarning, match="skipping blob store"):

--- a/tests/test_telonex_data_source.py
+++ b/tests/test_telonex_data_source.py
@@ -563,6 +563,48 @@ def test_telonex_api_source_materialized_deltas_cache_tracks_raw_cache(
     assert metadata["source"] == source
 
 
+def test_telonex_deltas_cache_source_skips_missing_local_before_api_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(TELONEX_CACHE_ROOT_ENV, str(tmp_path / "cache"))
+    loader = _make_polymarket_loader()
+    load_kwargs = {
+        "base_url": "https://api.example.test",
+        "channel": TELONEX_FULL_BOOK_CHANNEL,
+        "date": "2026-01-19",
+        "market_slug": "cache-test",
+        "token_index": 0,
+        "outcome": "Yes",
+    }
+    loader._write_api_cache_day(
+        payload=_book_parquet_payload(1_768_780_800_000_000),
+        **load_kwargs,
+    )
+    config = telonex_module.TelonexLoaderConfig(
+        channel=TELONEX_FULL_BOOK_CHANNEL,
+        ordered_source_entries=(
+            telonex_module.TelonexSourceEntry(kind="local", target=str(tmp_path / "missing")),
+            telonex_module.TelonexSourceEntry(
+                kind="api",
+                target="https://api.example.test",
+                api_key="test-key",
+            ),
+        ),
+    )
+
+    source = loader._deltas_cache_source_fingerprint(
+        config=config,
+        date="2026-01-19",
+        market_slug="cache-test",
+        token_index=0,
+        outcome="Yes",
+    )
+
+    assert source is not None
+    assert source["source_stage"] == "api"
+    assert source["path"].endswith("2026-01-19.parquet")
+
+
 def test_telonex_fast_api_cache_invalidates_when_raw_cache_changes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Tighten settlement/reporting accounting so resolution is only applied when observable, post-settlement fills are pruned, active periods are fill/inventory based, Brier/report series handle empty or non-datetime indexes, and joint summaries avoid double counting.
- Fix fill marker rendering in saved HTML reports at the artifact level: every fill remains present, opaque/down/no tokens preserve the correct yes/no side, hidden markets no longer leak markers, and the market price line now receives the exact fill price at the exact fill timestamp under the displayed market label.
- Fix the earlier PnL marker rendering bug where the market-PnL panel collapsed each market to only its final fill marker; saved HTML reports now preserve a PnL marker for every fill.
- Add saved-HTML regression checks that parse Bokeh `ColumnDataSource` payloads so marker values, sides, prices, quantities, and marker/line alignment are validated from the actual generated HTML.
- Enable Telonex API-backed order-book pulls to reuse materialized book-delta caches keyed to the raw API cache fingerprint, and report cache-hit source labels instead of making cache hits look like fresh API calls.
- Fix Telonex materialized-delta cache lookup when a higher-priority local source is absent: the cache metadata now falls through to the API-cache fingerprint instead of rejecting valid API-derived deltas caches and rebuilding from `*.fast.parquet` every run.
- Add `BookBuySellRandomStrategy` plus a PMXT runner, `backtests/polymarket_book_buy_sell_random.py`, which alternates deterministic-random buy and sell attempts on three-day windows using seeded randomness and marketable IOC orders against L2 books.
- Add profile replay audit support which can emulate public Polymarket user trades slightly before execution time, with optional latest-trade-time filters for bounded comparisons.
- Add a prediction-market order guard plus stricter execution defaults: queue position enabled, realistic static latency, no naked sells/overbuying cash, duplicate order reservation handling, and safer legacy runtime defaults.
- Harden PMXT/Telonex/replay loading around timestamp precision, cache fingerprints, invalid/crossed books, missing-hour resets, local-source priority, and trade-tick execution integration.
- Harden optimizer validation/ranking, including invalid train/holdout windows, TPE bounds, typed candidate identities, non-finite metrics, required usable equity/fill metrics, and joint drawdown from joint equity.
- Refresh `CODEBASE_UML.md` after the structural changes.

## Verification

- `uv run python backtests/polymarket_book_buy_sell_random.py` -> completed, PMXT book/trade cache output visible, 710,068 book events, 28 fills, summary saved to `output/polymarket_book_buy_sell_random_summary.html`
- `uv run pytest tests/test_buy_sell_random_strategy.py tests/test_book_strategy_configs.py tests/test_backtest_script_entrypoints.py -q` -> 67 passed
- `uv run pytest tests/test_notice_license_coverage.py tests/test_buy_sell_random_strategy.py tests/test_backtest_script_entrypoints.py -q` -> 51 passed
- `printf '0\n' | make backtest` -> menu discovery/exit passed and showed `polymarket_book_buy_sell_random.py`
- `uv run pytest tests/test_telonex_data_source.py tests/test_timing_test.py -q` -> 45 passed
- Exact Telonex repro, `human-moon-landing-in-2026`, 2026-03-01 through 2026-04-11, with `local:/Volumes/LaCie/telonex_data -> api:${TELONEX_API_KEY}` -> all days reported `telonex deltas cache ...parquet`, 717,623 records, about 3s total locally
- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> 165 files already formatted
- `uv run pytest tests/ -q` -> 585 passed, 1 skipped, 13 warnings
- `POLYMARKET_PROFILE_REPLAY_SOURCE=snapshot uv run python backtests/polymarket_profile_replay_verification.py` -> runner path exercised earlier, but the selected snapshot market had no valid PMXT L2 book data remaining after source/expiration clipping, so this did not produce a valid profile PnL comparison
- `uv run python backtests/polymarket_btc_5m_late_favorite_taker_hold.py` -> started after the marker fix and confirmed PMXT/trade progress output was visible; stopped during large archive fallback after recent BTC 5m windows skipped because no valid PMXT L2 book data remained, so it is not counted as completed validation
- `uv run python backtests/polymarket_book_ema_crossover.py` -> passed, summary HTML generated, PMXT/trade progress output visible
- `uv run python backtests/polymarket_book_ema_optimizer.py` -> passed, evaluated 18 random-grid candidates and wrote optimizer summary artifacts under ignored `output/`
- `uv run python backtests/polymarket_book_joint_portfolio_runner.py` -> intentionally stopped during PMXT source fill after showing expected per-hour progress output; current local data path was scanning 1009 hours with ~50+ minute ETA

## Notes

This PR targets `v3` because the audit branch was cut from `origin/v3` / `origin/HEAD`. Generated `output/` artifacts are ignored and not included. Two notebook output files remain dirty locally and are intentionally not included in this PR update because their diffs are Bokeh output/id churn rather than engine changes.