### PR TITLE
[codex] Deploy docs from v4 and enforce PR-only publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [v3]
+    branches: [v4]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"
@@ -10,7 +10,7 @@ on:
       - "docs_overrides/**"
       - "mkdocs.yml"
   pull_request:
-    branches: [v3]
+    branches: [v4]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ features from the NautilusTrader documentation.
   not make unless the user explicitly asks.
 - Keep changes tightly scoped to the request. Avoid unrelated refactors and
   formatting churn.
-- Never push directly to `main`.
+- NEVER push directly to `main`, `v4`, `v3`, or any default/base/release
+  branch. Push only to a separate PR branch.
 
 ## README And Docs
 
@@ -229,9 +230,15 @@ Explicitly check:
 
 ## PR Hygiene
 
+- DO NOT MERGE TO `main`, `v4`, `v3`, or any other base branch unless the user
+  gives an explicit merge command for that exact PR. Opening or updating a PR is
+  not permission to merge it.
+- NEVER push straight to a base branch. All repo changes must go through:
+  branch -> draft PR -> review -> green CI -> explicit user merge command.
 - Use branch -> draft PR -> review -> green CI -> explicit user merge command.
-- Before pushing a PR update to its base branch target (`main`, `v3`, or any
-  other version branch), run `uv run python scripts/generate_codebase_uml.py`.
+- Before pushing code-structure changes to a PR branch whose base is `main`,
+  `v4`, `v3`, or any other version branch, run
+  `uv run python scripts/generate_codebase_uml.py`.
   Include the refreshed root `CODEBASE_UML.md` in the PR whenever code structure
   changed, so agents and reviewers can use an up-to-date project map.
 - Review the PR diff after opening it.


### PR DESCRIPTION
## Summary

- Update the Docs workflow branch filters from `v3` to `v4`.
- Keep both docs deploys on push and docs PR checks aligned with the migrated default branch.
- Strengthen `AGENTS.md` to make the PR-only publishing rule explicit: never push straight to `main`, `v4`, `v3`, or another base/default/release branch, and never merge without an explicit user merge command for the exact PR.

## Root Cause

The repository default branch is now `v4`, but `.github/workflows/docs.yml` was still scoped to `v3`. As a result, docs changes on `v4` could build in PR contexts but did not deploy from `v4` pushes.

The agent instructions also had weaker wording that only mentioned direct pushes to `main`, which left the active `v4` base-branch case insufficiently explicit.

## Validation

- `uv run mkdocs build --strict`