### PR TITLE
Adopt Nautilus 1.226 for prediction backtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v5
       - run: uv venv --python 3.13
-      - run: uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" aiohttp bokeh duckdb textual nbformat nbclient ipykernel pytest ruff
+      - run: uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" aiohttp bokeh duckdb textual nbformat nbclient ipykernel pytest ruff py-clob-client python-dotenv
       - run: make native-develop
       - run: uv run ruff check .
       - run: uv run ruff format --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v5
       - run: uv venv --python 3.13
-      - run: uv pip install "nautilus_trader[polymarket,visualization]==1.225.0" aiohttp bokeh duckdb textual nbformat nbclient ipykernel pytest ruff
+      - run: uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" aiohttp bokeh duckdb textual nbformat nbclient ipykernel pytest ruff
       - run: make native-develop
       - run: uv run ruff check .
       - run: uv run ruff format --check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ features from the NautilusTrader documentation.
   not make unless the user explicitly asks.
 - Keep changes tightly scoped to the request. Avoid unrelated refactors and
   formatting churn.
+- Do not add backwards-compatibility shims for old dependency APIs or old repo
+  behavior. Versioned branches preserve older versions; the active branch should
+  adopt the current target dependency/API directly.
 - NEVER push directly to `main`, `v4`, `v3`, or any default/base/release
   branch. Push only to a separate PR branch.
 

--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-05-05T21:52:25+00:00
-Modules: 112 | Classes: 166 | Functions/methods: 1505
+Generated: 2026-05-06T20:15:11+00:00
+Modules: 211 | Classes: 247 | Functions/methods: 2386
 
 ## Backtesting Data Flow
 
@@ -89,6 +89,656 @@ flowchart TD
 ### `backtests/polymarket_telonex_book_joint_portfolio_runner.py`
 - Imports: `__future__, decimal`
 - Function L18: `run() -> None`
+
+### `backtests/private/__init__.py`
+- Imports: none
+
+### `backtests/private/telonex_btc_5m_adjacent_lead_lag_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L124: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L141: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L187: `_evaluate_results(*, trial_id: int, phase: str, params: dict[str, Any], results: list[dict[str, Any]], replay_count: int) -> _Evaluation`
+- Function L242: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L263: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L312: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L342: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_book_event_pressure_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L103: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L107: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L126: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L141: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L194: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L215: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L264: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L294: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_boundary_breakout_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L128: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L143: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L196: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L217: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L266: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L295: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_boundary_hold_breakout_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L128: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L144: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L197: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L218: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L267: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L297: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_cancel_replace_pressure_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L129: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L146: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L194: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L215: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L264: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L293: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_certainty_collapse_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L113: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L117: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L136: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L149: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L202: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L223: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L272: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L302: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_depth_convexity_skew_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L109: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L113: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L133: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L150: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L198: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L219: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L268: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L298: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_depth_entropy_compression_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L109: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L113: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L132: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L149: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L197: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L218: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L267: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L297: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_final_pressure_squeeze_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L110: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L114: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L128: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L145: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L198: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L219: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L268: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L299: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_impact_fair_fade_search.py`
+- Imports: `__future__, backtests, csv, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
+- Function L57: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L74: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L122: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L143: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L192: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L221: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_impact_fair_price_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L105: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L109: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L123: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L140: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L188: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L209: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L258: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L288: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_multiblock_s99_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, typing`
+- Function L42: `_env_epoch_list(name: str, default: tuple[int, ...]) -> tuple[int, ...]`
+- Function L54: `_windows_from_starts(*, starts: tuple[int, ...], windows_per_block: int) -> tuple[tuple[str, str, str], ...]`
+- Function L70: `_candidate_params() -> list[dict[str, Any]]`
+- Function L125: `_params_for_strategy(params: dict[str, Any]) -> dict[str, Any]`
+- Function L138: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L168: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_multiblock_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
+- Function L61: `_env_epoch_list(name: str, default: tuple[int, ...]) -> tuple[int, ...]`
+- Function L73: `_windows_from_starts(*, starts: tuple[int, ...], windows_per_block: int) -> tuple[tuple[str, str, str], ...]`
+- Function L85: `_known_s54_leader() -> dict[str, Any]`
+- Function L101: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L123: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L144: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L193: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L223: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_passive_hold_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L59: `_parse_utc_iso(value: str) -> datetime`
+- Function L63: `_btc_5m_replays_with_metadata(windows: tuple[tuple[str, str, str], ...], *, activation_seconds_before_close: int) -> tuple[object, ...]`
+- Function L91: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L133: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L137: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L158: `_strategy_params(params: dict[str, Any]) -> dict[str, Any]`
+- Function L166: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L185: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L234: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L255: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L304: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L335: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_taker_hold.py`
+- Imports: `__future__, datetime, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `_env_int(name: str, default: int) -> int`
+- Function L39: `_utc_iso(value: datetime) -> str`
+- Function L43: `_btc_5m_windows() -> tuple[tuple[str, datetime, datetime], ...]`
+- Function L60: `_btc_5m_replays() -> Any`
+- Function L83: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_taker_hold_s94_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L57: `_parse_utc(value: str) -> datetime`
+- Function L61: `_btc_5m_replays(windows: tuple[tuple[str, str, str], ...], *, activation_seconds_before_close: float) -> tuple[object, ...]`
+- Function L91: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L127: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L131: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L145: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L161: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L214: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L235: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L284: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L314: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_taker_hold_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L55: `_utc_iso(value: datetime) -> str`
+- Function L59: `_parse_utc_iso(value: str) -> datetime`
+- Function L63: `_btc_5m_replays(windows: tuple[tuple[str, str, str], ...], *, activation_seconds_before_close: float) -> Any`
+- Function L93: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L132: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L136: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L150: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L168: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L222: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L243: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L292: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L322: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_favorite_value_cap_s100_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, typing`
+- Function L42: `_env_epoch_list(name: str, default: tuple[int, ...]) -> tuple[int, ...]`
+- Function L54: `_windows_from_starts(*, starts: tuple[int, ...], windows_per_block: int) -> tuple[tuple[str, str, str], ...]`
+- Function L70: `_candidate_params() -> list[dict[str, Any]]`
+- Function L135: `_params_for_strategy(params: dict[str, Any]) -> dict[str, Any]`
+- Function L148: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L178: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_late_settlement_ablation_s95_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, typing`
+- Function L42: `_candidate_params() -> list[dict[str, Any]]`
+- Function L131: `_params_for_strategy(params: dict[str, Any]) -> dict[str, Any]`
+- Function L135: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L165: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_liquidity_withdrawal_hold_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L110: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L114: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L134: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L151: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L204: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L225: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L274: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L304: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_liquidity_withdrawal_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L110: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L114: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L134: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L151: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L206: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L227: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L276: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L306: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_low_price_passive_sweep_reprice_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, typing`
+- Function L43: `_run_label() -> str`
+- Function L50: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L124: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L163: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_opening_range_breakout_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L108: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L112: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L131: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L148: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L196: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L217: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L266: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L295: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_pair_arbitrage_search.py`
+- Imports: `__future__, csv, dataclasses, datetime, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L60: `_env_int(name: str, default: int) -> int`
+- Function L67: `_env_float(name: str, default: float) -> float`
+- Function L74: `_utc_iso(value: datetime) -> str`
+- Function L78: `_start_time() -> datetime`
+- Function L85: `_btc_5m_windows(*, start: datetime, count: int) -> tuple[tuple[str, str, str], ...]`
+- Function L97: `_btc_5m_replays(windows: tuple[tuple[str, str, str], ...]) -> tuple[object, ...]`
+- Function L113: `_replays_from_payload(payload: list[dict[str, Any]]) -> tuple[object, ...]`
+- Function L128: `_replays_to_payload(replays: tuple[object, ...]) -> list[dict[str, Any]]`
+- Function L141: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L172: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L176: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L193: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L206: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L254: `_as_float(value: object, *, default: float = 0.0) -> float`
+- Function L258: `_as_int(value: object, *, default: int = 0) -> int`
+- Function L262: `_evaluate_results(*, trial_id: int, phase: str, params: dict[str, Any], results: list[dict[str, Any]], replay_count: int) -> _Evaluation`
+- Function L317: `_worker_payload(evaluation: _Evaluation) -> dict[str, Any]`
+- Function L331: `_evaluation_from_worker_payload(*, trial_id: int, phase: str, params: dict[str, Any], payload: dict[str, Any]) -> _Evaluation`
+- Function L354: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L375: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L424: `_evaluation_row(evaluation: _Evaluation) -> dict[str, Any]`
+- Function L441: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L472: `run() -> None`
+- Class L45: `_Evaluation`
+
+### `backtests/private/telonex_btc_5m_pair_book_relative_strength_search.py`
+- Imports: `__future__, backtests, csv, dataclasses, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L69: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L114: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L118: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L132: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L149: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L197: `_evaluate_results(*, trial_id: int, phase: str, params: dict[str, Any], results: list[dict[str, Any]], replay_count: int) -> _Evaluation`
+- Function L252: `_worker_payload(evaluation: _Evaluation) -> dict[str, Any]`
+- Function L266: `_evaluation_from_worker_payload(*, trial_id: int, phase: str, params: dict[str, Any], payload: dict[str, Any]) -> _Evaluation`
+- Function L289: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L310: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L359: `_evaluation_row(evaluation: _Evaluation) -> dict[str, Any]`
+- Function L376: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L406: `run() -> None`
+- Class L54: `_Evaluation`
+
+### `backtests/private/telonex_btc_5m_passive_pair_accumulation_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L60: `_run_label() -> str`
+- Function L69: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L108: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L131: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L149: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L203: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L227: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L279: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L313: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_passive_pressure_momentum_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L59: `_run_label() -> str`
+- Function L66: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L129: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L153: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L171: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L225: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L246: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L298: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L338: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_passive_relative_value_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L59: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L118: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L142: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L158: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L212: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L233: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L282: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L314: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_passive_sweep_reprice_momentum_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L59: `_run_label() -> str`
+- Function L66: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L138: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L163: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L181: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L235: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L256: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L308: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L347: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_quote_velocity_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L108: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L112: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L131: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L142: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L195: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L216: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L265: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L295: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_round_trip_pair_arbitrage_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L90: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L94: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L111: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L128: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L176: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L197: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L246: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L276: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_settlement_pair_arbitrage_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L60: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L93: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L106: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L160: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L181: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L230: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L261: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_snap_trade_flow_search.py`
+- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, random, typing`
+- Function L35: `_env_int(name: str, default: int) -> int`
+- Function L42: `_start_time() -> datetime`
+- Function L49: `_run_label() -> str`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L104: `_evaluation_row(evaluation: base._Evaluation) -> dict[str, Any]`
+- Function L108: `_write_artifacts(*, run_label: str, evaluations: list[base._Evaluation]) -> tuple[Path, Path]`
+- Function L143: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_sweep_resiliency_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L108: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L112: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L131: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L148: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L196: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L217: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L266: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L296: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_trade_flow_search.py`
+- Imports: `__future__, csv, dataclasses, datetime, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L60: `_env_int(name: str, default: int) -> int`
+- Function L67: `_env_float(name: str, default: float) -> float`
+- Function L74: `_utc_iso(value: datetime) -> str`
+- Function L78: `_start_time() -> datetime`
+- Function L85: `_btc_5m_windows(*, start: datetime, count: int) -> tuple[tuple[str, str, str], ...]`
+- Function L97: `_btc_5m_replays(windows: tuple[tuple[str, str, str], ...]) -> tuple[object, ...]`
+- Function L113: `_replays_from_payload(payload: list[dict[str, Any]]) -> tuple[object, ...]`
+- Function L128: `_replays_to_payload(replays: tuple[object, ...]) -> list[dict[str, Any]]`
+- Function L141: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L189: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L193: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L207: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L218: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L266: `_as_float(value: object, *, default: float = 0.0) -> float`
+- Function L270: `_as_int(value: object, *, default: int = 0) -> int`
+- Function L274: `_evaluate_results(*, trial_id: int, phase: str, params: dict[str, Any], results: list[dict[str, Any]], replay_count: int) -> _Evaluation`
+- Function L329: `_worker_payload(evaluation: _Evaluation) -> dict[str, Any]`
+- Function L343: `_evaluation_from_worker_payload(*, trial_id: int, phase: str, params: dict[str, Any], payload: dict[str, Any]) -> _Evaluation`
+- Function L366: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L387: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L436: `_evaluation_row(evaluation: _Evaluation) -> dict[str, Any]`
+- Function L453: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L483: `run() -> None`
+- Class L45: `_Evaluation`
+
+### `backtests/private/telonex_btc_5m_volatility_expansion_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L130: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L145: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L198: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L219: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L268: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L298: `run() -> None`
+
+### `backtests/private/telonex_btc_5m_volume_clock_flow_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L56: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L114: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L118: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L132: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L149: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L197: `_evaluate_results(*, trial_id: int, phase: str, params: dict[str, Any], results: list[dict[str, Any]], replay_count: int) -> _Evaluation`
+- Function L252: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L273: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L322: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L352: `run() -> None`
+
+### `backtests/private/telonex_depth_pressure_trend_search.py`
+- Imports: `__future__, decimal, dotenv, importlib, os, pathlib`
+- Function L28: `_env_int(name: str, default: int) -> int`
+- Function L35: `_search(name: str) -> str`
+- Function L39: `_market_slugs() -> tuple[str, ...]`
+- Function L51: `_base_replays() -> tuple[object, ...]`
+- Function L66: `_window_specs() -> tuple[tuple[tuple[str, str, str], ...], tuple[tuple[str, str, str], ...]]`
+- Function L103: `build_search_config() -> object`
+- Function L217: `run() -> None`
+
+### `backtests/private/telonex_event_drawdown_controlled_deep_rebound_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, typing`
+- Function L44: `_canonical_params(params: dict[str, Any]) -> str`
+- Function L48: `_valid_params(params: dict[str, Any]) -> bool`
+- Function L58: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L167: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L200: `run() -> None`
+
+### `backtests/private/telonex_event_microprice_carry_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L68: `_event_replays(slugs: tuple[str, ...]) -> tuple[object, ...]`
+- Function L84: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L119: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L123: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L137: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L148: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L201: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L222: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L271: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L303: `run() -> None`
+
+### `backtests/private/telonex_event_panic_fade_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L57: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L102: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L106: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L127: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L138: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L189: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L210: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L259: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L291: `run() -> None`
+
+### `backtests/private/telonex_event_passive_no_stop_hold_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L62: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L111: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L132: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L181: `_write_artifacts(*, evaluations: list[_Evaluation], train_slugs: tuple[str, ...], holdout_slugs: tuple[str, ...]) -> tuple[Path, Path]`
+- Function L218: `run() -> None`
+
+### `backtests/private/telonex_event_passive_pressure_carry_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L62: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L111: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L132: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L181: `_write_artifacts(*, evaluations: list[_Evaluation], train_slugs: tuple[str, ...], holdout_slugs: tuple[str, ...]) -> tuple[Path, Path]`
+- Function L219: `run() -> None`
+
+### `backtests/private/telonex_event_passive_slow_hold_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L62: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L111: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L132: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L181: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L213: `run() -> None`
+
+### `backtests/private/telonex_event_passive_spread_capture_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L57: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L132: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L147: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L199: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L220: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L269: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L301: `run() -> None`
+
+### `backtests/private/telonex_event_persistent_bid_support_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L57: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L106: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L110: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L132: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L149: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L202: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L223: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L272: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L304: `run() -> None`
+
+### `backtests/private/telonex_event_persistent_bid_support_slow_hold_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L62: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L111: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L132: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L181: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L213: `run() -> None`
+
+### `backtests/private/telonex_event_supported_deep_rebound_gated_search.py`
+- Imports: `__future__, backtests, csv, dotenv, importlib, json, os, pathlib`
+- Function L42: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L75: `run() -> None`
+
+### `backtests/private/telonex_event_supported_deep_rebound_search.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
+- Function L57: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
+- Function L102: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L106: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L127: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L138: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L191: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L212: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L261: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L292: `run() -> None`
+
+### `backtests/private/telonex_event_supported_rebound_fixed_confirmation.py`
+- Imports: `__future__, backtests, csv, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
+- Function L80: `_event_replays_for_window(*, start_time: str, end_time: str) -> tuple[object, ...]`
+- Function L100: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
+- Function L104: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
+- Function L125: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
+- Function L136: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
+- Function L189: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L210: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
+- Function L259: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
+- Function L290: `run() -> None`
+
+### `backtests/private/telonex_guarded_breakout_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L148: `run() -> None`
+
+### `backtests/private/telonex_liquidity_reversion_search.py`
+- Imports: `__future__, decimal, dotenv, importlib, os, pathlib`
+- Function L28: `_env_int(name: str, default: int) -> int`
+- Function L35: `_search(name: str) -> str`
+- Function L39: `_market_slugs() -> tuple[str, ...]`
+- Function L51: `_base_replays() -> tuple[object, ...]`
+- Function L66: `_window_specs() -> tuple[tuple[tuple[str, str, str], ...], tuple[tuple[str, str, str], ...]]`
+- Function L103: `build_search_config() -> object`
+- Function L212: `run() -> None`
+
+### `backtests/private/telonex_liquidity_shock_resiliency_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L156: `run() -> None`
+
+### `backtests/private/telonex_microprice_imbalance_search.py`
+- Imports: `__future__, decimal, dotenv, importlib, os, pathlib`
+- Function L28: `_env_int(name: str, default: int) -> int`
+- Function L35: `_search(name: str) -> str`
+- Function L39: `_market_slugs() -> tuple[str, ...]`
+- Function L51: `_base_replays() -> tuple[object, ...]`
+- Function L66: `_window_specs() -> tuple[tuple[tuple[str, str, str], ...], tuple[tuple[str, str, str], ...]]`
+- Function L103: `build_search_config() -> object`
+- Function L207: `run() -> None`
+
+### `backtests/private/telonex_panic_liquidity_fade_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L138: `run() -> None`
+
+### `backtests/private/telonex_passive_spread_capture_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L151: `run() -> None`
+
+### `backtests/private/telonex_rsi_liquidity_reversion_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L132: `run() -> None`
+
+### `backtests/private/telonex_vwap_liquidity_momentum_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L151: `run() -> None`
+
+### `backtests/private/telonex_vwap_liquidity_reversion_s90_search.py`
+- Imports: `__future__, backtests, dataclasses, dotenv, importlib, os, pathlib`
+- Function L28: `run() -> None`
+
+### `backtests/private/telonex_vwap_liquidity_reversion_search.py`
+- Imports: `__future__, backtests, decimal, dotenv, importlib, os, pathlib`
+- Function L32: `build_search_config() -> object`
+- Function L151: `run() -> None`
 
 ### `backtests/sitecustomize.py`
 - Imports: `__future__, importlib, pathlib, sys`
@@ -362,62 +1012,62 @@ flowchart TD
 - Imports: none
 
 ### `prediction_market_extensions/adapters/polymarket/execution.py`
-- Imports: `asyncio, collections, json, msgspec, nautilus_trader, prediction_market_extensions, py_clob_client, typing`
-- Class L124: `PolymarketExecutionClient(LiveExecutionClient)`
-  - Method L151: `__init__(self, loop: asyncio.AbstractEventLoop, http_client: ClobClient, msgbus: MessageBus, cache: Cache, clock: LiveClock, instrument_provider: PolymarketInstrumentProvider, ws_auth: PolymarketWebSocketAuth, config: PolymarketExecClientConfig, name: str | None) -> None`
-  - Method L249: `async _connect(self) -> None`
-  - Method L271: `async _disconnect(self) -> None`
-  - Method L274: `_stop(self) -> None`
-  - Method L277: `async _maintain_active_market(self, instrument_id: InstrumentId) -> None`
-  - Method L281: `async _update_account_state(self) -> None`
-  - Method L302: `async _fetch_user_positions(self, *, limit: int = 100, size_threshold: int = 0) -> list[dict[str, Any]]`
-  - Method L350: `async generate_order_status_reports(self, command: GenerateOrderStatusReports) -> list[OrderStatusReport]`
-  - Method L521: `async generate_order_status_report(self, command: GenerateOrderStatusReport) -> OrderStatusReport | None`
-  - Method L576: `async generate_fill_reports(self, command: GenerateFillReports) -> list[FillReport]`
-  - Method L625: `async generate_position_status_reports(self, command: GeneratePositionStatusReports) -> list[PositionStatusReport]`
-  - Method L664: `_parse_trades_response_object(self, command: GenerateFillReports, json_obj: JSON, parsed_fill_keys: set[tuple[TradeId, VenueOrderId]], reports: list[FillReport]) -> None`
-  - Method L719: `async _fetch_quantities_from_gamma_api(self, instrument_ids: list[InstrumentId]) -> dict[InstrumentId, Quantity]`
-  - Method L757: `async _fetch_quantities_from_clob_api(self, instrument_ids: list[InstrumentId]) -> dict[InstrumentId, Quantity]`
-  - Method L785: `_generate_cancel_event(self, strategy_id, instrument_id, client_order_id, venue_order_id, reason: str, ts_event: int) -> None`
-  - Method L811: `_get_neg_risk_for_instrument(self, instrument) -> bool`
-  - Method L816: `async _query_account(self, _command: QueryAccount) -> None`
-  - Method L820: `async _cancel_order(self, command: CancelOrder) -> None`
-  - Method L867: `async _batch_cancel_orders(self, command: BatchCancelOrders) -> None`
-  - Method L920: `async _cancel_all_orders(self, command: CancelAllOrders) -> None`
-  - Method L968: `async _cancel_all_global(self) -> None`
-  - Method L1002: `async _cancel_market_orders(self, instrument_id: InstrumentId | None = None, asset_id: str = '') -> None`
-  - Method L1056: `async _submit_order(self, command: SubmitOrder) -> None`
-  - Method L1130: `_validate_order_for_batch(self, order: Order) -> str | None`
-  - Method L1154: `async _submit_order_list(self, command: SubmitOrderList) -> None`
-  - Method L1224: `async _sign_orders_for_batch(self, orders: list[Order]) -> tuple[list[Order], list[PostOrdersArgs]]`
-  - Method L1285: `async _post_signed_orders_batch(self, orders: list[Order], signed_orders_args: list[PostOrdersArgs]) -> None`
-  - Method L1314: `_reject_all_orders(self, orders: list[Order], reason: str) -> None`
-  - Method L1327: `_process_batch_response(self, orders: list[Order], response: list) -> None`
-  - Method L1378: `_deny_market_order_quantity(self, order: Order, reason: str) -> None`
-  - Method L1390: `async _submit_market_order(self, command: SubmitOrder, instrument) -> None`
-  - Method L1439: `async _submit_limit_order(self, command: SubmitOrder, instrument) -> None`
-  - Method L1485: `async _post_signed_order(self, order: Order, signed_order, post_only: bool = False) -> None`
-  - Method L1521: `_handle_ws_message(self, raw: bytes) -> None`
-  - Method L1543: `_add_trade_to_cache(self, msg: PolymarketUserTrade, raw: bytes) -> None`
-  - Method L1553: `async _wait_for_ack_order(self, msg: PolymarketUserOrder, venue_order_id: VenueOrderId) -> None`
-  - Method L1576: `async _wait_for_ack_trade(self, msg: PolymarketUserTrade, venue_order_id: VenueOrderId) -> None`
-  - Method L1603: `_handle_ws_order_msg(self, msg: PolymarketUserOrder, wait_for_ack: bool) -> Any`
-  - Method L1675: `_truncate_ordered_dict(self, store: OrderedDict[Any, Any]) -> None`
-  - Method L1679: `_record_processed_trade(self, trade_id: TradeId, status: PolymarketTradeStatus) -> None`
-  - Method L1693: `_record_processed_fill(self, trade_id: TradeId, venue_order_id: VenueOrderId) -> None`
-  - Method L1699: `_handle_ws_trade_msg(self, msg: PolymarketUserTrade, wait_for_ack: bool) -> Any`
-  - Method L1741: `_handle_user_trade_in_ws_trade_msg(self, msg: PolymarketUserTrade, trade_id: TradeId, wait_for_ack: bool, order_id: str) -> Any`
+- Imports: `asyncio, collections, json, msgspec, nautilus_trader, py_clob_client, typing`
+- Class L122: `PolymarketExecutionClient(LiveExecutionClient)`
+  - Method L149: `__init__(self, loop: asyncio.AbstractEventLoop, http_client: ClobClient, msgbus: MessageBus, cache: Cache, clock: LiveClock, instrument_provider: PolymarketInstrumentProvider, ws_auth: PolymarketWebSocketAuth, config: PolymarketExecClientConfig, name: str | None) -> None`
+  - Method L247: `async _connect(self) -> None`
+  - Method L269: `async _disconnect(self) -> None`
+  - Method L272: `_stop(self) -> None`
+  - Method L275: `async _maintain_active_market(self, instrument_id: InstrumentId) -> None`
+  - Method L279: `async _update_account_state(self) -> None`
+  - Method L298: `async _fetch_user_positions(self, *, limit: int = 100, size_threshold: int = 0) -> list[dict[str, Any]]`
+  - Method L346: `async generate_order_status_reports(self, command: GenerateOrderStatusReports) -> list[OrderStatusReport]`
+  - Method L517: `async generate_order_status_report(self, command: GenerateOrderStatusReport) -> OrderStatusReport | None`
+  - Method L572: `async generate_fill_reports(self, command: GenerateFillReports) -> list[FillReport]`
+  - Method L621: `async generate_position_status_reports(self, command: GeneratePositionStatusReports) -> list[PositionStatusReport]`
+  - Method L660: `_parse_trades_response_object(self, command: GenerateFillReports, json_obj: JSON, parsed_fill_keys: set[tuple[TradeId, VenueOrderId]], reports: list[FillReport]) -> None`
+  - Method L715: `async _fetch_quantities_from_gamma_api(self, instrument_ids: list[InstrumentId]) -> dict[InstrumentId, Quantity]`
+  - Method L753: `async _fetch_quantities_from_clob_api(self, instrument_ids: list[InstrumentId]) -> dict[InstrumentId, Quantity]`
+  - Method L781: `_generate_cancel_event(self, strategy_id, instrument_id, client_order_id, venue_order_id, reason: str, ts_event: int) -> None`
+  - Method L807: `_get_neg_risk_for_instrument(self, instrument) -> bool`
+  - Method L812: `async _query_account(self, _command: QueryAccount) -> None`
+  - Method L816: `async _cancel_order(self, command: CancelOrder) -> None`
+  - Method L863: `async _batch_cancel_orders(self, command: BatchCancelOrders) -> None`
+  - Method L916: `async _cancel_all_orders(self, command: CancelAllOrders) -> None`
+  - Method L964: `async _cancel_all_global(self) -> None`
+  - Method L998: `async _cancel_market_orders(self, instrument_id: InstrumentId | None = None, asset_id: str = '') -> None`
+  - Method L1052: `async _submit_order(self, command: SubmitOrder) -> None`
+  - Method L1126: `_validate_order_for_batch(self, order: Order) -> str | None`
+  - Method L1150: `async _submit_order_list(self, command: SubmitOrderList) -> None`
+  - Method L1220: `async _sign_orders_for_batch(self, orders: list[Order]) -> tuple[list[Order], list[PostOrdersArgs]]`
+  - Method L1281: `async _post_signed_orders_batch(self, orders: list[Order], signed_orders_args: list[PostOrdersArgs]) -> None`
+  - Method L1310: `_reject_all_orders(self, orders: list[Order], reason: str) -> None`
+  - Method L1323: `_process_batch_response(self, orders: list[Order], response: list) -> None`
+  - Method L1374: `_deny_market_order_quantity(self, order: Order, reason: str) -> None`
+  - Method L1386: `async _submit_market_order(self, command: SubmitOrder, instrument) -> None`
+  - Method L1435: `async _submit_limit_order(self, command: SubmitOrder, instrument) -> None`
+  - Method L1481: `async _post_signed_order(self, order: Order, signed_order, post_only: bool = False) -> None`
+  - Method L1517: `_handle_ws_message(self, raw: bytes) -> None`
+  - Method L1539: `_add_trade_to_cache(self, msg: PolymarketUserTrade, raw: bytes) -> None`
+  - Method L1549: `async _wait_for_ack_order(self, msg: PolymarketUserOrder, venue_order_id: VenueOrderId) -> None`
+  - Method L1572: `async _wait_for_ack_trade(self, msg: PolymarketUserTrade, venue_order_id: VenueOrderId) -> None`
+  - Method L1599: `_handle_ws_order_msg(self, msg: PolymarketUserOrder, wait_for_ack: bool) -> Any`
+  - Method L1671: `_truncate_ordered_dict(self, store: OrderedDict[Any, Any]) -> None`
+  - Method L1675: `_record_processed_trade(self, trade_id: TradeId, status: PolymarketTradeStatus) -> None`
+  - Method L1689: `_record_processed_fill(self, trade_id: TradeId, venue_order_id: VenueOrderId) -> None`
+  - Method L1695: `_handle_ws_trade_msg(self, msg: PolymarketUserTrade, wait_for_ack: bool) -> Any`
+  - Method L1737: `_handle_user_trade_in_ws_trade_msg(self, msg: PolymarketUserTrade, trade_id: TradeId, wait_for_ack: bool, order_id: str) -> Any`
 
 ### `prediction_market_extensions/adapters/polymarket/fee_model.py`
 - Imports: `__future__, collections, decimal, nautilus_trader, prediction_market_extensions, typing`
-- Function L62: `_normalize_label(value: object) -> str | None`
-- Function L71: `_iter_tag_labels(tags: object) -> Iterable[str]`
-- Function L93: `_market_labels(info: Mapping[str, Any] | None) -> set[str]`
-- Function L121: `infer_maker_rebate_rate(*, market_info: Mapping[str, Any] | None, fee_rate_bps: Decimal) -> Decimal`
-- Function L151: `calculate_maker_rebate(*, quantity: Decimal, price: Decimal, fee_rate_bps: Decimal, maker_rebate_rate: Decimal) -> float`
-- Class L176: `PolymarketFeeModel(FeeModel)`
-  - Method L200: `__init__(self, *, maker_rebates_enabled: bool = True) -> None`
-  - Method L203: `get_commission(self, order, fill_qty, fill_px, instrument) -> Money`
+- Function L66: `_normalize_label(value: object) -> str | None`
+- Function L75: `_iter_tag_labels(tags: object) -> Iterable[str]`
+- Function L97: `_market_labels(info: Mapping[str, Any] | None) -> set[str]`
+- Function L125: `infer_maker_rebate_rate(*, market_info: Mapping[str, Any] | None, fee_rate_bps: Decimal) -> Decimal`
+- Function L155: `calculate_maker_rebate(*, quantity: Decimal, price: Decimal, fee_rate_bps: Decimal, maker_rebate_rate: Decimal) -> float`
+- Class L187: `PolymarketFeeModel(FeeModel)`
+  - Method L211: `__init__(self, *, maker_rebates_enabled: bool = True) -> None`
+  - Method L214: `get_commission(self, order, fill_qty, fill_px, instrument) -> Money`
 
 ### `prediction_market_extensions/adapters/polymarket/gamma_markets.py`
 - Imports: `__future__, collections, math, msgspec, nautilus_trader, os, typing`
@@ -497,10 +1147,9 @@ flowchart TD
 - Function L215: `is_resolved_sports_market(market: Mapping[str, Any], *, now: datetime, max_days_since_close: float) -> bool`
 
 ### `prediction_market_extensions/adapters/polymarket/parsing.py`
-- Imports: `__future__, decimal`
-- Function L34: `basis_points_as_decimal(basis_points: Decimal) -> Decimal`
-- Function L52: `infer_fee_exponent(fee_rate_bps: Decimal) -> int`
-- Function L75: `calculate_commission(quantity: Decimal, price: Decimal, fee_rate_bps: Decimal, fee_exponent: int = 1, **_kwargs: object) -> float`
+- Imports: `__future__, decimal, nautilus_trader`
+- Function L32: `basis_points_as_decimal(basis_points: Decimal) -> Decimal`
+- Function L50: `calculate_commission(quantity: Decimal, price: Decimal, fee_rate: Decimal, liquidity_side: LiquiditySide) -> float`
 
 ### `prediction_market_extensions/adapters/polymarket/pmxt.py`
 - Imports: `__future__, collections, concurrent, contextlib, dataclasses, datetime, duckdb, nautilus_trader, os, pandas, pathlib, prediction_market_extensions, pyarrow, re, shutil, tempfile, time, typing, urllib, warnings`
@@ -999,26 +1648,26 @@ flowchart TD
 - Function L535: `_series_values(series: object) -> list[float]`
 - Function L550: `_max_drawdown_currency(equity_series: object) -> float`
 - Function L563: `_joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float`
-- Function L631: `_as_float(value: object, *, default: float = 0.0) -> float`
-- Function L637: `_as_int(value: object, *, default: int = 0) -> int`
-- Function L645: `_score_result(*, pnl: float, max_drawdown_currency: float, fills: int, requested_coverage_ratio: float, terminated_early: bool, initial_cash: float, min_fills_per_window: int) -> float`
-- Function L663: `_evaluate_window(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues, window: ParameterSearchWindow) -> _WindowEvaluation`
-- Function L758: `_median_metric(values: Sequence[float]) -> float`
-- Function L762: `_build_leaderboard_row(*, trial_id: int, params: ParameterValues, train_evaluations: Sequence[_WindowEvaluation], holdout_evaluations: Sequence[_WindowEvaluation] = ()) -> ParameterSearchLeaderboardRow`
-- Function L813: `_train_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[float, int]`
-- Function L817: `_final_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[int, float, float, int]`
-- Function L825: `_params_dict(params: ParameterValues) -> dict[str, Any]`
-- Function L829: `_json_safe(value) -> Any`
-- Function L843: `_write_leaderboard_csv(*, rows: Sequence[ParameterSearchLeaderboardRow], output_path: Path) -> str`
-- Function L906: `_summary_payload(*, config: ParameterSearchConfig, summary: ParameterSearchSummary) -> dict[str, Any]`
-- Function L945: `_write_summary_json(*, config: ParameterSearchConfig, summary: ParameterSearchSummary, output_path: Path) -> str`
-- Function L958: `_format_score(value: float | None) -> str`
-- Function L964: `_print_top_candidates(*, rows: Sequence[ParameterSearchLeaderboardRow], holdout_enabled: bool) -> None`
-- Function L986: `_evaluate_train_windows(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues) -> tuple[_WindowEvaluation, ...]`
-- Function L1001: `_run_random_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
-- Function L1026: `_suggest_params_from_trial(trial, parameter_space: Mapping[str, ParameterSpec]) -> ParameterValues`
-- Function L1061: `_run_tpe_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
-- Function L1101: `run_parameter_search(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None = None) -> ParameterSearchSummary`
+- Function L633: `_as_float(value: object, *, default: float = 0.0) -> float`
+- Function L639: `_as_int(value: object, *, default: int = 0) -> int`
+- Function L647: `_score_result(*, pnl: float, max_drawdown_currency: float, fills: int, requested_coverage_ratio: float, terminated_early: bool, initial_cash: float, min_fills_per_window: int) -> float`
+- Function L665: `_evaluate_window(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues, window: ParameterSearchWindow) -> _WindowEvaluation`
+- Function L760: `_median_metric(values: Sequence[float]) -> float`
+- Function L764: `_build_leaderboard_row(*, trial_id: int, params: ParameterValues, train_evaluations: Sequence[_WindowEvaluation], holdout_evaluations: Sequence[_WindowEvaluation] = ()) -> ParameterSearchLeaderboardRow`
+- Function L815: `_train_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[float, int]`
+- Function L819: `_final_row_sort_key(row: ParameterSearchLeaderboardRow) -> tuple[int, float, float, int]`
+- Function L827: `_params_dict(params: ParameterValues) -> dict[str, Any]`
+- Function L831: `_json_safe(value) -> Any`
+- Function L845: `_write_leaderboard_csv(*, rows: Sequence[ParameterSearchLeaderboardRow], output_path: Path) -> str`
+- Function L908: `_summary_payload(*, config: ParameterSearchConfig, summary: ParameterSearchSummary) -> dict[str, Any]`
+- Function L947: `_write_summary_json(*, config: ParameterSearchConfig, summary: ParameterSearchSummary, output_path: Path) -> str`
+- Function L960: `_format_score(value: float | None) -> str`
+- Function L966: `_print_top_candidates(*, rows: Sequence[ParameterSearchLeaderboardRow], holdout_enabled: bool) -> None`
+- Function L988: `_evaluate_train_windows(*, config: ParameterSearchConfig, evaluator: BacktestEvaluator | None, trial_id: int, params: ParameterValues) -> tuple[_WindowEvaluation, ...]`
+- Function L1003: `_run_random_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
+- Function L1028: `_suggest_params_from_trial(trial, parameter_space: Mapping[str, ParameterSpec]) -> ParameterValues`
+- Function L1063: `_run_tpe_trials(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None) -> tuple[dict[int, tuple[_WindowEvaluation, ...]], dict[int, ParameterSearchLeaderboardRow], int, int]`
+- Function L1103: `run_parameter_search(config: ParameterSearchConfig, *, evaluator: BacktestEvaluator | None = None) -> ParameterSearchSummary`
 - Class L52: `ParameterSearchWindow`
 - Class L59: `ParameterSearchConfig`
   - Method L85: `optimizer_type(self) -> str`
@@ -1093,10 +1742,13 @@ flowchart TD
   - Method L528: `apply(self, results: Results) -> Results`
 
 ### `prediction_market_extensions/backtesting/_strategy_configs.py`
-- Imports: `__future__, collections, copy, nautilus_trader, typing`
-- Function L17: `_normalized_config(*, raw_config: Mapping[str, Any], instrument_id: InstrumentId) -> dict[str, Any]`
-- Function L33: `build_importable_strategy_configs(*, strategy_configs: Sequence[StrategyConfigSpec], instrument_id: InstrumentId) -> list[ImportableStrategyConfig]`
-- Function L55: `build_strategies_from_configs(*, strategy_configs: Sequence[StrategyConfigSpec], instrument_id: InstrumentId) -> list[Strategy]`
+- Imports: `__future__, collections, copy, importlib, nautilus_trader, typing`
+- Function L18: `_is_primary_instrument_sentinel(value) -> bool`
+- Function L22: `_import_symbol(import_path: str) -> Any`
+- Function L31: `_config_field_names(config_path: str) -> set[str]`
+- Function L36: `_normalized_config(*, raw_config: Mapping[str, Any], config_path: str, instrument_id: InstrumentId) -> dict[str, Any]`
+- Function L74: `build_importable_strategy_configs(*, strategy_configs: Sequence[StrategyConfigSpec], instrument_id: InstrumentId) -> list[ImportableStrategyConfig]`
+- Function L100: `build_strategies_from_configs(*, strategy_configs: Sequence[StrategyConfigSpec], instrument_id: InstrumentId) -> list[Strategy]`
 
 ### `prediction_market_extensions/backtesting/_timing_harness.py`
 - Imports: `__future__, collections, functools, inspect, os, typing`
@@ -1312,40 +1964,41 @@ flowchart TD
 - Function L391: `_trade_source_label(source: str) -> str`
 - Function L414: `_print_trade_progress_line(*, day: pd.Timestamp, elapsed_secs: float, rows: int, source: str) -> None`
 - Function L437: `_polymarket_ceiling_warning(caught_warnings: list[warnings.WarningMessage]) -> str | None`
-- Function L445: `_trade_days_for_window(start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, ...]`
-- Function L458: `async _load_trade_ticks(loader, *, start: pd.Timestamp, end: pd.Timestamp, market_label: str) -> tuple[TradeTick, ...]`
-- Function L538: `_merge_records(*, book_records: tuple[OrderBookDeltas, ...], trade_records: tuple[TradeTick, ...]) -> tuple[object, ...]`
-- Function L587: `async _gather_bounded(values: Sequence[Any], *, workers: int, func: Callable[[Any], Any]) -> list[Any]`
-- Function L606: `_resolve_materialize_workers(source_workers: int) -> int`
-- Function L618: `_resolve_pmxt_grouped_market_chunk_size() -> int`
-- Function L628: `_pmxt_cache_disabled_for_all(prepared: Sequence[_PreparedBookReplay]) -> bool`
-- Function L634: `_emit_materialize_worker_event(*, vendor: str, materialize_workers: int, source_workers: int) -> None`
-- Function L658: `_call_int_method(obj, name: str, default: int) -> int`
-- Function L668: `_prepared_book_day_count(item: _PreparedBookReplay) -> int`
-- Function L678: `_telonex_materialized_cache_complete(prepared: Sequence[_PreparedBookReplay]) -> bool`
-- Function L700: `_resolve_telonex_book_workers(prepared: Sequence[_PreparedBookReplay], *, requested_workers: int) -> int`
-- Class L567: `_ResolvedBookReplay`
-- Class L574: `_PreparedBookReplay`
-- Class L581: `_LoadedBookReplay`
-- Class L751: `_BaseReplayAdapter(HistoricalReplayAdapter)`
-  - Method L761: `key(self) -> ReplayAdapterKey`
-  - Method L765: `replay_spec_type(self) -> type[Any]`
-  - Method L768: `configure_sources(self, *, sources: tuple[str, ...] | list[str]) -> AbstractContextManager[Any]`
-  - Method L774: `engine_profile(self) -> ReplayEngineProfile`
-  - Method L777: `build_single_market_replay(self, *, field_values: Mapping[str, Any]) -> Any`
-  - Method L789: `_resolve_book_replay_window(self, replay: BookReplay, *, request: ReplayLoadRequest, source_label: str) -> _ResolvedBookReplay`
-  - Method L817: `_emit_book_replay_start(*, resolved: _ResolvedBookReplay, vendor: str) -> None`
-  - Method L836: `_emit_book_replay_fetch_error(*, replay: BookReplay, vendor: str, source_label: str, error: Exception) -> None`
-  - Method L850: `_build_loaded_book_replay_or_none(self, *, prepared: _PreparedBookReplay, records: tuple[object, ...], book_event_count: int | None = None, request: ReplayLoadRequest, vendor: str, source_label: str) -> LoadedReplay | None`
-  - Method L909: `_build_loaded_replay(self, *, replay, instrument, records: tuple[Any, ...], count: int, count_key: str, market_key: str, market_id: str, prices: tuple[float, ...], outcome: str, realized_outcome: float | None, metadata: dict[str, Any], requested_window: ReplayWindow) -> LoadedReplay`
-- Class L945: `PolymarketPMXTBookReplayAdapter(_BaseReplayAdapter)`
-  - Method L946: `__init__(self) -> None`
-  - Method L973: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
-  - Method L1083: `async load_replays(self, replays: Sequence[BookReplay], *, request: ReplayLoadRequest, workers: int) -> list[LoadedReplay]`
-- Class L1813: `PolymarketTelonexBookReplayAdapter(_BaseReplayAdapter)`
-  - Method L1814: `__init__(self) -> None`
-  - Method L1844: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
-  - Method L1964: `async load_replays(self, replays: Sequence[BookReplay], *, request: ReplayLoadRequest, workers: int) -> list[LoadedReplay]`
+- Function L445: `_disable_polymarket_trade_fallback() -> bool`
+- Function L450: `_trade_days_for_window(start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, ...]`
+- Function L463: `async _load_trade_ticks(loader, *, start: pd.Timestamp, end: pd.Timestamp, market_label: str) -> tuple[TradeTick, ...]`
+- Function L548: `_merge_records(*, book_records: tuple[OrderBookDeltas, ...], trade_records: tuple[TradeTick, ...]) -> tuple[object, ...]`
+- Function L597: `async _gather_bounded(values: Sequence[Any], *, workers: int, func: Callable[[Any], Any]) -> list[Any]`
+- Function L616: `_resolve_materialize_workers(source_workers: int) -> int`
+- Function L628: `_resolve_pmxt_grouped_market_chunk_size() -> int`
+- Function L638: `_pmxt_cache_disabled_for_all(prepared: Sequence[_PreparedBookReplay]) -> bool`
+- Function L644: `_emit_materialize_worker_event(*, vendor: str, materialize_workers: int, source_workers: int) -> None`
+- Function L668: `_call_int_method(obj, name: str, default: int) -> int`
+- Function L678: `_prepared_book_day_count(item: _PreparedBookReplay) -> int`
+- Function L688: `_telonex_materialized_cache_complete(prepared: Sequence[_PreparedBookReplay]) -> bool`
+- Function L710: `_resolve_telonex_book_workers(prepared: Sequence[_PreparedBookReplay], *, requested_workers: int) -> int`
+- Class L577: `_ResolvedBookReplay`
+- Class L584: `_PreparedBookReplay`
+- Class L591: `_LoadedBookReplay`
+- Class L761: `_BaseReplayAdapter(HistoricalReplayAdapter)`
+  - Method L771: `key(self) -> ReplayAdapterKey`
+  - Method L775: `replay_spec_type(self) -> type[Any]`
+  - Method L778: `configure_sources(self, *, sources: tuple[str, ...] | list[str]) -> AbstractContextManager[Any]`
+  - Method L784: `engine_profile(self) -> ReplayEngineProfile`
+  - Method L787: `build_single_market_replay(self, *, field_values: Mapping[str, Any]) -> Any`
+  - Method L799: `_resolve_book_replay_window(self, replay: BookReplay, *, request: ReplayLoadRequest, source_label: str) -> _ResolvedBookReplay`
+  - Method L827: `_emit_book_replay_start(*, resolved: _ResolvedBookReplay, vendor: str) -> None`
+  - Method L846: `_emit_book_replay_fetch_error(*, replay: BookReplay, vendor: str, source_label: str, error: Exception) -> None`
+  - Method L860: `_build_loaded_book_replay_or_none(self, *, prepared: _PreparedBookReplay, records: tuple[object, ...], book_event_count: int | None = None, request: ReplayLoadRequest, vendor: str, source_label: str) -> LoadedReplay | None`
+  - Method L919: `_build_loaded_replay(self, *, replay, instrument, records: tuple[Any, ...], count: int, count_key: str, market_key: str, market_id: str, prices: tuple[float, ...], outcome: str, realized_outcome: float | None, metadata: dict[str, Any], requested_window: ReplayWindow) -> LoadedReplay`
+- Class L955: `PolymarketPMXTBookReplayAdapter(_BaseReplayAdapter)`
+  - Method L956: `__init__(self) -> None`
+  - Method L983: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
+  - Method L1093: `async load_replays(self, replays: Sequence[BookReplay], *, request: ReplayLoadRequest, workers: int) -> list[LoadedReplay]`
+- Class L1823: `PolymarketTelonexBookReplayAdapter(_BaseReplayAdapter)`
+  - Method L1824: `__init__(self) -> None`
+  - Method L1854: `async load_replay(self, replay: BookReplay, *, request: ReplayLoadRequest) -> LoadedReplay | None`
+  - Method L1974: `async load_replays(self, replays: Sequence[BookReplay], *, request: ReplayLoadRequest, workers: int) -> list[LoadedReplay]`
 
 ### `prediction_market_extensions/backtesting/data_sources/telonex.py`
 - Imports: `__future__, collections, concurrent, contextlib, contextvars, dataclasses, datetime, duckdb, hashlib, io, nautilus_trader, numpy, os, pandas, pathlib, prediction_market_extensions, pyarrow, re, resource, tempfile, threading, time, urllib, warnings`
@@ -1382,103 +2035,103 @@ flowchart TD
 - Function L520: `_source_summary_parts(entries: Sequence[TelonexSourceEntry]) -> list[str]`
 - Function L531: `_source_summary_line(label: str, parts: Sequence[str]) -> str`
 - Function L535: `_trade_source_summary_parts(entries: Sequence[TelonexSourceEntry]) -> list[str]`
-- Function L550: `_source_summary(entries: Sequence[TelonexSourceEntry]) -> str`
-- Function L561: `resolve_telonex_loader_config(*, sources: Sequence[str] | None = None, channel: str | None = None) -> tuple[TelonexDataSourceSelection, TelonexLoaderConfig]`
-- Function L581: `resolve_telonex_data_source_selection(*, sources: Sequence[str] | None = None) -> tuple[TelonexDataSourceSelection, dict[str, str | None]]`
-- Function L589: `configured_telonex_data_source(*, sources: Sequence[str] | None = None, channel: str | None = None) -> Iterator[TelonexDataSourceSelection]`
+- Function L558: `_source_summary(entries: Sequence[TelonexSourceEntry]) -> str`
+- Function L569: `resolve_telonex_loader_config(*, sources: Sequence[str] | None = None, channel: str | None = None) -> tuple[TelonexDataSourceSelection, TelonexLoaderConfig]`
+- Function L589: `resolve_telonex_data_source_selection(*, sources: Sequence[str] | None = None) -> tuple[TelonexDataSourceSelection, dict[str, str | None]]`
+- Function L597: `configured_telonex_data_source(*, sources: Sequence[str] | None = None, channel: str | None = None) -> Iterator[TelonexDataSourceSelection]`
 - Class L145: `TelonexSourceEntry`
 - Class L152: `TelonexLoaderConfig`
 - Class L158: `TelonexDataSourceSelection`
 - Class L164: `_TelonexDayResult`
 - Class L171: `_TelonexBlobRowGroupIndex`
-- Class L600: `RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader)`
-  - Method L601: `__init__(self, *args, **kwargs) -> None`
-  - Method L606: `_ensure_blob_scan_caches(self) -> None`
-  - Method L636: `_forget_blob_ts_cache_key(self, cache_key: tuple[str, str, str, int, str | None, int, int]) -> None`
-  - Method L646: `async from_market_slug(cls, slug: str, token_index: int = 0, http_client = None) -> 'RunnerPolymarketTelonexBookDataLoader'`
-  - Method L659: `_download_progress(self, url: str, downloaded_bytes: int, total_bytes: int | None, finished: bool) -> None`
-  - Method L677: `_telonex_source_kind(source: str) -> str | None`
-  - Method L681: `_telonex_stage_for_source(source: str) -> str`
-  - Method L684: `_day_progress(self, date: str, event: str, source: str, rows: int) -> None`
-  - Method L717: `_emit_cache_write_event(self, *, cache_kind: str, cache_path: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, level: str, status: str, message: str, rows: int | None = None, bytes_count: int | None = None, book_events: int | None = None, trade_ticks: int | None = None, error: str | None = None) -> None`
-  - Method L766: `_resolve_api_cache_root(cls) -> Path | None`
-  - Method L770: `_resolve_prefetch_workers(cls) -> int`
-  - Method L780: `_resolve_local_prefetch_workers(cls) -> int`
-  - Method L790: `_resolve_cache_prefetch_workers(cls) -> int`
-  - Method L800: `_resolve_api_worker_limit(cls) -> int`
-  - Method L804: `_resolve_file_worker_limit(cls) -> int`
-  - Method L807: `_config(self) -> TelonexLoaderConfig`
-  - Method L814: `_date_range(start: pd.Timestamp, end: pd.Timestamp) -> list[str]`
-  - Method L820: `_outcome_segments(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
-  - Method L827: `_local_blob_root(root: Path) -> Path | None`
-  - Method L841: `_outcome_segment_candidates(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
-  - Method L848: `_month_partition_dirs(*, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[Path, ...]`
-  - Method L859: `_readable_blob_part_paths(self, *, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool]`
-  - Method L896: `_scan_readable_blob_part_paths(self, partition_dir: Path) -> tuple[tuple[str, ...], bool]`
-  - Method L936: `_manifest_blob_part_paths(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool] | None`
-  - Method L1013: `_manifest_completed_row_count(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, date: str) -> int | None`
-  - Method L1052: `_manifest_empty_day_exists(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, date: str) -> bool`
-  - Method L1089: `_blob_row_group_index(self, path: str) -> _TelonexBlobRowGroupIndex | None`
-  - Method L1113: `_build_blob_row_group_index(parquet_file: pq.ParquetFile) -> _TelonexBlobRowGroupIndex`
-  - Method L1171: `_load_blob_range_row_groups(self, *, part_paths: Sequence[str], market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None | object`
-  - Method L1235: `_blob_row_groups_by_part(self, *, part_paths: Sequence[str], market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, list[int]] | object`
-  - Method L1263: `_load_blob_range(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
-  - Method L1488: `_try_load_deltas_day_from_local_blob_native(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas], Mapping[str, Sequence[object]], str] | None`
-  - Method L1620: `_download_api_day_to_cache(self, *, presigned_url: str, progress_url: str, cache_path: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> int | None`
-  - Method L1705: `_download_api_day_to_temp_file(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, str] | None`
-  - Method L1774: `_ensure_api_day_cache_path(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path | None, str]`
-  - Method L1837: `_try_load_deltas_day_from_api_native(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas], Mapping[str, Sequence[object]], str] | None`
-  - Method L1927: `_cached_ts_ns_for_frame(self, frame: pd.DataFrame, column_name: str) -> np.ndarray | None`
-  - Method L1938: `_local_consolidated_candidates(cls, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
-  - Method L1956: `_local_daily_candidates(cls, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
-  - Method L1975: `_local_consolidated_path(self, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L1995: `_local_path_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L2018: `_safe_read_parquet(path: Path) -> pd.DataFrame | None`
-  - Method L2029: `_load_local_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L2052: `_api_url(*, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L2071: `_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L2095: `_load_api_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L2124: `_write_api_cache_day(self, *, payload: bytes, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
-  - Method L2185: `_fast_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
-  - Method L2207: `_load_fast_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L2236: `_write_fast_cache_day(self, *, frame: pd.DataFrame, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
-  - Method L2333: `_load_api_day_cached(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L2408: `_deltas_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
-  - Method L2437: `has_complete_materialized_deltas_cache(self, *, start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None) -> bool`
-  - Method L2468: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas] | None, str]`
-  - Method L2514: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], delta_columns: Mapping[str, Sequence[object]] | None = None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> None`
-  - Method L2592: `_trade_ticks_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
-  - Method L2621: `_load_trade_ticks_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[tuple[TradeTick, ...] | None, str]`
-  - Method L2677: `_write_trade_ticks_cache_day(self, *, records: Sequence[TradeTick], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> None`
-  - Method L2752: `_trade_ticks_to_cache_table(records: Sequence[TradeTick]) -> pa.Table`
-  - Method L2779: `_trade_ticks_from_cache_table(self, table: pa.Table) -> tuple[TradeTick, ...]`
-  - Method L2782: `_trade_ticks_from_cache_frame(self, frame: pd.DataFrame) -> tuple[TradeTick, ...]`
-  - Method L2818: `_deltas_columns_to_table(data: Mapping[str, Sequence[object]]) -> pa.Table`
-  - Method L2834: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
-  - Method L2870: `_numeric_table_column(table: pa.Table, name: str) -> np.ndarray`
-  - Method L2873: `_deltas_records_from_table(self, table: pa.Table) -> list[OrderBookDeltas]`
-  - Method L2888: `_deltas_records_from_columns(self, data: dict[str, Sequence[object]]) -> list[OrderBookDeltas]`
-  - Method L2940: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
-  - Method L2967: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
-  - Method L3060: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
-  - Method L3072: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
-  - Method L3077: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
-  - Method L3091: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
-  - Method L3097: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> list[OrderBookDeltas]`
-  - Method L3113: `_book_events_and_delta_columns_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> tuple[list[OrderBookDeltas], Mapping[str, Sequence[object]] | None]`
-  - Method L3206: `_optional_column(frame: pd.DataFrame, names: Sequence[str]) -> str | None`
-  - Method L3212: `_onchain_fill_trade_ticks_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp) -> list[TradeTick]`
-  - Method L3287: `_trade_ticks_from_native_columns(self, data: tuple[list[float], list[float], list[int], list[str], list[int], list[int]]) -> list[TradeTick]`
-  - Method L3316: `_rounded_float64_array(values: object, precision: int) -> np.ndarray`
-  - Method L3319: `_empty_local_blob_day_frame(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
-  - Method L3355: `_parse_telonex_trade_frame(self, frame: pd.DataFrame, *, channel: str, source: str, start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int) -> tuple[TradeTick, ...] | None`
-  - Method L3380: `load_telonex_onchain_fill_ticks(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str | None = None, token_index: int | None = None, outcome: str | None = None) -> tuple[TradeTick, ...] | None`
-  - Method L3555: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
-  - Method L3623: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
-  - Method L3665: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
-  - Method L3684: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None]) -> _TelonexDayResult`
-  - Method L3861: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool) -> Iterator[_TelonexDayResult]`
-  - Method L3934: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
+- Class L608: `RunnerPolymarketTelonexBookDataLoader(PolymarketDataLoader)`
+  - Method L609: `__init__(self, *args, **kwargs) -> None`
+  - Method L614: `_ensure_blob_scan_caches(self) -> None`
+  - Method L644: `_forget_blob_ts_cache_key(self, cache_key: tuple[str, str, str, int, str | None, int, int]) -> None`
+  - Method L654: `async from_market_slug(cls, slug: str, token_index: int = 0, http_client = None) -> 'RunnerPolymarketTelonexBookDataLoader'`
+  - Method L667: `_download_progress(self, url: str, downloaded_bytes: int, total_bytes: int | None, finished: bool) -> None`
+  - Method L685: `_telonex_source_kind(source: str) -> str | None`
+  - Method L689: `_telonex_stage_for_source(source: str) -> str`
+  - Method L692: `_day_progress(self, date: str, event: str, source: str, rows: int) -> None`
+  - Method L725: `_emit_cache_write_event(self, *, cache_kind: str, cache_path: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, level: str, status: str, message: str, rows: int | None = None, bytes_count: int | None = None, book_events: int | None = None, trade_ticks: int | None = None, error: str | None = None) -> None`
+  - Method L774: `_resolve_api_cache_root(cls) -> Path | None`
+  - Method L778: `_resolve_prefetch_workers(cls) -> int`
+  - Method L788: `_resolve_local_prefetch_workers(cls) -> int`
+  - Method L798: `_resolve_cache_prefetch_workers(cls) -> int`
+  - Method L808: `_resolve_api_worker_limit(cls) -> int`
+  - Method L812: `_resolve_file_worker_limit(cls) -> int`
+  - Method L815: `_config(self) -> TelonexLoaderConfig`
+  - Method L822: `_date_range(start: pd.Timestamp, end: pd.Timestamp) -> list[str]`
+  - Method L828: `_outcome_segments(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
+  - Method L835: `_local_blob_root(root: Path) -> Path | None`
+  - Method L849: `_outcome_segment_candidates(*, token_index: int, outcome: str | None) -> tuple[str, ...]`
+  - Method L856: `_month_partition_dirs(*, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[Path, ...]`
+  - Method L867: `_readable_blob_part_paths(self, *, channel_dir: Path, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool]`
+  - Method L904: `_scan_readable_blob_part_paths(self, partition_dir: Path) -> tuple[tuple[str, ...], bool]`
+  - Method L944: `_manifest_blob_part_paths(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[str], bool] | None`
+  - Method L1021: `_manifest_completed_row_count(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, date: str) -> int | None`
+  - Method L1060: `_manifest_empty_day_exists(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, date: str) -> bool`
+  - Method L1097: `_blob_row_group_index(self, path: str) -> _TelonexBlobRowGroupIndex | None`
+  - Method L1121: `_build_blob_row_group_index(parquet_file: pq.ParquetFile) -> _TelonexBlobRowGroupIndex`
+  - Method L1179: `_load_blob_range_row_groups(self, *, part_paths: Sequence[str], market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None | object`
+  - Method L1243: `_blob_row_groups_by_part(self, *, part_paths: Sequence[str], market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> dict[str, list[int]] | object`
+  - Method L1271: `_load_blob_range(self, *, store_root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame | None`
+  - Method L1496: `_try_load_deltas_day_from_local_blob_native(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas], Mapping[str, Sequence[object]], str] | None`
+  - Method L1628: `_download_api_day_to_cache(self, *, presigned_url: str, progress_url: str, cache_path: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> int | None`
+  - Method L1713: `_download_api_day_to_temp_file(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, str] | None`
+  - Method L1782: `_ensure_api_day_cache_path(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path | None, str]`
+  - Method L1845: `_try_load_deltas_day_from_api_native(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas], Mapping[str, Sequence[object]], str] | None`
+  - Method L1935: `_cached_ts_ns_for_frame(self, frame: pd.DataFrame, column_name: str) -> np.ndarray | None`
+  - Method L1946: `_local_consolidated_candidates(cls, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
+  - Method L1964: `_local_daily_candidates(cls, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[Path, ...]`
+  - Method L1983: `_local_consolidated_path(self, *, root: Path, channel: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L2003: `_local_path_for_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L2026: `_safe_read_parquet(path: Path) -> pd.DataFrame | None`
+  - Method L2037: `_load_local_day(self, *, root: Path, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2060: `_api_url(*, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L2079: `_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L2103: `_load_api_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2132: `_write_api_cache_day(self, *, payload: bytes, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
+  - Method L2193: `_fast_api_cache_path(cls, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> Path | None`
+  - Method L2215: `_load_fast_cache_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L2244: `_write_fast_cache_day(self, *, frame: pd.DataFrame, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> None`
+  - Method L2341: `_load_api_day_cached(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L2416: `_deltas_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
+  - Method L2445: `has_complete_materialized_deltas_cache(self, *, start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None) -> bool`
+  - Method L2476: `_load_deltas_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[list[OrderBookDeltas] | None, str]`
+  - Method L2522: `_write_deltas_cache_day(self, *, records: Sequence[OrderBookDeltas], delta_columns: Mapping[str, Sequence[object]] | None = None, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> None`
+  - Method L2600: `_trade_ticks_cache_path(cls, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, instrument_id: object, start: pd.Timestamp, end: pd.Timestamp) -> Path | None`
+  - Method L2629: `_load_trade_ticks_cache_day(self, *, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> tuple[tuple[TradeTick, ...] | None, str]`
+  - Method L2685: `_write_trade_ticks_cache_day(self, *, records: Sequence[TradeTick], channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp) -> None`
+  - Method L2760: `_trade_ticks_to_cache_table(records: Sequence[TradeTick]) -> pa.Table`
+  - Method L2787: `_trade_ticks_from_cache_table(self, table: pa.Table) -> tuple[TradeTick, ...]`
+  - Method L2790: `_trade_ticks_from_cache_frame(self, frame: pd.DataFrame) -> tuple[TradeTick, ...]`
+  - Method L2826: `_deltas_columns_to_table(data: Mapping[str, Sequence[object]]) -> pa.Table`
+  - Method L2842: `_deltas_records_to_table(records: Sequence[OrderBookDeltas]) -> pa.Table`
+  - Method L2878: `_numeric_table_column(table: pa.Table, name: str) -> np.ndarray`
+  - Method L2881: `_deltas_records_from_table(self, table: pa.Table) -> list[OrderBookDeltas]`
+  - Method L2896: `_deltas_records_from_columns(self, data: dict[str, Sequence[object]]) -> list[OrderBookDeltas]`
+  - Method L2948: `_resolve_presigned_url(*, url: str, api_key: str) -> str`
+  - Method L2975: `_load_api_day(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, api_key: str | None = None) -> pd.DataFrame | None`
+  - Method L3068: `_column_to_ns(column: pd.Series, column_name: str) -> np.ndarray`
+  - Method L3080: `_normalize_to_utc(value: pd.Timestamp) -> pd.Timestamp`
+  - Method L3085: `_day_window(self, date: str, *, start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp] | None`
+  - Method L3099: `_first_present_column(frame: pd.DataFrame, names: Sequence[str], *, label: str) -> str`
+  - Method L3105: `_book_events_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> list[OrderBookDeltas]`
+  - Method L3121: `_book_events_and_delta_columns_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp, include_order_book: bool = True) -> tuple[list[OrderBookDeltas], Mapping[str, Sequence[object]] | None]`
+  - Method L3214: `_optional_column(frame: pd.DataFrame, names: Sequence[str]) -> str | None`
+  - Method L3220: `_onchain_fill_trade_ticks_from_frame(self, frame: pd.DataFrame, *, start: pd.Timestamp, end: pd.Timestamp) -> list[TradeTick]`
+  - Method L3295: `_trade_ticks_from_native_columns(self, data: tuple[list[float], list[float], list[int], list[str], list[int], list[int]]) -> list[TradeTick]`
+  - Method L3324: `_rounded_float64_array(values: object, precision: int) -> np.ndarray`
+  - Method L3327: `_empty_local_blob_day_frame(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> pd.DataFrame | None`
+  - Method L3363: `_parse_telonex_trade_frame(self, frame: pd.DataFrame, *, channel: str, source: str, start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int) -> tuple[TradeTick, ...] | None`
+  - Method L3388: `load_telonex_onchain_fill_ticks(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str | None = None, token_index: int | None = None, outcome: str | None = None) -> tuple[TradeTick, ...] | None`
+  - Method L3563: `_try_load_day_from_local(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None, start: pd.Timestamp, end: pd.Timestamp, range_cache: dict[Path, pd.DataFrame | None]) -> pd.DataFrame | None`
+  - Method L3631: `_try_load_day_from_api_entry(self, *, entry: TelonexSourceEntry, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> tuple[pd.DataFrame | None, str]`
+  - Method L3673: `_telonex_api_source_label(self, *, base_url: str, channel: str, date: str, market_slug: str, token_index: int, outcome: str | None) -> str`
+  - Method L3692: `_load_order_book_deltas_day(self, *, date: str, config: TelonexLoaderConfig, start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool, range_cache: dict[Path, pd.DataFrame | None]) -> _TelonexDayResult`
+  - Method L3869: `_iter_loaded_telonex_days(self, *, dates: list[str], config: TelonexLoaderConfig, api_entries: Sequence[TelonexSourceEntry], start: pd.Timestamp, end: pd.Timestamp, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool) -> Iterator[_TelonexDayResult]`
+  - Method L3942: `load_order_book_deltas(self, start: pd.Timestamp, end: pd.Timestamp, *, market_slug: str, token_index: int, outcome: str | None, include_order_book: bool = True) -> list[OrderBookDeltas]`
 
 ### `prediction_market_extensions/backtesting/data_sources/vendors.py`
 - Imports: `__future__, dataclasses`
@@ -1755,28 +2408,28 @@ flowchart TD
 - Function L64: `_clamp_probability(value: Decimal) -> Decimal`
 - Function L68: `_fee_per_share(*, price: Decimal, taker_fee: Decimal) -> Decimal`
 - Class L74: `BookBinaryPairArbitrageConfig(StrategyConfig)`
-  - Method L100: `__post_init__(self) -> None`
-- Class L118: `BookBinaryPairArbitrageStrategy(Strategy)`
-  - Method L132: `__init__(self, config: BookBinaryPairArbitrageConfig) -> None`
-  - Method L142: `on_start(self) -> None`
-  - Method L166: `on_order_book_deltas(self, deltas) -> None`
-  - Method L178: `_best_ask_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None`
-  - Method L192: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
-  - Method L198: `_free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None`
-  - Method L210: `_avg_entry_price(self, instrument_id: InstrumentId, size: Decimal) -> float | None`
-  - Method L226: `_rounded_quantity(self, instrument_id: InstrumentId, size: Decimal) -> Any`
-  - Method L242: `_pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
-  - Method L245: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
-  - Method L323: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], quantities: list[object], visible_size: float, net_unit_cost: float, edge: float) -> None`
-  - Method L362: `_event_order_is_closed(self, event) -> bool`
-  - Method L377: `_mark_order_event(self, event) -> None`
-  - Method L385: `on_order_filled(self, event) -> None`
-  - Method L388: `on_order_rejected(self, event) -> None`
-  - Method L391: `on_order_denied(self, event) -> None`
-  - Method L394: `on_order_canceled(self, event) -> None`
-  - Method L397: `on_order_expired(self, event) -> None`
-  - Method L400: `on_stop(self) -> None`
-  - Method L409: `on_reset(self) -> None`
+  - Method L101: `__post_init__(self) -> None`
+- Class L121: `BookBinaryPairArbitrageStrategy(Strategy)`
+  - Method L135: `__init__(self, config: BookBinaryPairArbitrageConfig) -> None`
+  - Method L145: `on_start(self) -> None`
+  - Method L169: `on_order_book_deltas(self, deltas) -> None`
+  - Method L181: `_best_ask_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None`
+  - Method L195: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L203: `_free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None`
+  - Method L215: `_avg_entry_price(self, instrument_id: InstrumentId, size: Decimal) -> float | None`
+  - Method L231: `_rounded_quantity(self, instrument_id: InstrumentId, size: Decimal) -> Any`
+  - Method L247: `_pair_has_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L250: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L328: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], quantities: list[object], visible_size: float, net_unit_cost: float, edge: float) -> None`
+  - Method L367: `_event_order_is_closed(self, event) -> bool`
+  - Method L382: `_mark_order_event(self, event) -> None`
+  - Method L390: `on_order_filled(self, event) -> None`
+  - Method L393: `on_order_rejected(self, event) -> None`
+  - Method L396: `on_order_denied(self, event) -> None`
+  - Method L399: `on_order_canceled(self, event) -> None`
+  - Method L402: `on_order_expired(self, event) -> None`
+  - Method L405: `on_stop(self) -> None`
+  - Method L414: `on_reset(self) -> None`
 
 ### `strategies/breakout.py`
 - Imports: `__future__, collections, decimal, math, nautilus_trader, strategies, typing`
@@ -1813,28 +2466,28 @@ flowchart TD
 - Class L37: `LongOnlyConfig(Protocol)`
 - Class L105: `LongOnlyPredictionMarketStrategy(Strategy)`
   - Method L110: `__init__(self, config: LongOnlyConfig) -> None`
-  - Method L123: `_warn_entry_unfillable(self, *, desired_size: Decimal, reference_price: float | None, reason: str) -> None`
-  - Method L139: `_subscribe(self) -> None`
-  - Method L142: `on_start(self) -> None`
-  - Method L150: `on_order_book_deltas(self, deltas) -> None`
-  - Method L157: `_in_position(self) -> bool`
-  - Method L160: `_free_quote_balance(self) -> Decimal | None`
-  - Method L170: `_remember_market_context(self, *, entry_reference_price: float | None, entry_visible_size: float | None, exit_visible_size: float | None = None) -> None`
-  - Method L183: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
-  - Method L190: `_entry_quantity(self, *, reference_price: float | None = None, visible_size: float | None = None) -> Any`
-  - Method L254: `_submit_entry(self, *, reference_price: float | None = None, visible_size: float | None = None) -> None`
-  - Method L283: `_submit_exit(self) -> None`
-  - Method L329: `_entry_price_with_fees(self) -> float | None`
-  - Method L342: `_exit_price_after_fees(self, price: float) -> float`
-  - Method L350: `_risk_exit(self, *, price: float, take_profit: float, stop_loss: float) -> bool`
-  - Method L370: `_event_order_is_closed(self, event) -> bool`
-  - Method L385: `on_order_filled(self, event) -> None`
-  - Method L408: `on_order_rejected(self, event) -> None`
-  - Method L411: `on_order_denied(self, event) -> None`
-  - Method L414: `on_order_canceled(self, event) -> None`
-  - Method L417: `on_order_expired(self, event) -> None`
-  - Method L420: `on_stop(self) -> None`
-  - Method L424: `on_reset(self) -> None`
+  - Method L125: `_warn_entry_unfillable(self, *, desired_size: Decimal, reference_price: float | None, reason: str) -> None`
+  - Method L141: `_subscribe(self) -> None`
+  - Method L144: `on_start(self) -> None`
+  - Method L152: `on_order_book_deltas(self, deltas) -> None`
+  - Method L160: `_in_position(self) -> bool`
+  - Method L163: `_free_quote_balance(self) -> Decimal | None`
+  - Method L173: `_remember_market_context(self, *, entry_reference_price: float | None, entry_visible_size: float | None, exit_visible_size: float | None = None) -> None`
+  - Method L186: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L193: `_entry_quantity(self, *, reference_price: float | None = None, visible_size: float | None = None) -> Any`
+  - Method L257: `_submit_entry(self, *, reference_price: float | None = None, visible_size: float | None = None) -> None`
+  - Method L286: `_submit_exit(self) -> None`
+  - Method L348: `_entry_price_with_fees(self) -> float | None`
+  - Method L361: `_exit_price_after_fees(self, price: float) -> float`
+  - Method L369: `_risk_exit(self, *, price: float, take_profit: float, stop_loss: float) -> bool`
+  - Method L389: `_event_order_is_closed(self, event) -> bool`
+  - Method L404: `on_order_filled(self, event) -> None`
+  - Method L428: `on_order_rejected(self, event) -> None`
+  - Method L431: `on_order_denied(self, event) -> None`
+  - Method L434: `on_order_canceled(self, event) -> None`
+  - Method L437: `on_order_expired(self, event) -> None`
+  - Method L440: `on_stop(self) -> None`
+  - Method L444: `on_reset(self) -> None`
 
 ### `strategies/deep_value.py`
 - Imports: `__future__, decimal, nautilus_trader, strategies`
@@ -1974,6 +2627,612 @@ flowchart TD
 - Class L170: `BookPanicFadeStrategy(_PanicFadeBase)`
   - Method L171: `_subscribe(self) -> None`
   - Method L177: `on_order_book(self, order_book) -> None`
+
+### `strategies/private/__init__.py`
+- Imports: none
+
+### `strategies/private/adjacent_contract_lead_lag.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L22: `BookAdjacentContractLeadLagConfig(StrategyConfig)`
+  - Method L48: `__post_init__(self) -> None`
+- Class L100: `BookAdjacentContractLeadLagStrategy(BookTradeFlowMomentumStrategy)`
+  - Method L105: `on_start(self) -> None`
+  - Method L109: `_relative_pressure(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L123: `_prior_pair_signal(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[int, float, float] | None`
+  - Method L156: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L251: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_book_event_pressure.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L21: `BookBTCBookEventPressureConfig(StrategyConfig)`
+  - Method L46: `__post_init__(self) -> None`
+- Class L83: `BookBTCBookEventPressureStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L88: `__init__(self, config: BookBTCBookEventPressureConfig) -> None`
+  - Method L92: `on_start(self) -> None`
+  - Method L98: `on_order_book_deltas(self, deltas) -> None`
+  - Method L105: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L112: `_event_count(self, *, instrument_id: InstrumentId, current_ts_ns: int) -> int`
+  - Method L120: `_relative_event_share(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, current_ts_ns: int) -> tuple[int, float]`
+  - Method L135: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None], current_ts_ns: int) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L183: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L264: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_boundary_breakout.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L20: `BookBTCBoundaryBreakoutConfig(StrategyConfig)`
+  - Method L46: `__post_init__(self) -> None`
+- Class L93: `BookBTCBoundaryBreakoutStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L98: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L105: `_boundary_cross_strength(self, instrument_id: InstrumentId, midpoint: float) -> float | None`
+  - Method L118: `_relative_boundary_edge(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L133: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L177: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L253: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_boundary_hold_breakout.py`
+- Imports: `__future__, nautilus_trader, strategies`
+- Class L12: `BookBTCBoundaryHoldBreakoutStrategy(BookBTCBoundaryBreakoutStrategy)`
+  - Method L17: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L93: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_certainty_collapse.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L20: `BookBTCCertaintyCollapseConfig(StrategyConfig)`
+  - Method L49: `__post_init__(self) -> None`
+- Class L95: `BookBTCCertaintyCollapseStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L100: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L107: `_history_stats(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L121: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L177: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L254: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_final_pressure_squeeze.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L20: `BookBTCFinalPressureSqueezeConfig(StrategyConfig)`
+  - Method L46: `__post_init__(self) -> None`
+- Class L110: `BookBTCFinalPressureSqueezeStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L115: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L122: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L164: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L240: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_late_favorite_passive_hold.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L22: `BookBTCLateFavoritePassiveHoldConfig(StrategyConfig)`
+  - Method L42: `__post_init__(self) -> None`
+- Class L73: `BookBTCLateFavoritePassiveHoldStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L82: `__init__(self, config: BookBTCLateFavoritePassiveHoldConfig) -> None`
+  - Method L92: `_subscribe(self) -> None`
+  - Method L98: `_price_increment(self) -> float`
+  - Method L104: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L112: `_book_state(self, order_book: OrderBook) -> dict[str, float] | None`
+  - Method L150: `_entry_window_is_open(self, ts_event_ns: int) -> bool`
+  - Method L159: `_entry_guard_passes(self, state: dict[str, float], *, ts_event_ns: int) -> bool`
+  - Method L178: `_limit_entry_price(self, state: dict[str, float]) -> float | None`
+  - Method L189: `_submit_limit_entry(self, *, price: float, visible_size: float) -> None`
+  - Method L217: `_cancel_active_entry(self) -> None`
+  - Method L224: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L271: `on_order_accepted(self, event) -> None`
+  - Method L275: `on_order_filled(self, event) -> None`
+  - Method L285: `on_order_rejected(self, event) -> None`
+  - Method L290: `on_order_denied(self, event) -> None`
+  - Method L295: `on_order_canceled(self, event) -> None`
+  - Method L300: `on_order_expired(self, event) -> None`
+  - Method L305: `on_stop(self) -> None`
+  - Method L309: `on_reset(self) -> None`
+
+### `strategies/private/btc_liquidity_withdrawal.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L21: `BookBTCLiquidityWithdrawalConfig(StrategyConfig)`
+  - Method L49: `__post_init__(self) -> None`
+- Class L97: `BookBTCLiquidityWithdrawalStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L102: `__init__(self, config: BookBTCLiquidityWithdrawalConfig) -> None`
+  - Method L107: `on_start(self) -> None`
+  - Method L115: `_depth_baseline(self, instrument_id: InstrumentId) -> tuple[float, float] | None`
+  - Method L123: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L157: `_record_depth_event(self, *, instrument_id: InstrumentId, bid_depth: float, ask_depth: float) -> None`
+  - Method L173: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L219: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L291: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L298: `on_reset(self) -> None`
+
+### `strategies/private/btc_liquidity_withdrawal_hold.py`
+- Imports: `__future__, nautilus_trader, strategies`
+- Class L12: `BookBTCLiquidityWithdrawalHoldStrategy(BookBTCLiquidityWithdrawalStrategy)`
+  - Method L17: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L89: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/btc_opening_range_breakout.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L20: `BookBTCOpeningRangeBreakoutConfig(StrategyConfig)`
+  - Method L46: `__post_init__(self) -> None`
+- Class L92: `BookBTCOpeningRangeBreakoutStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L97: `__init__(self, config: BookBTCOpeningRangeBreakoutConfig) -> None`
+  - Method L104: `on_start(self) -> None`
+  - Method L108: `_reset_opening_state(self) -> None`
+  - Method L115: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L122: `_record_opening(self, *, instrument_id: InstrumentId, midpoint: float) -> None`
+  - Method L134: `_opening_midpoint(self, instrument_id: InstrumentId) -> float | None`
+  - Method L140: `_relative_momentum(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L156: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L203: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L285: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L292: `on_reset(self) -> None`
+
+### `strategies/private/btc_quote_velocity.py`
+- Imports: `__future__, collections, decimal, math, nautilus_trader, strategies`
+- Class L22: `BookBTCQuoteVelocityConfig(StrategyConfig)`
+  - Method L50: `__post_init__(self) -> None`
+- Class L101: `BookBTCQuoteVelocityStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L106: `__init__(self, config: BookBTCQuoteVelocityConfig) -> None`
+  - Method L111: `on_start(self) -> None`
+  - Method L118: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L135: `_record_velocity_event(self, *, instrument_id: InstrumentId, state: dict[str, float]) -> None`
+  - Method L149: `_prune_velocity_events(self, *, instrument_id: InstrumentId, current_ts_ns: int) -> None`
+  - Method L156: `_velocity_stats(self, *, instrument_id: InstrumentId, current_ts_ns: int) -> dict[str, float] | None`
+  - Method L192: `_relative_velocity(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, current_ts_ns: int) -> float | None`
+  - Method L211: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None], current_ts_ns: int) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L268: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L352: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L359: `on_reset(self) -> None`
+
+### `strategies/private/btc_volatility_expansion.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L22: `BookBTCVolatilityExpansionConfig(StrategyConfig)`
+  - Method L48: `__post_init__(self) -> None`
+- Class L88: `BookBTCVolatilityExpansionStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L93: `__init__(self, config: BookBTCVolatilityExpansionConfig) -> None`
+  - Method L97: `on_start(self) -> None`
+  - Method L104: `_record_midpoint(self, instrument_id: InstrumentId) -> None`
+  - Method L117: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L124: `_compression_stats(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L139: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L185: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L258: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L265: `on_reset(self) -> None`
+
+### `strategies/private/cancel_replace_pressure.py`
+- Imports: `__future__, collections, dataclasses, decimal, nautilus_trader, strategies`
+- Class L23: `_BookSnapshot`
+- Class L30: `BookCancelReplacePressureConfig(StrategyConfig)`
+  - Method L56: `__post_init__(self) -> None`
+- Class L103: `BookCancelReplacePressureStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L108: `__init__(self, config: BookCancelReplacePressureConfig) -> None`
+  - Method L113: `on_start(self) -> None`
+  - Method L120: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L150: `_depth_change(self, *, previous: float, current: float) -> float`
+  - Method L155: `_migration_event(self, *, previous: _BookSnapshot | None, current: _BookSnapshot) -> float`
+  - Method L191: `_relative_cancel_pressure(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L206: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L248: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L326: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L333: `on_reset(self) -> None`
+
+### `strategies/private/depth_convexity_skew.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L22: `BookDepthConvexitySkewConfig(StrategyConfig)`
+  - Method L49: `__post_init__(self) -> None`
+- Class L99: `BookDepthConvexitySkewStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L104: `__init__(self, config: BookDepthConvexitySkewConfig) -> None`
+  - Method L108: `on_start(self) -> None`
+  - Method L113: `_split_depth(self, levels: list[object]) -> tuple[float, float]`
+  - Method L129: `_shape_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L165: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L173: `_relative_shape_skew(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L187: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L231: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L309: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L316: `on_reset(self) -> None`
+
+### `strategies/private/depth_entropy_compression.py`
+- Imports: `__future__, collections, decimal, math, nautilus_trader, strategies`
+- Class L23: `BookDepthEntropyCompressionConfig(StrategyConfig)`
+  - Method L50: `__post_init__(self) -> None`
+- Class L107: `BookDepthEntropyCompressionStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L112: `__init__(self, config: BookDepthEntropyCompressionConfig) -> None`
+  - Method L116: `on_start(self) -> None`
+  - Method L121: `_normalized_entropy(self, levels: list[object]) -> tuple[float, float] | None`
+  - Method L136: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L169: `_relative_entropy_edge(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L183: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L228: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L305: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L312: `on_reset(self) -> None`
+
+### `strategies/private/depth_pressure_trend.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies, typing`
+- Class L24: `_DepthPressureTrendConfig(Protocol)`
+- Class L48: `BookDepthPressureTrendConfig(StrategyConfig)`
+  - Method L68: `__post_init__(self) -> None`
+- Class L89: `BookDepthPressureTrendStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L98: `__init__(self, config: _DepthPressureTrendConfig) -> None`
+  - Method L108: `_subscribe(self) -> None`
+  - Method L114: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L122: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L132: `_midpoint_trend(self, midpoint: float) -> float | None`
+  - Method L138: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L179: `_on_book_signal(self, *, order_book: OrderBook, bid: float, ask: float, spread: float, pressure: float, microprice_edge: float, midpoint_trend: float | None, entry_visible_size: float | None, exit_visible_size: float | None, current_ts_ns: int | None) -> None`
+  - Method L262: `_seconds_elapsed(self, *, start_ts_ns: int | None, current_ts_ns: int | None, seconds: float) -> bool`
+  - Method L271: `_min_holding_elapsed(self, current_ts_ns: int | None) -> bool`
+  - Method L278: `_reentry_cooldown_elapsed(self, current_ts_ns: int | None) -> bool`
+  - Method L287: `_fill_ts_ns(self, event: object) -> int | None`
+  - Method L290: `on_order_filled(self, event) -> None`
+  - Method L305: `on_reset(self) -> None`
+
+### `strategies/private/event_microprice_carry.py`
+- Imports: `__future__, strategies`
+- Class L9: `BookEventMicropriceCarryStrategy(BookMicropriceImbalanceStrategy)`
+  - Method L14: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/event_panic_fade.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L23: `BookEventPanicFadeConfig(StrategyConfig)`
+  - Method L44: `__post_init__(self) -> None`
+- Class L78: `BookEventPanicFadeStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L83: `__init__(self, config: BookEventPanicFadeConfig) -> None`
+  - Method L90: `_subscribe(self) -> None`
+  - Method L96: `_depth_sum(self, levels: list[object]) -> float`
+  - Method L104: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L114: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L206: `on_order_filled(self, event) -> None`
+  - Method L216: `on_reset(self) -> None`
+  - Method L223: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/event_persistent_bid_support.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L23: `BookEventPersistentBidSupportConfig(StrategyConfig)`
+  - Method L46: `__post_init__(self) -> None`
+- Class L86: `BookEventPersistentBidSupportStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L91: `__init__(self, config: BookEventPersistentBidSupportConfig) -> None`
+  - Method L100: `_subscribe(self) -> None`
+  - Method L106: `_depth_sum(self, levels: list[object]) -> float`
+  - Method L114: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L124: `_support_is_persistent(self) -> bool`
+  - Method L153: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L230: `on_order_filled(self, event) -> None`
+  - Method L240: `on_reset(self) -> None`
+  - Method L249: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/guarded_breakout.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L21: `BookGuardedBreakoutConfig(StrategyConfig)`
+  - Method L39: `__post_init__(self) -> None`
+- Class L59: `BookGuardedBreakoutStrategy(_BreakoutBase)`
+  - Method L60: `_subscribe(self) -> None`
+  - Method L66: `_depth_sum(self, levels: list[object]) -> float`
+  - Method L74: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L84: `_entry_guard_passes(self, *, best_ask: float, entry_reference_price: float, spread: float, order_book: OrderBook, expected_entry_price: float | None) -> bool`
+  - Method L122: `on_order_book(self, order_book: OrderBook) -> None`
+
+### `strategies/private/impact_fair_price_drift.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L26: `BookImpactFairPriceDriftConfig(StrategyConfig)`
+  - Method L51: `__post_init__(self) -> None`
+- Class L96: `BookImpactFairPriceDriftStrategy(BookTradeFlowMomentumStrategy)`
+  - Method L101: `__init__(self, config: BookImpactFairPriceDriftConfig) -> None`
+  - Method L105: `on_start(self) -> None`
+  - Method L130: `_impact_quantity(self, instrument_id: InstrumentId) -> Any`
+  - Method L145: `_avg_px_for_quantity(self, *, instrument_id: InstrumentId, order_side: OrderSide) -> float | None`
+  - Method L156: `_fee_adjusted_buy_cost(self, *, instrument_id: InstrumentId, price: float) -> float`
+  - Method L167: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L193: `_attach_fair_values(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> bool`
+  - Method L223: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L264: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L330: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L334: `on_reset(self) -> None`
+- Class L340: `BookImpactFairPriceFadeStrategy(BookImpactFairPriceDriftStrategy)`
+  - Method L345: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L389: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L454: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/liquidity_reversion.py`
+- Imports: `__future__, collections, decimal, math, nautilus_trader, strategies, typing`
+- Class L25: `_LiquidityReversionConfig(Protocol)`
+- Class L46: `BookLiquidityReversionConfig(StrategyConfig)`
+  - Method L66: `__post_init__(self) -> None`
+- Class L89: `BookLiquidityReversionStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L97: `__init__(self, config: _LiquidityReversionConfig) -> None`
+  - Method L104: `_subscribe(self) -> None`
+  - Method L110: `_depth_sum(self, levels: list[object]) -> float`
+  - Method L118: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L128: `_rolling_stats(self) -> tuple[float, float] | None`
+  - Method L137: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L177: `_on_book_signal(self, *, order_book: OrderBook, bid: float, ask: float, spread: float, midpoint: float, previous_midpoint: float | None, pressure: float, microprice_edge: float, stats: tuple[float, float] | None, entry_visible_size: float | None, exit_visible_size: float | None) -> None`
+  - Method L263: `on_order_filled(self, event) -> None`
+  - Method L274: `on_reset(self) -> None`
+
+### `strategies/private/liquidity_shock_resiliency.py`
+- Imports: `__future__, collections, dataclasses, decimal, nautilus_trader, strategies`
+- Class L24: `_ShockState`
+- Class L32: `BookLiquidityShockResiliencyConfig(StrategyConfig)`
+  - Method L56: `__post_init__(self) -> None`
+- Class L90: `BookLiquidityShockResiliencyStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L95: `__init__(self, config: BookLiquidityShockResiliencyConfig) -> None`
+  - Method L106: `_subscribe(self) -> None`
+  - Method L113: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L121: `_book_state(self, order_book: OrderBook) -> dict[str, float] | None`
+  - Method L157: `on_trade_tick(self, trade) -> None`
+  - Method L166: `_signed_trade_size(self, trade) -> float`
+  - Method L178: `_prune_trades(self, current_ts_ns: int) -> None`
+  - Method L185: `_recent_sell_volume(self, current_ts_ns: int) -> float`
+  - Method L189: `_baseline(self, values: deque[float]) -> float | None`
+  - Method L194: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L204: `_detect_or_update_shock(self, *, state: dict[str, float], current_ts_ns: int) -> None`
+  - Method L232: `_shock_recovered(self, *, state: dict[str, float], expected_entry_price: float | None) -> bool`
+  - Method L264: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L311: `on_order_filled(self, event) -> None`
+  - Method L319: `on_reset(self) -> None`
+
+### `strategies/private/pair_book_relative_strength.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L24: `BookPairBookRelativeStrengthConfig(StrategyConfig)`
+  - Method L47: `__post_init__(self) -> None`
+- Class L88: `BookPairBookRelativeStrengthStrategy(BookTradeFlowMomentumStrategy)`
+  - Method L93: `on_start(self) -> None`
+  - Method L117: `_relative_pressure(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L132: `_relative_trend(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L147: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L182: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L255: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/panic_liquidity_fade.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L20: `BookPanicLiquidityFadeConfig(StrategyConfig)`
+  - Method L38: `__post_init__(self) -> None`
+- Class L56: `BookPanicLiquidityFadeStrategy(_PanicFadeBase)`
+  - Method L57: `_subscribe(self) -> None`
+  - Method L63: `_depth_sum(self, levels: list[object]) -> float`
+  - Method L71: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L81: `_entry_guard_passes(self, *, mid: float, bid: float, ask: float, spread: float, expected_entry_price: float | None, order_book: OrderBook) -> bool`
+  - Method L130: `on_order_book(self, order_book: OrderBook) -> None`
+
+### `strategies/private/passive_pair_accumulation.py`
+- Imports: `__future__, decimal, nautilus_trader, prediction_market_extensions, strategies`
+- Class L31: `BookPassivePairAccumulationConfig(StrategyConfig)`
+  - Method L58: `__post_init__(self) -> None`
+- Class L82: `BookPassivePairAccumulationStrategy(BookBinaryPairArbitrageStrategy)`
+  - Method L90: `__init__(self, config: BookPassivePairAccumulationConfig) -> None`
+  - Method L101: `on_start(self) -> None`
+  - Method L133: `on_order_book_deltas(self, deltas) -> None`
+  - Method L148: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L157: `_position_size(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L169: `_price_increment(self, instrument_id: InstrumentId) -> float`
+  - Method L176: `_best_bid_state(self, instrument_id: InstrumentId) -> tuple[float, float, float, float]`
+  - Method L186: `_passive_price(self, instrument_id: InstrumentId, *, bid: float, ask: float) -> float | None`
+  - Method L196: `_active_pair_orders(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L199: `_pair_positions(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[Decimal, Decimal]`
+  - Method L205: `_matched_position_size(self, pair: tuple[InstrumentId, InstrumentId]) -> Decimal`
+  - Method L209: `_has_pair_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L213: `_surplus_position_sizes(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[Decimal, Decimal]`
+  - Method L221: `_target_reached(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L229: `_entry_state(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[list[float], list[object], float, float, Decimal] | None`
+  - Method L294: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L339: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], prices: list[float], quantities: list[object], visible_size: float, edge: float, target_size: Decimal) -> None`
+  - Method L384: `_cancel_pair_orders(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L393: `_submit_surplus_exit(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L420: `_mark_order_closed(self, event) -> None`
+  - Method L434: `on_order_filled(self, event) -> None`
+  - Method L441: `on_order_rejected(self, event) -> None`
+  - Method L447: `on_order_denied(self, event) -> None`
+  - Method L450: `on_order_canceled(self, event) -> None`
+  - Method L453: `on_order_expired(self, event) -> None`
+  - Method L456: `on_stop(self) -> None`
+  - Method L462: `on_reset(self) -> None`
+
+### `strategies/private/passive_pressure_momentum.py`
+- Imports: `__future__, nautilus_trader, prediction_market_extensions, strategies`
+- Class L21: `BookPassivePressureMomentumConfig(BookPassiveRelativeValueConfig)`
+  - Method L44: `__post_init__(self) -> None`
+- Class L76: `BookPassivePressureMomentumStrategy(BookPassiveRelativeValueStrategy)`
+  - Method L84: `__init__(self, config: BookPassivePressureMomentumConfig) -> None`
+  - Method L95: `on_start(self) -> None`
+  - Method L103: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L123: `_signal_score(self, *, state: dict[str, float], other_state: dict[str, float]) -> float | None`
+  - Method L160: `_entry_candidate(self, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float]]) -> tuple[InstrumentId, dict[str, float], float, float] | None`
+  - Method L199: `_evaluate_active_entry(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float]]) -> None`
+  - Method L230: `_evaluate_position(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float]]) -> None`
+  - Method L298: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L305: `on_reset(self) -> None`
+
+### `strategies/private/passive_relative_value.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, prediction_market_extensions, strategies`
+- Class L35: `BookPassiveRelativeValueConfig(StrategyConfig)`
+  - Method L73: `__post_init__(self) -> None`
+- Class L128: `BookPassiveRelativeValueStrategy(BookBinaryPairArbitrageStrategy)`
+  - Method L137: `__init__(self, config: BookPassiveRelativeValueConfig) -> None`
+  - Method L153: `on_start(self) -> None`
+  - Method L185: `on_order_book_deltas(self, deltas) -> None`
+  - Method L201: `_record_midpoint(self, instrument_id: InstrumentId) -> None`
+  - Method L209: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L217: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L266: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L275: `_position_size(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L287: `_price_increment(self, instrument_id: InstrumentId) -> float`
+  - Method L294: `_passive_price(self, instrument_id: InstrumentId, *, bid: float, ask: float) -> float | None`
+  - Method L301: `_entry_edge(self, *, instrument_id: InstrumentId, passive_price: float, fair_value: float) -> float`
+  - Method L318: `_position_instrument(self, pair: tuple[InstrumentId, InstrumentId]) -> InstrumentId | None`
+  - Method L324: `_pair_has_active_order(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L327: `_entry_candidate(self, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float]]) -> tuple[InstrumentId, dict[str, float], float, float] | None`
+  - Method L379: `_entry_quantity(self, *, instrument_id: InstrumentId, reference_price: float, visible_size: float) -> Any`
+  - Method L403: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L450: `_evaluate_active_entry(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float]]) -> None`
+  - Method L484: `_evaluate_position(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float]]) -> None`
+  - Method L531: `_submit_entry(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, price: float, edge: float, visible_size: float) -> None`
+  - Method L569: `_submit_exit(self, *, instrument_id: InstrumentId, visible_size: float | None) -> None`
+  - Method L591: `_cancel_pair_orders(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L599: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L606: `_mark_order_closed(self, event) -> None`
+  - Method L617: `on_order_filled(self, event) -> None`
+  - Method L654: `on_order_rejected(self, event) -> None`
+  - Method L657: `on_order_denied(self, event) -> None`
+  - Method L660: `on_order_canceled(self, event) -> None`
+  - Method L663: `on_order_expired(self, event) -> None`
+  - Method L666: `on_stop(self) -> None`
+  - Method L678: `on_reset(self) -> None`
+
+### `strategies/private/passive_spread_capture.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L23: `BookPassiveSpreadCaptureConfig(StrategyConfig)`
+  - Method L46: `__post_init__(self) -> None`
+- Class L81: `BookPassiveSpreadCaptureStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L89: `__init__(self, config: BookPassiveSpreadCaptureConfig) -> None`
+  - Method L98: `_subscribe(self) -> None`
+  - Method L104: `_price_increment(self) -> float`
+  - Method L110: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L118: `_book_state(self, order_book: OrderBook) -> dict[str, float] | None`
+  - Method L162: `_entry_guard_passes(self, state: dict[str, float]) -> bool`
+  - Method L181: `_limit_entry_price(self, state: dict[str, float]) -> float | None`
+  - Method L192: `_submit_limit_entry(self, *, price: float, visible_size: float) -> None`
+  - Method L217: `_cancel_active_entry(self) -> None`
+  - Method L223: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L276: `on_order_accepted(self, event) -> None`
+  - Method L280: `on_order_filled(self, event) -> None`
+  - Method L292: `on_order_rejected(self, event) -> None`
+  - Method L296: `on_order_denied(self, event) -> None`
+  - Method L300: `on_order_canceled(self, event) -> None`
+  - Method L304: `on_order_expired(self, event) -> None`
+  - Method L308: `on_stop(self) -> None`
+  - Method L312: `on_reset(self) -> None`
+
+### `strategies/private/passive_sweep_reprice_momentum.py`
+- Imports: `__future__, collections, dataclasses, nautilus_trader, prediction_market_extensions, strategies`
+- Class L26: `_SweepSnapshot`
+- Class L35: `BookPassiveSweepRepriceMomentumConfig(BookPassivePressureMomentumConfig)`
+  - Method L56: `__post_init__(self) -> None`
+- Class L76: `BookPassiveSweepRepriceMomentumStrategy(BookPassivePressureMomentumStrategy)`
+  - Method L81: `__init__(self, config: BookPassiveSweepRepriceMomentumConfig) -> None`
+  - Method L87: `on_start(self) -> None`
+  - Method L98: `_depth_change(self, *, previous: float, current: float) -> float`
+  - Method L103: `_sweep_event(self, *, previous: _SweepSnapshot | None, current: _SweepSnapshot, microprice_edge: float) -> float`
+  - Method L159: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L194: `_signal_score(self, *, state: dict[str, float], other_state: dict[str, float]) -> float | None`
+  - Method L211: `_evaluate_active_entry(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float]]) -> None`
+  - Method L243: `on_order_accepted(self, event) -> None`
+  - Method L252: `_mark_order_closed(self, event) -> None`
+  - Method L260: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L267: `on_reset(self) -> None`
+
+### `strategies/private/round_trip_pair_arbitrage.py`
+- Imports: `__future__, decimal, nautilus_trader, prediction_market_extensions, strategies`
+- Class L28: `BookRoundTripPairArbitrageConfig(StrategyConfig)`
+  - Method L45: `__post_init__(self) -> None`
+- Class L66: `BookRoundTripPairArbitrageStrategy(BookBinaryPairArbitrageStrategy)`
+  - Method L71: `__init__(self, config: BookRoundTripPairArbitrageConfig) -> None`
+  - Method L78: `on_start(self) -> None`
+  - Method L101: `on_order_book_deltas(self, deltas) -> None`
+  - Method L116: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L122: `_fee_adjusted_price(self, *, instrument_id: InstrumentId, price: Decimal, side: OrderSide) -> Decimal`
+  - Method L132: `_position_size(self, instrument_id: InstrumentId) -> Decimal`
+  - Method L144: `_pair_position_size(self, pair: tuple[InstrumentId, InstrumentId]) -> Decimal`
+  - Method L147: `_best_bid_state(self, instrument_id: InstrumentId) -> tuple[float, float, float] | None`
+  - Method L161: `_avg_exit_price(self, instrument_id: InstrumentId, size: Decimal) -> float | None`
+  - Method L175: `_entry_unit_cost(self, pair: tuple[InstrumentId, InstrumentId]) -> Decimal | None`
+  - Method L185: `_exit_unit_value(self, *, pair: tuple[InstrumentId, InstrumentId], size: Decimal) -> tuple[Decimal, float] | None`
+  - Method L215: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L227: `_evaluate_exit(self, *, pair: tuple[InstrumentId, InstrumentId], pair_size: Decimal) -> None`
+  - Method L262: `_submit_unmatched_exit(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
+  - Method L269: `_submit_single_exit(self, *, instrument_id: InstrumentId, size: Decimal) -> None`
+  - Method L288: `_submit_pair_exit(self, *, pair: tuple[InstrumentId, InstrumentId], size: Decimal, visible_size: float, edge: float) -> None`
+  - Method L321: `on_order_filled(self, event) -> None`
+  - Method L351: `on_stop(self) -> None`
+  - Method L368: `on_reset(self) -> None`
+
+### `strategies/private/rsi_liquidity_reversion.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L22: `BookRSILiquidityReversionConfig(StrategyConfig)`
+  - Method L37: `__post_init__(self) -> None`
+- Class L53: `BookRSILiquidityReversionStrategy(_RSIReversionBase)`
+  - Method L54: `_subscribe(self) -> None`
+  - Method L60: `_depth_sum(self, levels: list[object]) -> float`
+  - Method L68: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L78: `_entry_guard_passes(self, *, bid: float, ask: float, spread: float, expected_entry_price: float | None, order_book: OrderBook) -> bool`
+  - Method L116: `on_order_book(self, order_book: OrderBook) -> None`
+
+### `strategies/private/sweep_resiliency_momentum.py`
+- Imports: `__future__, collections, dataclasses, decimal, nautilus_trader, strategies`
+- Class L23: `_ResiliencySnapshot`
+- Class L32: `BookSweepResiliencyMomentumConfig(StrategyConfig)`
+  - Method L60: `__post_init__(self) -> None`
+- Class L109: `BookSweepResiliencyMomentumStrategy(BookPairBookRelativeStrengthStrategy)`
+  - Method L114: `__init__(self, config: BookSweepResiliencyMomentumConfig) -> None`
+  - Method L119: `on_start(self) -> None`
+  - Method L126: `_depth_change(self, *, previous: float, current: float) -> float`
+  - Method L131: `_snapshot_from_state(self, *, instrument_id: InstrumentId, state: dict[str, float]) -> _ResiliencySnapshot | None`
+  - Method L153: `_sweep_event(self, *, previous: _ResiliencySnapshot | None, current: _ResiliencySnapshot) -> float`
+  - Method L198: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L218: `_relative_sweep_score(self, *, pair: tuple[InstrumentId, InstrumentId], instrument_id: InstrumentId, states: list[dict[str, float] | None]) -> float`
+  - Method L232: `_entry_candidate(self, *, pair: tuple[InstrumentId, InstrumentId], states: list[dict[str, float] | None]) -> tuple[InstrumentId, dict[str, float]] | None`
+  - Method L274: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L352: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L359: `on_reset(self) -> None`
+
+### `strategies/private/trade_flow_momentum.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, prediction_market_extensions, strategies, typing`
+- Class L33: `_TradeFlowMomentumConfig(Protocol)`
+- Class L60: `BookTradeFlowMomentumConfig(StrategyConfig)`
+  - Method L86: `__post_init__(self) -> None`
+- Class L127: `BookTradeFlowMomentumStrategy(Strategy)`
+  - Method L137: `__init__(self, config: _TradeFlowMomentumConfig) -> None`
+  - Method L156: `on_start(self) -> None`
+  - Method L182: `on_order_book_deltas(self, deltas) -> None`
+  - Method L197: `on_trade_tick(self, trade) -> None`
+  - Method L212: `_signed_trade_size(self, trade) -> float`
+  - Method L224: `_prune_flow(self, *, instrument_id: InstrumentId, current_ts_ns: int) -> None`
+  - Method L231: `_flow_stats(self, *, instrument_id: InstrumentId, current_ts_ns: int) -> tuple[float, float]`
+  - Method L241: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L249: `_record_midpoint(self, instrument_id: InstrumentId) -> None`
+  - Method L257: `_book_state(self, instrument_id: InstrumentId) -> dict[str, float] | None`
+  - Method L303: `_expected_entry_price(self, instrument_id: InstrumentId) -> float | None`
+  - Method L317: `_free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None`
+  - Method L329: `_entry_quantity(self, *, instrument_id: InstrumentId, reference_price: float, visible_size: float) -> Any`
+  - Method L365: `_submit_entry(self, *, instrument_id: InstrumentId, reference_price: float, visible_size: float) -> None`
+  - Method L393: `_submit_exit(self, *, instrument_id: InstrumentId, visible_size: float | None) -> None`
+  - Method L456: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L463: `_pair_has_pending(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
+  - Method L466: `_position_instrument(self, pair: tuple[InstrumentId, InstrumentId]) -> InstrumentId | None`
+  - Method L474: `_risk_exit(self, *, instrument_id: InstrumentId, bid: float, visible_size: float) -> bool`
+  - Method L494: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId], *, current_ts_ns: int) -> None`
+  - Method L597: `on_order_filled(self, event) -> None`
+  - Method L638: `on_order_rejected(self, event) -> None`
+  - Method L641: `on_order_denied(self, event) -> None`
+  - Method L644: `on_order_canceled(self, event) -> None`
+  - Method L647: `on_order_expired(self, event) -> None`
+  - Method L650: `_mark_not_pending(self, event) -> None`
+  - Method L655: `on_stop(self) -> None`
+  - Method L668: `on_reset(self) -> None`
+
+### `strategies/private/volume_clock_flow_toxicity.py`
+- Imports: `__future__, decimal, nautilus_trader, strategies`
+- Class L22: `BookVolumeClockFlowToxicityConfig(StrategyConfig)`
+  - Method L52: `__post_init__(self) -> None`
+- Class L105: `BookVolumeClockFlowToxicityStrategy(BookTradeFlowMomentumStrategy)`
+  - Method L110: `_flow_stats(self, *, instrument_id: InstrumentId, current_ts_ns: int) -> tuple[float, float]`
+  - Method L144: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/vwap_liquidity_momentum.py`
+- Imports: `__future__, nautilus_trader, strategies`
+- Class L12: `BookVWAPLiquidityMomentumStrategy(BookVWAPLiquidityReversionStrategy)`
+  - Method L17: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L78: `on_order_filled(self, event) -> None`
+  - Method L87: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+
+### `strategies/private/vwap_liquidity_reversion.py`
+- Imports: `__future__, collections, decimal, nautilus_trader, strategies`
+- Class L23: `BookVWAPLiquidityReversionConfig(StrategyConfig)`
+  - Method L42: `__post_init__(self) -> None`
+- Class L70: `BookVWAPLiquidityReversionStrategy(LongOnlyPredictionMarketStrategy)`
+  - Method L75: `__init__(self, config: BookVWAPLiquidityReversionConfig) -> None`
+  - Method L84: `_subscribe(self) -> None`
+  - Method L90: `_weighted_depth(self, levels: list[object]) -> float`
+  - Method L98: `_expected_entry_price(self, order_book: OrderBook) -> float | None`
+  - Method L110: `_book_state(self, order_book: OrderBook) -> dict[str, float] | None`
+  - Method L144: `_append_point(self, *, price: float, weight: float) -> None`
+  - Method L153: `_vwap(self) -> float | None`
+  - Method L158: `_entry_guard_passes(self, state: dict[str, float]) -> bool`
+  - Method L171: `on_order_book(self, order_book: OrderBook) -> None`
+  - Method L232: `on_order_filled(self, event) -> None`
+  - Method L241: `_order_tags(self, *, intent: str, visible_size: float | None) -> list[str]`
+  - Method L244: `on_reset(self) -> None`
 
 ### `strategies/rsi_reversion.py`
 - Imports: `__future__, decimal, nautilus_trader, strategies, typing`

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ backtest:
 	uv run python main.py
 
 install:
-	unset CONDA_PREFIX && uv venv --python 3.13 && uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv aiohttp
+	unset CONDA_PREFIX && uv venv --python 3.13 && uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv aiohttp pytest ruff
 
 check:
 	uv run ruff check .

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ backtest:
 	uv run python main.py
 
 install:
-	unset CONDA_PREFIX && uv venv --python 3.13 && uv pip install "nautilus_trader[polymarket,visualization]==1.225.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv aiohttp
+	unset CONDA_PREFIX && uv venv --python 3.13 && uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv aiohttp
 
 check:
 	uv run ruff check .

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@
 ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/evan-kolberg/prediction-market-backtesting)
 
 **New in Version 4:**
-- Rust-native PMXT and Telonex data conversion
-- Faster staged PMXT and Telonex data loading
-- Unified cache/local/archive/API source progress output
-- Materialized replay caches for repeated book loads
+- Nautilus 1.226.0
+- Rust-native data conversion
+- Faster staged data loading
+- Improved materialized caches
+- Unified cache/local/archive/API message bus
 
 **New in Version 3:**
 - Telonex vendor support

--- a/backtests/generic_optimizer_research.ipynb
+++ b/backtests/generic_optimizer_research.ipynb
@@ -336,7 +336,7 @@
     "report = MarketReportConfig(\n",
     "    count_key=\"book_events\",\n",
     "    count_label=\"Book Events\",\n",
-    "    pnl_label=\"PnL (USDC)\",\n",
+    "    pnl_label=\"PnL (pUSD)\",\n",
     "    market_key=\"slug\",\n",
     "    summary_report=True,\n",
     "    summary_report_path=f\"output/{name}_holdout_joint_portfolio.html\",\n",

--- a/backtests/generic_tpe_research.ipynb
+++ b/backtests/generic_tpe_research.ipynb
@@ -342,7 +342,7 @@
     "report = MarketReportConfig(\n",
     "    count_key=\"book_events\",\n",
     "    count_label=\"Book Events\",\n",
-    "    pnl_label=\"PnL (USDC)\",\n",
+    "    pnl_label=\"PnL (pUSD)\",\n",
     "    market_key=\"slug\",\n",
     "    summary_report=True,\n",
     "    summary_report_path=f\"output/{name}_holdout_joint_portfolio.html\",\n",

--- a/backtests/polymarket_beffer45_trade_replay_telonex.py
+++ b/backtests/polymarket_beffer45_trade_replay_telonex.py
@@ -332,7 +332,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=str(_REPORT_PATH),

--- a/backtests/polymarket_book_ema_crossover.py
+++ b/backtests/polymarket_book_ema_crossover.py
@@ -88,7 +88,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     summary_report=True,
                     summary_report_path="output/polymarket_book_ema_crossover_summary.html",
                     summary_plot_panels=(

--- a/backtests/polymarket_book_joint_portfolio_runner.py
+++ b/backtests/polymarket_book_joint_portfolio_runner.py
@@ -127,7 +127,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=(

--- a/backtests/polymarket_btc_5m_late_favorite_taker_hold.py
+++ b/backtests/polymarket_btc_5m_late_favorite_taker_hold.py
@@ -141,7 +141,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=SUMMARY_REPORT_PATH,

--- a/backtests/polymarket_btc_5m_pair_arbitrage.py
+++ b/backtests/polymarket_btc_5m_pair_arbitrage.py
@@ -131,7 +131,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=("output/polymarket_btc_5m_pair_arbitrage_summary.html"),

--- a/backtests/polymarket_pmxt_book_100_replay_runner.py
+++ b/backtests/polymarket_pmxt_book_100_replay_runner.py
@@ -214,7 +214,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=(

--- a/backtests/polymarket_telonex_book_100_replay_runner.py
+++ b/backtests/polymarket_telonex_book_100_replay_runner.py
@@ -217,7 +217,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=(

--- a/backtests/polymarket_telonex_book_joint_portfolio_runner.py
+++ b/backtests/polymarket_telonex_book_joint_portfolio_runner.py
@@ -195,7 +195,7 @@ def run() -> None:
                 report=MarketReportConfig(
                     count_key="book_events",
                     count_label="Book Events",
-                    pnl_label="PnL (USDC)",
+                    pnl_label="PnL (pUSD)",
                     market_key="sim_label",
                     summary_report=True,
                     summary_report_path=(

--- a/docs/account-ledger-replay.md
+++ b/docs/account-ledger-replay.md
@@ -199,7 +199,7 @@ as fresh IOC orders against the already-realized historical book.
 
 <div class="terminal-output-scroll">
 <pre><code>──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Market                                                   Book Events  Fills        Qty   AvgPx   Notional   PnL (USDC)    Return     MaxDD   Sharpe  Sortino      PF  Coverage
+Market                                                   Book Events  Fills        Qty   AvgPx   Notional   PnL (pUSD)    Return     MaxDD   Sharpe  Sortino      PF  Coverage
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 bitcoin-up-or-down-april-26-2026-4am-et:Up                    101833      1      14.01  0.3400       4.76      -4.6995    -0.47%    -1.18%      n/a   -15.87    0.88  +100.00%
 btc-updown-15m-1777222800:Up                                   61180      2      10.45  0.2400       2.51      +0.6700    +0.07%    -0.02%      n/a      n/a    2.17  +100.00%
@@ -293,7 +293,7 @@ TOTAL                                                        9385899     72    1
 
 Portfolio run stats: Iterations: 9,500,965 | Events: 410 | Orders: 153 | Positions: 48 | Elapsed: 260867.127s
 Portfolio return stats: Sharpe Ratio (252 days): -10.87 | Sortino Ratio (252 days): -10.2 | Profit Factor: 0 | Risk Return Ratio: -0.6849 | Returns Volatility (252 days): 1.017 | Average (Return): -0.04387
-Portfolio PnL stats (USDC.e): PnL (total): -148.5 | PnL% (total): -14.85 | Win Rate: 0.9167 | Expectancy: 1.164 | Avg Winner: 1.341 | Avg Loser: -0.7787
+Portfolio PnL stats (pUSD): PnL (total): -148.5 | PnL% (total): -14.85 | Win Rate: 0.9167 | Expectancy: 1.164 | Avg Winner: 1.341 | Avg Loser: -0.7787
 
 WARNING: bitcoin-up-or-down-april-26-2026-4am-et:Up: Replay selection is explicitly curated from named markets and may exclude cancelled, delisted, or zero-liquidity markets.
 WARNING: bitcoin-up-or-down-april-26-2026-4am-et:Up: No portfolio-level drawdown or daily-loss circuit breaker is configured for this run.

--- a/docs/backtests.md
+++ b/docs/backtests.md
@@ -133,7 +133,7 @@ def run() -> None:
             report=MarketReportConfig(
                 count_key="book_events",
                 count_label="Book Events",
-                pnl_label="PnL (USDC)",
+                pnl_label="PnL (pUSD)",
             ),
             empty_message="No replays met the book requirements.",
         )
@@ -175,7 +175,7 @@ build_replay_experiment(
     report=MarketReportConfig(
         count_key="book_events",
         count_label="Book Events",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         summary_report=True,
         summary_report_path="output/polymarket_book_joint_portfolio_runner_joint_portfolio.html",
         summary_plot_panels=(

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -95,7 +95,7 @@ build_replay_experiment(
     report=MarketReportConfig(
         count_key="book_events",
         count_label="Book Events",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         summary_report=True,
         summary_report_path="output/polymarket_book_joint_portfolio_runner_joint_portfolio.html",
         summary_plot_panels=(

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,29 +13,33 @@
 git clone https://github.com/evan-kolberg/prediction-market-backtesting.git
 cd prediction-market-backtesting
 
+make install
+make native-develop
+```
+
+`make install` creates the `.venv` and installs runtime, notebook, plotting,
+optimizer, downloader, and repo-gate dependencies. `make native-develop` builds
+the Rust-native data-loading extension.
+
+The equivalent manual install is:
+
+```bash
 # conda's linker flags can conflict with the venv
 unset CONDA_PREFIX
 
 uv venv --python 3.13
-uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv
+uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv aiohttp pytest ruff
 make native-develop
 ```
+
+After setup, run commands with `uv run ...`. You do not need to manually
+activate the virtualenv.
 
 If you want to build docs locally:
 
 ```bash
 uv pip install mkdocs-shadcn
 ```
-
-You can also use:
-
-```bash
-make install
-make native-develop
-```
-
-After setup, run commands with `uv run ...`. You do not need to manually
-activate the virtualenv.
 
 ## First Run
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,7 +17,7 @@ cd prediction-market-backtesting
 unset CONDA_PREFIX
 
 uv venv --python 3.13
-uv pip install "nautilus_trader[polymarket,visualization]==1.225.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv
+uv pip install "nautilus_trader[polymarket,visualization]==1.226.0" bokeh plotly numpy py-clob-client duckdb textual nbformat nbclient ipykernel optuna python-dotenv
 make native-develop
 ```
 
@@ -200,7 +200,7 @@ Throughput and memory controls:
 ## Extension Architecture
 
 This repo does not vendor NautilusTrader in-tree. Runtime code comes from
-upstream `nautilus_trader==1.225.0`, and local extensions live under
+upstream `nautilus_trader==1.226.0`, and local extensions live under
 `prediction_market_extensions/`.
 
 Extensions import from upstream Nautilus and add prediction-market-specific

--- a/prediction_market_extensions/__init__.py
+++ b/prediction_market_extensions/__init__.py
@@ -7,13 +7,11 @@ _COMMISSION_PATCH_INSTALLED = False
 
 def install_commission_patch() -> None:
     """
-    Monkey-patch upstream ``calculate_commission`` with the corrected fee curve.
+    Install the repo's Polymarket commission rounding policy.
 
-    Upstream uses ``qty * price * fee_rate_bps_as_fraction`` (linear).
-    The correct Polymarket formula is ``qty * feeRate * p * (1 - p)`` (curved),
-    which peaks at p=0.50 and tapers toward the extremes.
-
-    This is the only startup hook required. Call once at process start.
+    Nautilus 1.226 uses the current curved fee formula and pUSD currency
+    model. This startup hook keeps this repository's fee rounding centralized
+    while targeting the 1.226 function signature directly.
     """
     global _COMMISSION_PATCH_INSTALLED
     if _COMMISSION_PATCH_INSTALLED:

--- a/prediction_market_extensions/adapters/polymarket/execution.py
+++ b/prediction_market_extensions/adapters/polymarket/execution.py
@@ -30,7 +30,7 @@ from nautilus_trader.adapters.polymarket.common.constants import (
     POLYMARKET_VENUE,
     VALID_POLYMARKET_TIME_IN_FORCE,
 )
-from nautilus_trader.adapters.polymarket.common.conversion import usdce_from_units
+from nautilus_trader.adapters.polymarket.common.conversion import pusd_from_units
 from nautilus_trader.adapters.polymarket.common.credentials import PolymarketWebSocketAuth
 from nautilus_trader.adapters.polymarket.common.enums import (
     PolymarketEventType,
@@ -83,7 +83,7 @@ from nautilus_trader.execution.messages import (
 from nautilus_trader.execution.reports import FillReport, OrderStatusReport, PositionStatusReport
 from nautilus_trader.live.execution_client import LiveExecutionClient
 from nautilus_trader.live.retry import RetryManagerPool
-from nautilus_trader.model.currencies import USDC_POS
+from nautilus_trader.model.currencies import pUSD
 from nautilus_trader.model.enums import (
     AccountType,
     ContingencyType,
@@ -117,8 +117,6 @@ from py_clob_client.client import (
 )
 from py_clob_client.clob_types import AssetType, PostOrdersArgs
 from py_clob_client.exceptions import PolyApiException
-
-from prediction_market_extensions.adapters.polymarket.parsing import infer_fee_exponent
 
 
 class PolymarketExecutionClient(LiveExecutionClient):
@@ -167,7 +165,7 @@ class PolymarketExecutionClient(LiveExecutionClient):
             oms_type=OmsType.NETTING,
             instrument_provider=instrument_provider,
             account_type=AccountType.CASH,
-            base_currency=USDC_POS,
+            base_currency=pUSD,
             msgbus=msgbus,
             cache=cache,
             clock=clock,
@@ -287,10 +285,8 @@ class PolymarketExecutionClient(LiveExecutionClient):
         response: dict[str, Any] = await asyncio.to_thread(
             self._http_client.get_balance_allowance, params
         )
-        total = usdce_from_units(int(response["balance"]))
-        account_balance = AccountBalance(
-            total=total, locked=Money.from_raw(0, USDC_POS), free=total
-        )
+        total = pusd_from_units(int(response["balance"]))
+        account_balance = AccountBalance(total=total, locked=Money.from_raw(0, pUSD), free=total)
 
         self.generate_account_state(
             balances=[account_balance],
@@ -750,7 +746,7 @@ class PolymarketExecutionClient(LiveExecutionClient):
         for instrument_id in instrument_ids:
             size = size_by_asset.get(instrument_id, 0.0)
             # Gamma API returns size as decimal float (e.g., 1.5 shares)
-            quantities[instrument_id] = Quantity(float(size), precision=USDC_POS.precision)
+            quantities[instrument_id] = Quantity(float(size), precision=pUSD.precision)
 
         return quantities
 
@@ -775,7 +771,7 @@ class PolymarketExecutionClient(LiveExecutionClient):
                 self._http_client.get_balance_allowance, params
             )
             quantities[instrument_id] = Quantity.from_raw(
-                usdce_from_units(int(response["balance"])).raw, precision=USDC_POS.precision
+                pusd_from_units(int(response["balance"])).raw, precision=pUSD.precision
             )
 
         return quantities
@@ -1804,9 +1800,13 @@ class PolymarketExecutionClient(LiveExecutionClient):
 
         last_qty = instrument.make_qty(msg.last_qty(order_id))
         last_px = instrument.make_price(msg.last_px(order_id))
-        fee_rate_bps = msg.get_fee_rate_bps(order_id)
-        fee_exponent = infer_fee_exponent(fee_rate_bps)
-        commission = calculate_commission(last_qty, last_px, fee_rate_bps, fee_exponent)
+        liquidity_side = msg.liquidity_side()
+        commission = calculate_commission(
+            quantity=last_qty.as_decimal(),
+            price=last_px.as_decimal(),
+            fee_rate=instrument.taker_fee,
+            liquidity_side=liquidity_side,
+        )
         ts_event = secs_to_nanos(int(msg.match_time))
 
         self.generate_order_filled(
@@ -1820,9 +1820,9 @@ class PolymarketExecutionClient(LiveExecutionClient):
             order_type=order.order_type,
             last_qty=last_qty,
             last_px=last_px,
-            quote_currency=USDC_POS,
-            commission=Money(commission, USDC_POS),
-            liquidity_side=msg.liquidity_side(),
+            quote_currency=pUSD,
+            commission=Money(commission, pUSD),
+            liquidity_side=liquidity_side,
             ts_event=ts_event,
             info=msg.to_dict(),
         )

--- a/prediction_market_extensions/adapters/polymarket/fee_model.py
+++ b/prediction_market_extensions/adapters/polymarket/fee_model.py
@@ -23,9 +23,13 @@ from typing import Any
 
 from nautilus_trader.backtest.models import FeeModel
 from nautilus_trader.core.rust.model import OrderType
+from nautilus_trader.model.enums import LiquiditySide
 from nautilus_trader.model.objects import Money
 
-from prediction_market_extensions.adapters.polymarket.parsing import calculate_commission
+from prediction_market_extensions.adapters.polymarket.parsing import (
+    basis_points_as_decimal,
+    calculate_commission,
+)
 
 _CRYPTO_MAKER_REBATE_RATE = Decimal("0.20")
 _DEFAULT_FEE_ENABLED_MAKER_REBATE_RATE = Decimal("0.25")
@@ -167,7 +171,14 @@ def calculate_maker_rebate(
         return 0.0
 
     fee_equivalent = Decimal(
-        str(calculate_commission(quantity=quantity, price=price, fee_rate_bps=fee_rate_bps))
+        str(
+            calculate_commission(
+                quantity=quantity,
+                price=price,
+                fee_rate=basis_points_as_decimal(fee_rate_bps),
+                liquidity_side=LiquiditySide.TAKER,
+            )
+        )
     )
     rebate = fee_equivalent * maker_rebate_rate
     return float(rebate.quantize(_REBATE_QUANTUM, rounding=ROUND_HALF_UP))
@@ -253,6 +264,9 @@ class PolymarketFeeModel(FeeModel):
             return Money(Decimal(str(-rebate)), instrument.quote_currency)
 
         commission = calculate_commission(
-            quantity=fill_quantity, price=fill_price, fee_rate_bps=fee_rate_bps
+            quantity=fill_quantity,
+            price=fill_price,
+            fee_rate=taker_fee_dec,
+            liquidity_side=LiquiditySide.TAKER,
         )
         return Money(Decimal(str(commission)), instrument.quote_currency)

--- a/prediction_market_extensions/adapters/polymarket/parsing.py
+++ b/prediction_market_extensions/adapters/polymarket/parsing.py
@@ -15,20 +15,18 @@
 #  See the repository NOTICE file for provenance and licensing scope.
 #
 """
-Corrected Polymarket fee calculation.
+Polymarket fee calculation policy.
 
-Upstream ``nautilus_trader.adapters.polymarket.common.parsing.calculate_commission``
-uses a linear formula (``qty * price * fee_rate``).  Polymarket's actual fee
-curve is ``qty * feeRate * p * (1 - p)`` which peaks at p=0.50 and tapers
-toward the extremes.
-
-This module provides the corrected formula and is installed as a monkey-patch
-via ``prediction_market_extensions.install_commission_patch()``.
+NautilusTrader 1.226 uses Polymarket's curved taker-fee formula directly. This
+module centralizes the repository's Decimal rounding behavior while targeting
+the 1.226 function signature with no old-version compatibility layer.
 """
 
 from __future__ import annotations
 
 from decimal import ROUND_HALF_UP, Decimal
+
+from nautilus_trader.model.enums import LiquiditySide
 
 
 def basis_points_as_decimal(basis_points: Decimal) -> Decimal:
@@ -49,35 +47,11 @@ def basis_points_as_decimal(basis_points: Decimal) -> Decimal:
     return basis_points / Decimal(10_000)
 
 
-def infer_fee_exponent(fee_rate_bps: Decimal) -> int:
-    """
-    Return the legacy Polymarket fee exponent compatibility value.
-
-    Older code paths inferred different exponents by market type. Polymarket's
-    current fee documentation uses one shared fee curve for all fee-enabled
-    categories, so callers should treat the exponent as ``1``.
-
-    Parameters
-    ----------
-    fee_rate_bps : Decimal
-        The fee rate in basis points. Retained for API compatibility.
-
-    Returns
-    -------
-    int
-        Always ``1``.
-
-    """
-    del fee_rate_bps
-    return 1
-
-
 def calculate_commission(
     quantity: Decimal,
     price: Decimal,
-    fee_rate_bps: Decimal,
-    fee_exponent: int = 1,
-    **_kwargs: object,
+    fee_rate: Decimal,
+    liquidity_side: LiquiditySide,
 ) -> float:
     """
     Calculate commission from trade parameters and fee rate.
@@ -89,12 +63,12 @@ def calculate_commission(
     Where:
     - C = number of shares (quantity)
     - p = share price
-    - feeRate = fee_rate_bps / 10_000
+    - feeRate = the effective taker rate as a decimal fraction
 
     The fee peaks at p = 0.50 and decreases symmetrically toward the
     extremes (p -> 0 or p -> 1).
 
-    Polymarket rounds fees to 5 decimal places (0.00001 USDC minimum).
+    Polymarket rounds fees to 5 decimal places (0.00001 pUSD minimum).
 
     References
     ----------
@@ -106,10 +80,10 @@ def calculate_commission(
         The fill quantity.
     price : Decimal
         The fill price (0 to 1).
-    fee_rate_bps : Decimal
-        The fee rate in basis points.
-    fee_exponent : int, default 1
-        Retained for backward compatibility with <= 1.225.0 and ignored.
+    fee_rate : Decimal
+        The effective fee rate as a decimal fraction, e.g. ``0.03`` for 3%.
+    liquidity_side : LiquiditySide
+        The liquidity side for this fill. Maker fills pay no fee.
 
     Returns
     -------
@@ -117,10 +91,8 @@ def calculate_commission(
         The commission amount rounded to 5 decimal places.
 
     """
-    if fee_rate_bps <= 0:
+    if liquidity_side != LiquiditySide.TAKER or fee_rate <= 0:
         return 0.0
 
-    del fee_exponent
-    fee_rate = basis_points_as_decimal(fee_rate_bps)
     commission = quantity * fee_rate * price * (Decimal(1) - price)
     return float(commission.quantize(Decimal("0.00001"), rounding=ROUND_HALF_UP))

--- a/prediction_market_extensions/backtesting/_optimizer.py
+++ b/prediction_market_extensions/backtesting/_optimizer.py
@@ -601,6 +601,8 @@ def _joint_portfolio_drawdown(equity_series_list: Sequence[object]) -> float:
             continue
         index = pd.to_datetime(timestamps, utc=True, errors="coerce")
         frame = pd.Series(values, index=index).dropna().sort_index()
+        if frame.index.has_duplicates:
+            frame = frame.groupby(level=0).last()
         if not frame.empty:
             frames.append(frame)
 

--- a/prediction_market_extensions/backtesting/_strategy_configs.py
+++ b/prediction_market_extensions/backtesting/_strategy_configs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from importlib import import_module
 from typing import Any
 
 from nautilus_trader.config import ImportableStrategyConfig
@@ -14,17 +15,57 @@ type StrategyConfigSpec = Mapping[str, Any]
 _PRIMARY_INSTRUMENT_SENTINELS = {None, "__PRIMARY_INSTRUMENT__", "__PRIMARY_INSTRUMENTS__"}
 
 
+def _is_primary_instrument_sentinel(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and value in _PRIMARY_INSTRUMENT_SENTINELS)
+
+
+def _import_symbol(import_path: str) -> Any:
+    module_path, separator, symbol_name = import_path.partition(":")
+    if not separator:
+        module_path, _, symbol_name = import_path.rpartition(".")
+    if not module_path or not symbol_name:
+        raise ValueError(f"invalid import path: {import_path!r}")
+    return getattr(import_module(module_path), symbol_name)
+
+
+def _config_field_names(config_path: str) -> set[str]:
+    config_cls = _import_symbol(config_path)
+    return set(getattr(config_cls, "__struct_fields__", ()))
+
+
 def _normalized_config(
-    *, raw_config: Mapping[str, Any], instrument_id: InstrumentId
+    *, raw_config: Mapping[str, Any], config_path: str, instrument_id: InstrumentId
 ) -> dict[str, Any]:
     config = deepcopy(dict(raw_config))
-    instrument_ids = config.get("instrument_ids")
-    if instrument_ids is None or instrument_ids == "__PRIMARY_INSTRUMENTS__":
-        config["instrument_ids"] = [instrument_id]
+    fields = _config_field_names(config_path)
+    supports_instrument_id = "instrument_id" in fields
+    supports_instrument_ids = "instrument_ids" in fields
 
-    if ("instrument_id" not in config and "instrument_ids" not in config) or config.get(
-        "instrument_id"
-    ) in _PRIMARY_INSTRUMENT_SENTINELS:
+    has_instrument_id = "instrument_id" in config
+    has_instrument_ids = "instrument_ids" in config
+
+    if not has_instrument_id and not has_instrument_ids:
+        if supports_instrument_id:
+            config["instrument_id"] = instrument_id
+        elif supports_instrument_ids:
+            config["instrument_ids"] = [instrument_id]
+        return config
+
+    if _is_primary_instrument_sentinel(config.get("instrument_id")) and has_instrument_id:
+        if supports_instrument_id:
+            config["instrument_id"] = instrument_id
+        elif supports_instrument_ids:
+            config.pop("instrument_id", None)
+            config["instrument_ids"] = [instrument_id]
+
+    if _is_primary_instrument_sentinel(config.get("instrument_ids")) and has_instrument_ids:
+        if supports_instrument_ids:
+            config["instrument_ids"] = [instrument_id]
+        elif supports_instrument_id:
+            config.pop("instrument_ids", None)
+            config["instrument_id"] = instrument_id
+
+    if "instrument_id" not in config and "instrument_ids" not in config and supports_instrument_id:
         config["instrument_id"] = instrument_id
 
     return config
@@ -45,7 +86,11 @@ def build_importable_strategy_configs(
             ImportableStrategyConfig(
                 strategy_path=strategy_path,
                 config_path=config_path,
-                config=_normalized_config(raw_config=raw_config, instrument_id=instrument_id),
+                config=_normalized_config(
+                    raw_config=raw_config,
+                    config_path=config_path,
+                    instrument_id=instrument_id,
+                ),
             )
         )
 

--- a/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
+++ b/prediction_market_extensions/backtesting/data_sources/replay_adapters.py
@@ -19,7 +19,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from nautilus_trader.adapters.polymarket import POLYMARKET_VENUE
 from nautilus_trader.model.book import OrderBook
-from nautilus_trader.model.currencies import USDC_POS
+from nautilus_trader.model.currencies import pUSD
 from nautilus_trader.model.data import OrderBookDeltas, TradeTick
 from nautilus_trader.model.enums import AccountType, BookType, OmsType
 
@@ -442,6 +442,11 @@ def _polymarket_ceiling_warning(caught_warnings: list[warnings.WarningMessage]) 
     return None
 
 
+def _disable_polymarket_trade_fallback() -> bool:
+    raw = os.getenv("TELONEX_DISABLE_POLYMARKET_TRADE_FALLBACK", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _trade_days_for_window(start: pd.Timestamp, end: pd.Timestamp) -> tuple[pd.Timestamp, ...]:
     start_utc = _normalize_timestamp(start)
     end_utc = _normalize_timestamp(end)
@@ -476,6 +481,11 @@ async def _load_trade_ticks(
             day_trades = tuple(sorted(telonex_trades, key=_trade_record_sort_key))
             source = str(
                 getattr(loader, "_telonex_last_trade_source", None) or "telonex onchain_fills"
+            )
+        elif callable(telonex_loader) and _disable_polymarket_trade_fallback():
+            day_trades = ()
+            source = str(
+                getattr(loader, "_telonex_last_trade_source", None) or "telonex onchain_fills empty"
             )
         elif cache_path is not None and cache_path.exists():
             frame = await asyncio.to_thread(pd.read_parquet, cache_path)
@@ -555,7 +565,7 @@ L2_BOOK_ENGINE_PROFILE = ReplayEngineProfile(
     venue=POLYMARKET_VENUE,
     oms_type=OmsType.NETTING,
     account_type=AccountType.CASH,
-    base_currency=USDC_POS,
+    base_currency=pUSD,
     fee_model_factory=PolymarketFeeModel,
     fill_model_mode="passive_book",
     book_type=BookType.L2_MBP,

--- a/prediction_market_extensions/backtesting/data_sources/telonex.py
+++ b/prediction_market_extensions/backtesting/data_sources/telonex.py
@@ -543,7 +543,15 @@ def _trade_source_summary_parts(entries: Sequence[TelonexSourceEntry]) -> list[s
     for entry in api_entries:
         suffix = " (key set)" if entry.api_key else " (key missing)"
         parts.append(f"api {entry.target}{suffix}")
-    parts.extend(("polymarket cache", f"api {_POLYMARKET_PUBLIC_TRADES_API_URL}"))
+    if os.getenv("TELONEX_DISABLE_POLYMARKET_TRADE_FALLBACK", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        parts.append("polymarket fallback disabled")
+    else:
+        parts.extend(("polymarket cache", f"api {_POLYMARKET_PUBLIC_TRADES_API_URL}"))
     return parts
 
 

--- a/strategies/binary_pair_arbitrage.py
+++ b/strategies/binary_pair_arbitrage.py
@@ -96,6 +96,7 @@ class BookBinaryPairArbitrageConfig(StrategyConfig, frozen=True):  # type: ignor
     pairing_mode: str = "sequential"
     hold_to_resolution: bool = True
     include_taker_fees_in_signal: bool = True
+    signal_fee_rate: float | None = None
 
     def __post_init__(self) -> None:
         require_positive_decimal("trade_size", self.trade_size)
@@ -107,6 +108,8 @@ class BookBinaryPairArbitrageConfig(StrategyConfig, frozen=True):  # type: ignor
         require_finite_nonnegative_float("min_visible_size", self.min_visible_size)
         require_nonnegative_int("max_entries_per_pair", self.max_entries_per_pair)
         require_nonnegative_int("reentry_cooldown_updates", self.reentry_cooldown_updates)
+        if self.signal_fee_rate is not None:
+            require_finite_nonnegative_float("signal_fee_rate", self.signal_fee_rate)
         if self.pairing_mode != "sequential":
             raise ValueError("pairing_mode currently supports only 'sequential'")
         if len(self.instrument_ids) < 2 or len(self.instrument_ids) % 2 != 0:
@@ -193,6 +196,8 @@ class BookBinaryPairArbitrageStrategy(Strategy):
         instrument = self._instruments.get(instrument_id)
         if instrument is None:
             return Decimal("0")
+        if self.config.signal_fee_rate is not None:
+            return Decimal(str(self.config.signal_fee_rate))
         return _decimal_or_none(getattr(instrument, "taker_fee", None)) or Decimal("0")
 
     def _free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None:

--- a/strategies/core.py
+++ b/strategies/core.py
@@ -117,6 +117,8 @@ class LongOnlyPredictionMarketStrategy(Strategy):
         self._last_entry_reference_price: float | None = None
         self._last_entry_visible_size: float | None = None
         self._last_exit_visible_size: float | None = None
+        self._last_book_ts_ns: int = 0
+        self._last_exit_attempt_ts_ns: int | None = None
         self._entry_warning_emitted: bool = False
         self._order_book: OrderBook | None = None
 
@@ -152,6 +154,7 @@ class LongOnlyPredictionMarketStrategy(Strategy):
         if self._order_book is None:
             self._order_book = OrderBook(instrument_id, book_type=BookType.L2_MBP)
         self._order_book.apply_deltas(deltas)
+        self._last_book_ts_ns = int(getattr(deltas, "ts_event", 0) or 0)
         self.on_order_book(self._order_book)
 
     def _in_position(self) -> bool:
@@ -282,6 +285,14 @@ class LongOnlyPredictionMarketStrategy(Strategy):
 
     def _submit_exit(self) -> None:
         assert self._instrument is not None
+        retry_cooldown_seconds = float(getattr(self.config, "exit_retry_cooldown_seconds", 5.0))
+        retry_cooldown_ns = int(retry_cooldown_seconds * 1_000_000_000)
+        if (
+            self._last_book_ts_ns > 0
+            and self._last_exit_attempt_ts_ns is not None
+            and self._last_book_ts_ns - self._last_exit_attempt_ts_ns < retry_cooldown_ns
+        ):
+            return
         net_position = self.portfolio.net_position(self.config.instrument_id)
         if net_position is None:
             return
@@ -310,6 +321,12 @@ class LongOnlyPredictionMarketStrategy(Strategy):
             return
         if quantity.as_double() <= 0:
             return
+        min_quantity = getattr(self._instrument, "min_quantity", None)
+        if min_quantity is not None and quantity.as_double() + 1e-12 < min_quantity.as_double():
+            return
+        lot_size = getattr(self._instrument, "lot_size", None)
+        if lot_size is not None and quantity.as_double() + 1e-12 < lot_size.as_double():
+            return
 
         order = self.order_factory.market(
             instrument_id=self.config.instrument_id,
@@ -319,6 +336,8 @@ class LongOnlyPredictionMarketStrategy(Strategy):
             reduce_only=True,
             tags=self._order_tags(intent="exit", visible_size=self._last_exit_visible_size),
         )
+        if self._last_book_ts_ns > 0:
+            self._last_exit_attempt_ts_ns = self._last_book_ts_ns
         self._pending = True
         try:
             self.submit_order(order)
@@ -400,6 +419,7 @@ class LongOnlyPredictionMarketStrategy(Strategy):
                 self._entry_price = float(self._entry_cost_sum / self._entry_qty_sum)
             else:
                 self._entry_price = None
+                self._last_exit_attempt_ts_ns = None
                 self._entry_qty_sum = Decimal("0")
                 self._entry_cost_sum = Decimal("0")
         if self._event_order_is_closed(event):
@@ -429,6 +449,8 @@ class LongOnlyPredictionMarketStrategy(Strategy):
         self._last_entry_reference_price = None
         self._last_entry_visible_size = None
         self._last_exit_visible_size = None
+        self._last_book_ts_ns = 0
+        self._last_exit_attempt_ts_ns = None
         self._entry_warning_emitted = False
         self._instrument = None
         self._order_book = None

--- a/tests/test_nautilus_override_bootstrap.py
+++ b/tests/test_nautilus_override_bootstrap.py
@@ -53,24 +53,26 @@ def test_extensions_resolve_to_own_namespace() -> None:
 
 
 def test_commission_patch_installed() -> None:
-    """Verify that the corrected calculate_commission is installed via monkey-patch."""
+    """Verify that the repo calculate_commission is installed via monkey-patch."""
     from decimal import Decimal
 
     from nautilus_trader.adapters.polymarket.common.parsing import calculate_commission
+    from nautilus_trader.model.enums import LiquiditySide
 
     from prediction_market_extensions.adapters.polymarket.parsing import (
         calculate_commission as pm_calculate_commission,
     )
 
     # After conftest.py runs install_commission_patch(), the upstream function
-    # should be our corrected version.
+    # should be the repo implementation.
     assert calculate_commission is pm_calculate_commission
 
     # Verify the fee curve: at p=0.50, fee = qty * feeRate * 0.50 * 0.50
     fee = calculate_commission(
         quantity=Decimal(100),
         price=Decimal("0.50"),
-        fee_rate_bps=Decimal(200),  # 2% = 200 bps
+        fee_rate=Decimal("0.02"),
+        liquidity_side=LiquiditySide.TAKER,
     )
     expected = 100 * 0.02 * 0.50 * 0.50  # = 0.50
     assert abs(fee - expected) < 0.001

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -463,6 +463,24 @@ def test_joint_portfolio_drawdown_tracks_concurrent_losses() -> None:
     assert joint == pytest.approx(40.0)
 
 
+def test_joint_portfolio_drawdown_uses_latest_duplicate_timestamp_value() -> None:
+    # Summary series can contain repeated timestamps when multiple events are
+    # recorded at the same exchange time. Reindexing requires unique labels;
+    # using the last value preserves the latest known equity at that instant.
+    market_a = [
+        ("2026-01-01T00:00:00Z", 100.0),
+        ("2026-01-01T01:00:00Z", 95.0),
+        ("2026-01-01T01:00:00Z", 90.0),
+        ("2026-01-01T02:00:00Z", 100.0),
+    ]
+    market_b = [
+        ("2026-01-01T00:30:00Z", 100.0),
+        ("2026-01-01T01:30:00Z", 100.0),
+    ]
+
+    assert optimizer._joint_portfolio_drawdown([market_a, market_b]) == pytest.approx(10.0)
+
+
 def test_parameter_search_config_accepts_base_replays_for_multi_market(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_polymarket_fees.py
+++ b/tests/test_polymarket_fees.py
@@ -5,7 +5,8 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 from nautilus_trader.core.rust.model import OrderType
-from nautilus_trader.model.currencies import USDC_POS
+from nautilus_trader.model.currencies import pUSD
+from nautilus_trader.model.enums import LiquiditySide
 from nautilus_trader.model.objects import Currency
 
 from prediction_market_extensions.adapters.polymarket.loaders import PolymarketDataLoader
@@ -16,7 +17,6 @@ from prediction_market_extensions.adapters.polymarket.fee_model import (
 )
 from prediction_market_extensions.adapters.polymarket.parsing import (
     calculate_commission,
-    infer_fee_exponent,
 )
 
 
@@ -24,9 +24,8 @@ def test_calculate_commission_matches_current_polymarket_formula() -> None:
     commission = calculate_commission(
         quantity=Decimal(100),
         price=Decimal("0.5"),
-        fee_rate_bps=Decimal(
-            30,
-        ),
+        fee_rate=Decimal("0.003"),
+        liquidity_side=LiquiditySide.TAKER,
     )
 
     assert commission == 0.075
@@ -36,18 +35,22 @@ def test_calculate_commission_rounds_to_five_decimals() -> None:
     commission = calculate_commission(
         quantity=Decimal(1),
         price=Decimal("0.5"),
-        fee_rate_bps=Decimal(
-            "2.2",
-        ),
+        fee_rate=Decimal("0.00022"),
+        liquidity_side=LiquiditySide.TAKER,
     )
 
     assert commission == 0.00006
 
 
-def test_infer_fee_exponent_is_now_a_compatibility_shim() -> None:
-    assert infer_fee_exponent(Decimal(0)) == 1
-    assert infer_fee_exponent(Decimal(35)) == 1
-    assert infer_fee_exponent(Decimal(2500)) == 1
+def test_calculate_commission_charges_takers_only() -> None:
+    commission = calculate_commission(
+        quantity=Decimal(100),
+        price=Decimal("0.5"),
+        fee_rate=Decimal("0.003"),
+        liquidity_side=LiquiditySide.MAKER,
+    )
+
+    assert commission == 0.0
 
 
 def test_fee_rate_enrichment_keeps_maker_fee_zero(monkeypatch) -> None:
@@ -133,7 +136,7 @@ def test_limit_orders_receive_polymarket_maker_rebate_credit() -> None:
         instrument=SimpleNamespace(
             info={"tags": ["Sports"]},
             taker_fee=Decimal("0.003"),
-            quote_currency=USDC_POS,
+            quote_currency=pUSD,
         ),
     )
 
@@ -163,7 +166,7 @@ def test_market_orders_still_pay_polymarket_taker_fee() -> None:
         instrument=SimpleNamespace(
             info={"tags": ["Sports"]},
             taker_fee=Decimal("0.003"),
-            quote_currency=USDC_POS,
+            quote_currency=pUSD,
         ),
     )
 

--- a/tests/test_prediction_market_report_timestamps.py
+++ b/tests/test_prediction_market_report_timestamps.py
@@ -70,7 +70,7 @@ def test_save_aggregate_backtest_report_accepts_mixed_iso_timestamp_precision(tm
         output_path=output_path,
         title="mixed timestamp precision chart",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
     )
 
     assert report_path == str(output_path.resolve())
@@ -173,7 +173,7 @@ def test_save_joint_portfolio_backtest_report_accepts_mixed_iso_timestamp_precis
         output_path=output_path,
         title="joint mixed timestamp precision chart",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
     )
 
     assert report_path == str(output_path.resolve())
@@ -278,7 +278,7 @@ def test_save_aggregate_backtest_report_adds_brier_placeholder_when_outcomes_mis
         output_path=tmp_path / "aggregate_brier_placeholder.html",
         title="aggregate placeholder chart",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=("brier_advantage",),
     )
 
@@ -377,7 +377,7 @@ def test_save_joint_portfolio_backtest_report_adds_brier_placeholder_when_outcom
         output_path=tmp_path / "joint_brier_placeholder.html",
         title="joint placeholder chart",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=("brier_advantage",),
     )
 
@@ -479,7 +479,7 @@ def test_save_aggregate_backtest_report_limits_dense_yes_price_fill_markers(
         output_path=tmp_path / "aggregate_dense_fills.html",
         title="aggregate dense fills",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
     )
 
     assert report_path == str((tmp_path / "aggregate_dense_fills.html").resolve())
@@ -576,7 +576,7 @@ def test_save_joint_portfolio_backtest_report_limits_dense_yes_price_fill_marker
         output_path=tmp_path / "joint_dense_fills.html",
         title="joint dense fills",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
     )
 
     assert report_path == str((tmp_path / "joint_dense_fills.html").resolve())
@@ -691,7 +691,7 @@ def test_save_aggregate_backtest_report_prunes_unused_payload_for_total_only_pan
         output_path=tmp_path / "aggregate_total_only.html",
         title="aggregate total only",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=("total_equity", "periodic_pnl", "monthly_returns"),
     )
 
@@ -784,7 +784,7 @@ def test_save_aggregate_backtest_report_keeps_market_payload_when_summary_panels
         output_path=tmp_path / "aggregate_rich.html",
         title="aggregate rich",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=("equity", "yes_price", "allocation", "market_pnl"),
     )
 
@@ -871,7 +871,7 @@ def test_save_joint_portfolio_backtest_report_prunes_unused_payload_for_total_on
         output_path=tmp_path / "joint_total_only.html",
         title="joint total only",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=("total_equity", "total_cash_equity", "periodic_pnl", "monthly_returns"),
     )
 
@@ -1001,7 +1001,7 @@ def test_save_joint_portfolio_backtest_report_keeps_market_overlays_when_needed(
         output_path=tmp_path / "joint_with_overlays.html",
         title="joint with overlays",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=(
             "total_brier_advantage",
             "brier_advantage",
@@ -1078,7 +1078,7 @@ def test_save_joint_portfolio_backtest_report_renders_market_overlay_labels(tmp_
         output_path=output_path,
         title="joint with rendered overlays",
         market_key="slug",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
         plot_panels=(
             "total_equity",
             "equity",

--- a/tests/test_prediction_market_summary_stats.py
+++ b/tests/test_prediction_market_summary_stats.py
@@ -36,7 +36,7 @@ def test_print_backtest_summary_includes_rich_statistics(capsys) -> None:
                         "Profit Factor": 2.0,
                     },
                     "stats_pnls": {
-                        "USDC": {
+                        "pUSD": {
                             "PnL (total)": 1.0,
                             "Win Rate": 0.5,
                             "Expectancy": 0.25,
@@ -57,7 +57,7 @@ def test_print_backtest_summary_includes_rich_statistics(capsys) -> None:
         market_key="slug",
         count_key="book_events",
         count_label="Book Events",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
     )
 
     output = capsys.readouterr().out
@@ -81,7 +81,7 @@ def test_print_backtest_summary_includes_rich_statistics(capsys) -> None:
     assert "Events: 34" in output
     assert "Portfolio return stats" in output
     assert "Sharpe Ratio (252 days): 1.5" in output
-    assert "Portfolio PnL stats (USDC)" in output
+    assert "Portfolio PnL stats (pUSD)" in output
 
 
 def test_print_backtest_summary_aligns_count_header_with_values(capsys) -> None:
@@ -98,7 +98,7 @@ def test_print_backtest_summary_aligns_count_header_with_values(capsys) -> None:
         market_key="slug",
         count_key="book_events",
         count_label="Book Events",
-        pnl_label="PnL (USDC)",
+        pnl_label="PnL (pUSD)",
     )
 
     output = capsys.readouterr().out

--- a/tests/test_replay_adapter_architecture.py
+++ b/tests/test_replay_adapter_architecture.py
@@ -809,6 +809,50 @@ def test_trade_tick_loader_falls_through_when_telonex_onchain_fills_empty(
     assert "telonex-local::/tmp/telonex" not in output
 
 
+def test_trade_tick_loader_can_disable_polymarket_fallback_for_telonex_only_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+) -> None:
+    class FakeTelonexLoader:
+        condition_id = "0xcondition"
+        token_id = "token"
+        instrument = SimpleNamespace()
+
+        def __init__(self) -> None:
+            self.telonex_calls = 0
+            self.polymarket_calls = 0
+            self._telonex_last_trade_source = "telonex api onchain_fills"
+
+        def load_telonex_onchain_fill_ticks(self, start, end):  # type: ignore[no-untyped-def]
+            del start, end
+            self.telonex_calls += 1
+            return ()
+
+        async def load_trades(self, start, end):  # type: ignore[no-untyped-def]
+            del start, end
+            self.polymarket_calls += 1
+            return []
+
+    loader = FakeTelonexLoader()
+    monkeypatch.setenv("TELONEX_DISABLE_POLYMARKET_TRADE_FALLBACK", "1")
+    monkeypatch.setattr(replay_adapters, "_cache_home", lambda: tmp_path)
+
+    trades = asyncio.run(
+        replay_adapters._load_trade_ticks(
+            loader,
+            start=pd.Timestamp("2026-01-19T00:00:00Z"),
+            end=pd.Timestamp("2026-01-19T23:59:59Z"),
+            market_label="demo-market",
+        )
+    )
+    output = capsys.readouterr().err
+
+    assert trades == ()
+    assert loader.telonex_calls == 1
+    assert loader.polymarket_calls == 0
+    assert "telonex api onchain_fills" in output
+    assert "polymarket api" not in output
+
+
 def test_trade_progress_labels_telonex_materialized_trade_cache(tmp_path, capsys) -> None:
     cache_path = tmp_path / "onchain_fills" / "2026-01-19.1-2.parquet"
 

--- a/tests/test_strategy_configs.py
+++ b/tests/test_strategy_configs.py
@@ -74,8 +74,8 @@ def test_prediction_market_backtest_binds_strategy_configs_across_sims() -> None
                 },
             },
             {
-                "strategy_path": "strategies:PortfolioProbeStrategy",
-                "config_path": "strategies:PortfolioProbeConfig",
+                "strategy_path": "strategies:BookBinaryPairArbitrageStrategy",
+                "config_path": "strategies:BookBinaryPairArbitrageConfig",
                 "config": {"instrument_ids": "__ALL_SIM_INSTRUMENT_IDS__"},
             },
         ],


### PR DESCRIPTION
## Summary
- Pin setup/CI/docs to `nautilus_trader[polymarket,visualization]==1.226.0`.
- Port Polymarket pUSD accounting, fee calculation, and strategy config handling to Nautilus 1.226 APIs.
- Update backtest/report labels and docs from USDC to pUSD where they refer to simulated account PnL.
- Add no-backwards-compatibility agent guidance and refresh `CODEBASE_UML.md`.

## Verification
- `uv run python -c "import nautilus_trader; print(nautilus_trader.__version__)"` -> `1.226.0`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` -> `575 passed, 1 skipped`
- Notebook JSON validation for edited optimizer notebooks.

## Runner Smoke Coverage
- PMXT EMA runner: passed; warm filtered-cache hits.
- Telonex joint runner: passed; Telonex cache hits with API priority configured.
- Telonex API ledger replay: passed with `api:${TELONEX_API_KEY}` and Polymarket fallback disabled; wrote Telonex book cache.
- PMXT BTC pair arbitrage: passed.
- PMXT BTC late-favorite runner: passed with 40 sims and PMXT cache hits.
- PMXT joint runner: verified cold PMXT cache miss -> local `/Volumes/storage/pmxt_data` -> filtered-cache writes, then stopped because it is too heavy for a regular smoke sweep.

Logs are in `output/verification_logs/` in the local workspace; they are not committed.