### PR TITLE
Update docs workflow for v4.1-alpha

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
-    branches: [v4]
+    branches: [v4.1-alpha]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"
@@ -10,7 +11,7 @@ on:
       - "docs_overrides/**"
       - "mkdocs.yml"
   pull_request:
-    branches: [v4]
+    branches: [v4.1-alpha]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"


### PR DESCRIPTION
## Summary
- switch the Docs workflow push/PR branch filter from v4 to v4.1-alpha
- add workflow_dispatch so docs can be manually rerun from GitHub

## Verification
- uv run mkdocs build --strict

After this merges, the Docs workflow should run on the v4.1-alpha push and can also be rerun manually from Actions.