### PR TITLE
Fix docs workflow for v4.1-alpha

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,9 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
-    branches: [v4]
+    branches: [v4.1-alpha]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"
@@ -10,7 +11,7 @@ on:
       - "docs_overrides/**"
       - "mkdocs.yml"
   pull_request:
-    branches: [v4]
+    branches: [v4.1-alpha]
     paths:
       - ".github/workflows/docs.yml"
       - "README.md"


### PR DESCRIPTION
## Summary
- update the Docs workflow branch filters from v4 to v4.1-alpha
- add workflow_dispatch so docs can be rerun manually from GitHub Actions

## Verification
- uv run mkdocs build --strict

After this merges, a push to v4.1-alpha will run the Docs deploy job, and the workflow can also be manually dispatched.