### PR TITLE
Harden live sandbox feature wiring

### DIFF
--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
-This file is generated from Python AST metadata and excludes `tests/`.
-Generated: 2026-05-09T19:51:48+00:00
-Modules: 133 | Classes: 180 | Functions/methods: 1805
+This file is generated from Python AST metadata and excludes `tests/` plus git-ignored private strategy/research directories.
+Generated: 2026-05-11T03:41:57+00:00
+Modules: 119 | Classes: 171 | Functions/methods: 1572
 
 ## Backtesting Data Flow
 
@@ -90,235 +90,36 @@ flowchart TD
 - Imports: `__future__, decimal`
 - Function L18: `run() -> None`
 
-### `backtests/private/__init__.py`
-- Imports: none
-
-### `backtests/private/telonex_btc_5m_late_favorite_chunked_forward_validate.py`
-- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
-- Function L68: `_run_label() -> str`
-- Function L77: `_initial_cash() -> float`
-- Function L81: `_parse_utc(value: str) -> datetime`
-- Function L85: `_late_favorite_replays(windows: tuple[tuple[str, str, str], ...], *, activation_seconds_before_close: int) -> tuple[object, ...]`
-- Function L114: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
-- Function L131: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
-- Function L135: `_forward_params() -> dict[str, Any]`
-- Function L145: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
-- Function L157: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
-- Function L211: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> Any`
-- Function L232: `_worker_payload(evaluation: object) -> dict[str, Any]`
-- Function L248: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> Any`
-- Function L299: `_aggregate_rows(rows: list[dict[str, Any]], params: dict[str, object]) -> dict[str, Any]`
-- Function L344: `run() -> None`
-
-### `backtests/private/telonex_btc_5m_microprice_imbalance_chunked_forward_validate.py`
-- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
-- Function L72: `_run_label() -> str`
-- Function L81: `_initial_cash() -> float`
-- Function L85: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
-- Function L103: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
-- Function L107: `_forward_params() -> dict[str, Any]`
-- Function L117: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
-- Function L125: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
-- Function L179: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> Any`
-- Function L200: `_worker_payload(evaluation: object) -> dict[str, Any]`
-- Function L216: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> Any`
-- Function L267: `_aggregate_rows(rows: list[dict[str, Any]], params: dict[str, object]) -> dict[str, Any]`
-- Function L312: `run() -> None`
-
-### `backtests/private/telonex_btc_5m_pair_arbitrage_chunked_forward_validate.py`
-- Imports: `__future__, backtests, csv, datetime, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
-- Function L69: `_run_label() -> str`
-- Function L78: `_initial_cash() -> float`
-- Function L82: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
-- Function L86: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
-- Function L103: `_forward_params() -> dict[str, Any]`
-- Function L113: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
-- Function L125: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
-- Function L179: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
-- Function L200: `_worker_payload(evaluation: _Evaluation) -> dict[str, Any]`
-- Function L216: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
-- Function L267: `_aggregate_rows(rows: list[dict[str, Any]], params: dict[str, object]) -> dict[str, Any]`
-- Function L312: `run() -> None`
-
-### `backtests/private/telonex_btc_5m_passive_pair_accumulation_search.py`
-- Imports: `__future__, csv, dataclasses, datetime, decimal, dotenv, importlib, json, os, pathlib, random, subprocess, sys, typing, uuid`
-- Function L87: `_env_int(name: str, default: int) -> int`
-- Function L94: `_env_float(name: str, default: float) -> float`
-- Function L101: `_initial_cash() -> float`
-- Function L105: `_run_label() -> str`
-- Function L114: `_utc_iso(value: datetime) -> str`
-- Function L118: `_start_time() -> datetime`
-- Function L125: `_btc_5m_windows(*, start: datetime, count: int) -> tuple[tuple[str, str, str], ...]`
-- Function L137: `_btc_5m_replays(windows: tuple[tuple[str, str, str], ...]) -> tuple[object, ...]`
-- Function L153: `_replays_from_payload(payload: list[dict[str, Any]]) -> tuple[object, ...]`
-- Function L168: `_replays_to_payload(replays: tuple[object, ...]) -> list[dict[str, Any]]`
-- Function L181: `_candidate(**overrides) -> dict[str, Any]`
-- Function L187: `_parameter_samples(*, max_trials: int, random_seed: int) -> list[dict[str, Any]]`
-- Function L271: `_serialize_params(params: dict[str, Any]) -> dict[str, str]`
-- Function L275: `_deserialize_params(payload: dict[str, str]) -> dict[str, Any]`
-- Function L306: `_strategy_config(params: dict[str, Any]) -> dict[str, Any]`
-- Function L324: `_run_experiment(*, name: str, replays: tuple[object, ...], params: dict[str, Any]) -> list[dict[str, Any]]`
-- Function L378: `_as_float(value: object, *, default: float = 0.0) -> float`
-- Function L382: `_as_int(value: object, *, default: int = 0) -> int`
-- Function L386: `_parse_time(value: object) -> datetime | None`
-- Function L398: `_event_side(result: dict[str, Any], event: dict[str, Any]) -> str`
-- Function L405: `_rolling_cash_required(results: list[dict[str, Any]]) -> float`
-- Function L460: `_evaluate_results(*, trial_id: int, phase: str, params: dict[str, Any], results: list[dict[str, Any]], replay_count: int) -> _Evaluation`
-- Function L524: `_worker_payload(evaluation: _Evaluation) -> dict[str, Any]`
-- Function L540: `_evaluation_from_worker_payload(*, trial_id: int, phase: str, params: dict[str, Any], payload: dict[str, Any]) -> _Evaluation`
-- Function L565: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
-- Function L589: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], params: dict[str, Any]) -> _Evaluation`
-- Function L643: `_evaluation_row(evaluation: _Evaluation) -> dict[str, Any]`
-- Function L662: `_write_artifacts(evaluations: list[_Evaluation]) -> tuple[Path, Path]`
-- Function L695: `run() -> None`
-- Class L70: `_Evaluation`
-
-### `backtests/private/telonex_btc_5m_passive_pair_chunked_forward_validate.py`
-- Imports: `__future__, backtests, csv, datetime, dotenv, importlib, json, os, pathlib, typing`
-- Function L43: `_run_label() -> str`
-- Function L52: `_forward_params() -> dict[str, object]`
-- Function L62: `_aggregate_rows(rows: list[dict[str, Any]], params: dict[str, object]) -> dict[str, Any]`
-- Function L108: `run() -> None`
-
-### `backtests/private/telonex_btc_5m_passive_pair_forward_validate.py`
-- Imports: `__future__, backtests, csv, datetime, dotenv, importlib, json, os, pathlib`
-- Function L41: `_run_label() -> str`
-- Function L50: `_forward_params() -> dict[str, object]`
-- Function L60: `run() -> None`
-
-### `backtests/private/telonex_btc_5m_snapshot_model_research.py`
-- Imports: `__future__, asyncio, csv, dataclasses, datetime, dotenv, duckdb, importlib, json, math, numpy, os, pathlib, prediction_market_extensions, typing`
-- Function L133: `_env_int(name: str, default: int) -> int`
-- Function L140: `_env_float(name: str, default: float) -> float`
-- Function L147: `_run_label() -> str`
-- Function L156: `_date_strings(start_ts: int, end_ts: int) -> list[str]`
-- Function L163: `_btc_trade_paths(start_ts: int, end_ts: int) -> list[str]`
-- Function L173: `_book_snapshot_path(slug: str, outcome: str, date: str) -> Path | None`
-- Function L182: `_load_btc_features(start_ts: int, end_ts: int) -> BtcFeatureStore`
-- Function L232: `_coerce_level(level: object) -> tuple[float, float] | None`
-- Function L245: `_book_features(bids: object, asks: object, *, levels: int) -> dict[str, float] | None`
-- Function L280: `_snapshot_targets_by_date(market_start_ts: int, snapshot_seconds: tuple[int, ...]) -> dict[str, list[tuple[int, int]]]`
-- Function L291: `_query_book_snapshots(conn: duckdb.DuckDBPyConnection, path: Path, targets: list[tuple[int, int]], *, max_age_seconds: int, depth_levels: int) -> dict[int, dict[str, float]]`
-- Function L354: `_market_snapshot_features(conn: duckdb.DuckDBPyConnection, *, slug: str, outcome: str, market_start_ts: int, snapshot_seconds: tuple[int, ...], max_age_seconds: int, depth_levels: int) -> dict[int, dict[str, float]]`
-- Function L381: `async _resolved_up(slug: str) -> float | None`
-- Function L393: `_market_slug(market_start_ts: int) -> str`
-- Function L397: `async _build_dataset(*, start_ts: int, windows: int, market_starts: tuple[int, ...] | None = None, snapshot_seconds: tuple[int, ...], max_age_seconds: int, depth_levels: int) -> list[dict[str, Any]]`
-- Function L514: `_matrix(rows: list[dict[str, Any]], columns: tuple[str, ...]) -> tuple[np.ndarray, np.ndarray]`
-- Function L520: `_fit_logistic(rows: list[dict[str, Any]], *, columns: tuple[str, ...], learning_rate: float, steps: int, l2: float) -> LogisticModel`
-- Function L552: `_predict(model: LogisticModel, rows: list[dict[str, Any]]) -> np.ndarray`
-- Function L561: `_auc(y: np.ndarray, p: np.ndarray) -> float | None`
-- Function L573: `_classification_metrics(rows: list[dict[str, Any]], probs: np.ndarray) -> dict[str, float | None]`
-- Function L588: `_max_drawdown(equity_values: list[float]) -> float`
-- Function L597: `_release_due(releases: list[tuple[int, float]], cash: float, now_ts: int) -> tuple[float, list[tuple[int, float]]]`
-- Function L607: `_evaluate_policy(rows: list[dict[str, Any]], probs: np.ndarray, policy: Policy, *, quantity: float, initial_cash: float, taker_fee_rate: float, settlement_delay_seconds: int) -> dict[str, Any]`
-- Function L728: `_policy_grid(snapshot_seconds: tuple[int, ...]) -> list[Policy]`
-- Function L751: `_split_rows(rows: list[dict[str, Any]], *, train_windows: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]`
-- Function L761: `_split_rows_three(rows: list[dict[str, Any]], *, train_windows: int, validation_windows: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]`
-- Function L778: `_write_csv(path: Path, rows: list[dict[str, Any]]) -> None`
-- Function L793: `_available_cached_btc_market_starts() -> list[int]`
-- Function L804: `_write_cached_market_manifest() -> Path`
-- Function L828: `_json_default(value: object) -> object`
-- Function L838: `async _run_async() -> None`
-- Function L1035: `run() -> None`
-- Class L71: `BtcFeatureStore`
-  - Method L78: `_offset(self, ts: int) -> int`
-  - Method L81: `price_at(self, ts: int) -> float`
-  - Method L87: `momentum(self, ts: int, seconds: int) -> float`
-  - Method L94: `volume(self, ts: int, seconds: int) -> float`
-  - Method L99: `volatility(self, ts: int, seconds: int) -> float`
-- Class L114: `LogisticModel`
-- Class L123: `Policy`
-  - Method L128: `name(self) -> str`
-
-### `backtests/private/telonex_btc_5m_snapshot_model_runner_validate.py`
-- Imports: `__future__, backtests, datetime, decimal, dotenv, html, json, os, pathlib, subprocess, sys, typing, uuid`
-- Function L53: `_run_label() -> str`
-- Function L62: `_model_path() -> str`
-- Function L69: `_parse_utc(value: str) -> datetime`
-- Function L73: `_replays(windows: tuple[tuple[str, str, str], ...]) -> tuple[object, ...]`
-- Function L89: `_replays_from_payload(payload: list[dict[str, Any]]) -> tuple[object, ...]`
-- Function L104: `_replays_to_payload(replays: tuple[object, ...]) -> list[dict[str, Any]]`
-- Function L117: `_snapshot_seconds() -> tuple[int, ...]`
-- Function L125: `_strategy_config() -> dict[str, Any]`
-- Function L204: `_run_experiment(*, name: str, replays: tuple[object, ...]) -> list[dict[str, Any]]`
-- Function L252: `_evaluate_chunk(*, chunk_index: int, windows: tuple[tuple[str, str, str], ...]) -> _Evaluation`
-- Function L321: `_worker_payload(evaluation: _Evaluation, *, fill_diagnostics: list[dict[str, Any]] | None = None) -> dict[str, Any]`
-- Function L342: `_evaluation_from_payload(*, chunk_index: int, payload: dict[str, Any]) -> _Evaluation`
-- Function L415: `_evaluate_chunk_worker(*, chunk_index: int, replays: tuple[object, ...]) -> tuple[_Evaluation, list[dict[str, Any]]]`
-- Function L452: `_resolved_up_from_result(result: dict[str, Any]) -> float | None`
-- Function L464: `_enrich_fill_diagnostics(*, diagnostics_path: Path, results: list[dict[str, Any]]) -> list[dict[str, Any]]`
-- Function L510: `_run_worker() -> None`
-- Function L590: `_aggregate(chunks: list[dict[str, Any]]) -> dict[str, Any]`
-- Function L611: `_svg_line_chart(*, title: str, values: list[float], labels: list[str], width: int = 980, height: int = 320) -> str`
-- Function L668: `_html_table(rows: list[tuple[str, object]]) -> str`
-- Function L675: `_write_html_report(*, path: Path, summary: dict[str, Any], chunks: list[dict[str, Any]], fills: list[dict[str, Any]], skipped: list[dict[str, Any]]) -> None`
-- Function L792: `main() -> None`
-- Function L928: `run() -> None`
-
-### `backtests/private/telonex_btc_5m_snapshot_model_walkforward.py`
-- Imports: `__future__, backtests, collections, csv, datetime, importlib, json, math, os, pathlib, statistics, typing`
-- Function L42: `_run_label() -> str`
-- Function L51: `_latest_dataset_path() -> Path`
-- Function L71: `_parse_value(key: str, value: str) -> Any`
-- Function L84: `_read_rows(path: Path) -> list[dict[str, Any]]`
-- Function L99: `_date(value: int) -> str`
-- Function L103: `_fold_rows(rows: list[dict[str, Any]], *, indexes: list[int], start: int, train_windows: int, validation_windows: int, holdout_windows: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]`
-- Function L123: `_chunked_validation_rows(rows: list[dict[str, Any]], *, indexes: list[int], start: int, windows: int, chunk_windows: int, min_rows: int) -> list[list[dict[str, Any]]]`
-- Function L142: `_stable_policy_rows(validation_chunks: list[list[dict[str, Any]]], validation_chunk_probs: list[Any], grid: list[Any], policy_kwargs: dict[str, Any]) -> list[dict[str, Any]]`
-- Function L195: `_aggregate_selected(rows: list[dict[str, Any]]) -> dict[str, Any]`
-- Function L220: `main() -> None`
-
-### `backtests/private/telonex_general_market_value_rebound_search.py`
-- Imports: `__future__, backtests, csv, dataclasses, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
-- Function L65: `_run_label() -> str`
-- Function L74: `_initial_cash() -> float`
-- Function L78: `_candidate_payload(candidate: Candidate) -> dict[str, Any]`
-- Function L87: `_candidate_from_payload(payload: dict[str, Any]) -> Candidate`
-- Function L110: `_candidates() -> list[Candidate]`
-- Function L191: `_strategy_config(candidate: Candidate) -> dict[str, Any]`
-- Function L199: `_market_slugs() -> tuple[str, ...]`
-- Function L204: `_replays(slugs: tuple[str, ...]) -> tuple[object, ...]`
-- Function L224: `_run_experiment(*, name: str, replays: tuple[object, ...], candidate: Candidate) -> list[dict[str, Any]]`
-- Function L278: `_evaluate_trial_direct(*, trial_id: int, phase: str, replays: tuple[object, ...], candidate: Candidate) -> Any`
-- Function L304: `_worker_payload(evaluation: object) -> dict[str, Any]`
-- Function L320: `_evaluate_trial(*, trial_id: int, phase: str, replays: tuple[object, ...], candidate: Candidate) -> Any`
-- Function L375: `_write_csv(path: Path, rows: list[dict[str, Any]]) -> None`
-- Function L386: `run() -> None`
-- Class L58: `Candidate`
-
-### `backtests/private/telonex_resolved_sports_research.py`
-- Imports: `__future__, asyncio, backtests, datetime, decimal, dotenv, json, os, pathlib, prediction_market_extensions, subprocess, sys, typing, uuid`
-- Function L52: `_run_label() -> str`
-- Function L61: `_utc_iso(value: datetime) -> str`
-- Function L65: `_bool_env(name: str, default: bool) -> bool`
-- Function L72: `_candidate_strategies() -> list[dict[str, Any]]`
-- Function L123: `async _discover_markets() -> list[dict[str, Any]]`
-- Function L134: `async _build_replays() -> tuple[tuple[object, ...], list[dict[str, Any]]]`
-- Function L185: `_replays_from_payload(payload: list[dict[str, Any]]) -> tuple[object, ...]`
-- Function L200: `_replays_to_payload(replays: tuple[object, ...]) -> list[dict[str, Any]]`
-- Function L213: `_run_experiment(*, name: str, replays: tuple[object, ...], strategy_spec: dict[str, Any]) -> list[dict[str, Any]]`
-- Function L272: `_strategy_by_name(name: str) -> dict[str, Any]`
-- Function L279: `_worker_payload(evaluation: object) -> dict[str, Any]`
-- Function L295: `_evaluate_strategy_worker(*, trial_id: int, strategy_spec: dict[str, Any], replays: tuple[object, ...]) -> dict[str, Any]`
-- Function L324: `_run_worker() -> None`
-- Function L346: `_aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]`
-- Function L363: `async _run_async() -> None`
-- Function L433: `main() -> None`
-
 ### `backtests/sitecustomize.py`
 - Imports: `__future__, importlib, pathlib, sys`
 
+### `live/btc_eth_sol_snapshot_model_sandbox.py`
+- Imports: `__future__, asyncio, live, os, pathlib, sys, typing`
+- Function L30: `_configure_env_defaults() -> None`
+- Function L39: `async _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -> None`
+- Function L44: `run() -> None`
+
 ### `live/btc_snapshot_model_sandbox.py`
-- Imports: `__future__, argparse, asyncio, decimal, dotenv, nautilus_trader, os, pathlib, prediction_market_extensions, sys, typing`
-- Function L49: `_model_path() -> str`
-- Function L53: `_trade_size() -> Decimal`
-- Function L57: `_diagnostics_path() -> str | None`
-- Function L65: `_settlement_path() -> str | None`
-- Function L74: `_strategy_parameters() -> dict[str, object]`
-- Function L114: `_build_strategy_config(*, instrument_ids: tuple[InstrumentId, ...], btc_instrument_id: InstrumentId) -> ImportableStrategyConfig`
-- Function L129: `_parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace`
-- Function L182: `async _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -> None`
-- Function L250: `run() -> None`
+- Imports: `__future__, argparse, asyncio, decimal, dotenv, json, nautilus_trader, os, pathlib, prediction_market_extensions, sys, typing`
+- Function L56: `_model_path() -> str`
+- Function L60: `_trade_size() -> Decimal`
+- Function L64: `_env_float(name: str, default: float) -> float`
+- Function L68: `_env_bool(name: str, default: bool) -> bool`
+- Function L75: `_diagnostics_path() -> str | None`
+- Function L83: `_settlement_path() -> str | None`
+- Function L92: `_split_csv(raw: str | None) -> tuple[str, ...]`
+- Function L98: `_instrument_id_for_spot_prefix(prefix: str) -> InstrumentId`
+- Function L103: `_model_extra_spot_prefixes(model_path: str) -> tuple[str, ...]`
+- Function L120: `_extra_spot_instrument_ids(model_path: str) -> tuple[InstrumentId, ...]`
+- Function L129: `_strategy_parameters() -> dict[str, object]`
+- Function L189: `_build_strategy_config(*, instrument_ids: tuple[InstrumentId, ...], btc_instrument_id: InstrumentId, extra_spot_instrument_ids: tuple[InstrumentId, ...] = ()) -> ImportableStrategyConfig`
+- Function L208: `_parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace`
+- Function L281: `_resolve_btc_data_source(args: argparse.Namespace) -> str`
+- Function L287: `_default_btc_instrument_id(btc_data_source: str) -> InstrumentId`
+- Function L291: `_btc_data_source_label(btc_data_source: str) -> str`
+- Function L297: `_policy_label(config: dict[str, object]) -> str`
+- Function L311: `async _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -> None`
+- Function L406: `run() -> None`
 
 ### `main.py`
 - Imports: `__future__, argparse, ast, asyncio, functools, importlib, inspect, json, os, pathlib, re, string, subprocess, sys, time, typing`
@@ -1746,24 +1547,30 @@ flowchart TD
 - Imports: none
 
 ### `prediction_market_extensions/live/btc_5m.py`
-- Imports: `__future__, datetime, nautilus_trader, os, time, typing`
-- Function L19: `floor_to_btc_5m_start(timestamp: int | None = None) -> int`
-- Function L24: `btc_5m_market_slug(market_start_ts: int) -> str`
-- Function L28: `upcoming_btc_5m_event_slugs(*, market_count: int = DEFAULT_MARKET_COUNT, include_current: bool = True, timestamp: int | None = None) -> list[str]`
-- Function L40: `configured_btc_5m_event_slugs() -> list[str]`
-- Function L56: `upcoming_btc_5m_window_label(*, timestamp: int | None = None) -> str`
-- Function L64: `async load_btc_5m_instrument_ids(*, market_count: int = DEFAULT_MARKET_COUNT, include_current: bool = True, event_slugs: Sequence[str] | None = None, http_client: HttpClient | None = None) -> tuple[InstrumentId, ...]`
+- Imports: `__future__, datetime, logging, nautilus_trader, os, time, typing`
+- Function L21: `floor_to_btc_5m_start(timestamp: int | None = None) -> int`
+- Function L26: `btc_5m_market_slug(market_start_ts: int) -> str`
+- Function L30: `upcoming_btc_5m_event_slugs(*, market_count: int = DEFAULT_MARKET_COUNT, include_current: bool = True, timestamp: int | None = None) -> list[str]`
+- Function L42: `configured_btc_5m_event_slugs() -> list[str]`
+- Function L58: `upcoming_btc_5m_window_label(*, timestamp: int | None = None) -> str`
+- Function L66: `async load_btc_5m_instrument_ids(*, market_count: int = DEFAULT_MARKET_COUNT, include_current: bool = True, event_slugs: Sequence[str] | None = None, http_client: HttpClient | None = None, min_loaded_markets: int = 1) -> tuple[InstrumentId, ...]`
 
 ### `prediction_market_extensions/live/btc_features.py`
 - Imports: `__future__, bisect, math`
 - Class L9: `LiveBtcFeatureStore`
-  - Method L12: `__init__(self, *, buffer_seconds: int) -> None`
-  - Method L18: `record_trade(self, *, ts_ns: int, price: float, size: float) -> None`
-  - Method L32: `_prune(self, *, current_second: int) -> None`
-  - Method L43: `price_at(self, ts: int) -> float`
-  - Method L51: `momentum(self, ts: int, seconds: int) -> float`
-  - Method L58: `volume(self, ts: int, seconds: int) -> float`
-  - Method L69: `volatility(self, ts: int, seconds: int) -> float`
+  - Method L12: `__init__(self, *, buffer_seconds: int, book_prefix: str = 'btc') -> None`
+  - Method L21: `record_trade(self, *, ts_ns: int, price: float, size: float) -> None`
+  - Method L35: `record_book(self, *, ts_ns: int, mid: float, spread: float, bid_size: float, ask_size: float, bid_depth: float, ask_depth: float, book_imbalance: float, microprice: float) -> None`
+  - Method L85: `_prune(self, *, current_second: int) -> None`
+  - Method L102: `price_at(self, ts: int) -> float`
+  - Method L110: `observation_second_at(self, ts: int) -> int | None`
+  - Method L118: `observation_age_seconds(self, ts: int) -> float`
+  - Method L124: `book_observation_second_at(self, ts: int) -> int | None`
+  - Method L132: `book_observation_age_seconds(self, ts: int) -> float`
+  - Method L138: `book_features_at(self, ts: int) -> dict[str, float] | None`
+  - Method L150: `momentum(self, ts: int, seconds: int) -> float`
+  - Method L157: `volume(self, ts: int, seconds: int) -> float`
+  - Method L168: `volatility(self, ts: int, seconds: int) -> float`
 
 ### `prediction_market_extensions/live/sandbox.py`
 - Imports: `__future__, asyncio, datetime, decimal, nautilus_trader, py_clob_client_v2, traceback, typing`
@@ -1771,8 +1578,8 @@ flowchart TD
 - Function L59: `_parse_iso8601_ns(value: object) -> int | None`
 - Function L74: `_tick_size_change_ts_ns(ws_message: PolymarketTickSizeChange) -> int | None`
 - Function L81: `is_post_expiry_tick_size_change(instrument: BinaryOption, ws_message: PolymarketTickSizeChange) -> bool`
-- Function L327: `build_polymarket_binance_sandbox_config(*, strategies: Sequence[ImportableStrategyConfig], event_slug_builder: str, binance_instrument_ids: frozenset[InstrumentId] | None = None, starting_balance: Decimal | str = Decimal('20'), trader_id: str = 'SANDBOX-001', log_level: str = 'INFO', polymarket_update_interval_mins: int | None = None, risk_submit_rate: str = '20/00:00:01') -> TradingNodeConfig`
-- Function L381: `build_polymarket_binance_sandbox_node(*, config: TradingNodeConfig) -> TradingNode`
+- Function L327: `build_polymarket_binance_sandbox_config(*, strategies: Sequence[ImportableStrategyConfig], event_slug_builder: str, binance_instrument_ids: frozenset[InstrumentId] | None = None, btc_instrument_ids: frozenset[InstrumentId] | None = None, starting_balance: Decimal | str = Decimal('20'), trader_id: str = 'SANDBOX-001', log_level: str = 'INFO', polymarket_update_interval_mins: int | None = None, binance_us: bool = True, risk_submit_rate: str = '20/00:00:01') -> TradingNodeConfig`
+- Function L384: `build_polymarket_binance_sandbox_node(*, config: TradingNodeConfig) -> TradingNode`
 - Class L96: `PublicPolymarketInstrumentProvider(PolymarketInstrumentProvider)`
   - Method L99: `async _load_from_event_slugs(self) -> None`
   - Method L141: `_prune_loaded_event_slug_instruments(self, event_slugs: Sequence[str]) -> int`
@@ -1969,19 +1776,19 @@ flowchart TD
 
 ### `scripts/generate_codebase_uml.py`
 - Imports: `__future__, ast, dataclasses, datetime, pathlib`
-- Function L47: `_is_included_python_file(path: Path) -> bool`
-- Function L54: `_unparse(node: ast.AST | None) -> str`
-- Function L63: `_format_arg(arg: ast.arg, default: ast.AST | None = None) -> str`
-- Function L71: `_callable_info(node: ast.FunctionDef | ast.AsyncFunctionDef) -> CallableInfo`
-- Function L97: `_imports(tree: ast.Module) -> list[str]`
-- Function L107: `_module_info(path: Path) -> ModuleInfo`
-- Function L132: `_mermaid_overview() -> str`
-- Function L148: `_render_module(module: ModuleInfo) -> list[str]`
-- Function L169: `build_document() -> str`
-- Function L199: `main() -> int`
-- Class L23: `CallableInfo`
-- Class L32: `ClassInfo`
-- Class L40: `ModuleInfo`
+- Function L51: `_is_included_python_file(path: Path) -> bool`
+- Function L60: `_unparse(node: ast.AST | None) -> str`
+- Function L69: `_format_arg(arg: ast.arg, default: ast.AST | None = None) -> str`
+- Function L77: `_callable_info(node: ast.FunctionDef | ast.AsyncFunctionDef) -> CallableInfo`
+- Function L103: `_imports(tree: ast.Module) -> list[str]`
+- Function L113: `_module_info(path: Path) -> ModuleInfo`
+- Function L138: `_mermaid_overview() -> str`
+- Function L154: `_render_module(module: ModuleInfo) -> list[str]`
+- Function L175: `build_document() -> str`
+- Function L206: `main() -> int`
+- Class L27: `CallableInfo`
+- Class L36: `ClassInfo`
+- Class L44: `ModuleInfo`
 
 ### `scripts/pmxt_download_raws.py`
 - Imports: `__future__, argparse, json, pathlib, scripts`
@@ -2260,97 +2067,6 @@ flowchart TD
 - Class L170: `BookPanicFadeStrategy(_PanicFadeBase)`
   - Method L171: `_subscribe(self) -> None`
   - Method L177: `on_order_book(self, order_book) -> None`
-
-### `strategies/private/__init__.py`
-- Imports: none
-
-### `strategies/private/btc_snapshot_model.py`
-- Imports: `__future__, backtests, decimal, json, math, nautilus_trader, pathlib, prediction_market_extensions, strategies, typing`
-- Function L159: `_as_float(value: object | None) -> float | None`
-- Function L173: `_decimal_or_none(value: object | None) -> Decimal | None`
-- Function L182: `_is_buy_order_side(value: object) -> bool`
-- Function L196: `_load_model(path: str) -> LogisticModel`
-- Function L208: `_market_start_from_slug(slug: str) -> int | None`
-- Function L215: `_market_prune_due_ns(*, market_start: int, post_end_retention_seconds: float) -> int`
-- Function L220: `_log_float(value: object, *, digits: int = 4) -> str`
-- Function L227: `_book_features(order_book: OrderBook, *, levels: int) -> dict[str, float] | None`
-- Class L49: `BookBtcSnapshotModelConfig(StrategyConfig)`
-  - Method L88: `__post_init__(self) -> None`
-- Class L265: `BookBtcSnapshotModelStrategy(Strategy)`
-  - Method L271: `__init__(self, config: BookBtcSnapshotModelConfig) -> None`
-  - Method L295: `_diagnostics_enabled(self) -> bool`
-  - Method L298: `_record_evaluation(self, payload: dict[str, Any]) -> None`
-  - Method L306: `_log_evaluation_event(self, payload: dict[str, Any]) -> None`
-  - Method L355: `_maybe_log_heartbeat(self, *, now_ns: int, btc_price: float | None) -> None`
-  - Method L383: `_mark_evaluated(self, slug: str, buckets: list[int]) -> None`
-  - Method L387: `_register_btc_5m_instrument(self, *, instrument_id: InstrumentId, instrument: object, strict: bool) -> bool`
-  - Method L427: `_subscribe_book_if_needed(self, instrument_id: InstrumentId) -> None`
-  - Method L433: `_scan_cached_btc_5m_instruments(self) -> int`
-  - Method L456: `_maybe_scan_cached_btc_5m_instruments(self, *, now_ns: int) -> None`
-  - Method L471: `_slug_has_unsettled_position(self, slug: str) -> bool`
-  - Method L477: `_prune_expired_markets(self, *, now_ns: int) -> None`
-  - Method L505: `_prune_market(self, slug: str) -> int`
-  - Method L530: `on_start(self) -> None`
-  - Method L562: `on_instrument(self, instrument) -> None`
-  - Method L581: `on_trade_tick(self, tick) -> None`
-  - Method L602: `on_order_book_deltas(self, deltas) -> None`
-  - Method L615: `_evaluate_market(self, *, slug: str, now_ns: int) -> None`
-  - Method L820: `_row(self, *, slug: str, market_start: int, snapshot_ts: int, bucket: int, up: dict[str, float], down: dict[str, float], up_age_seconds: float, down_age_seconds: float) -> dict[str, Any] | None`
-  - Method L880: `_passes_momentum_alignment(self, *, row: dict[str, Any], selected_outcome: str) -> bool`
-  - Method L910: `_passes_quality_gates(self, *, row: dict[str, Any], selected_outcome: str, ask: float, selected_probability: float) -> bool`
-  - Method L944: `_passes_context_quality_gates(self, *, row: dict[str, Any], selected_outcome: str, selected_probability: float) -> bool`
-  - Method L986: `_free_quote_balance(self, instrument_id: InstrumentId) -> Decimal | None`
-  - Method L998: `_rounded_entry_quantity(self, *, instrument_id: InstrumentId, ask: float, ask_size: float) -> object | None`
-  - Method L1024: `_expected_entry_price(self, *, instrument_id: InstrumentId, quantity: object) -> float | None`
-  - Method L1035: `_submit_model_entry(self, *, slug: str, instrument_id: InstrumentId, ask: float, ask_size: float, edge: float, prob_up: float, selected_outcome: str, selected_probability: float, row: dict[str, Any]) -> None`
-  - Method L1215: `on_order_filled(self, event) -> None`
-  - Method L1236: `_record_settlement_position(self, *, event, diagnostic: dict[str, Any]) -> None`
-  - Method L1286: `_maybe_poll_settlements(self, *, now_ns: int) -> None`
-  - Method L1313: `_try_settle_position(self, *, position: dict[str, Any], now_ns: int) -> bool`
-  - Method L1353: `_settlement_cash_balance(self) -> Decimal`
-  - Method L1368: `_settled_payout_value(self) -> Decimal`
-  - Method L1375: `_position_mark_value(self, position: dict[str, Any]) -> Decimal`
-  - Method L1400: `_open_mark_value(self) -> Decimal`
-  - Method L1407: `_portfolio_value_snapshot(self) -> dict[str, Decimal | int]`
-  - Method L1428: `_log_portfolio_value(self, *, reason: str, now_ns: int) -> None`
-  - Method L1441: `_write_settlement_ledger(self) -> None`
-  - Method L1460: `on_stop(self) -> None`
-  - Method L1474: `on_reset(self) -> None`
-
-### `strategies/private/passive_pair_accumulation.py`
-- Imports: `__future__, decimal, nautilus_trader, prediction_market_extensions, strategies`
-- Class L31: `BookPassivePairAccumulationConfig(StrategyConfig)`
-  - Method L65: `__post_init__(self) -> None`
-- Class L101: `BookPassivePairAccumulationStrategy(BookBinaryPairArbitrageStrategy)`
-  - Method L109: `__init__(self, config: BookPassivePairAccumulationConfig) -> None`
-  - Method L121: `on_start(self) -> None`
-  - Method L155: `on_order_book_deltas(self, deltas) -> None`
-  - Method L171: `_instrument_fee_rate(self, instrument_id: InstrumentId) -> Decimal`
-  - Method L180: `_position_size(self, instrument_id: InstrumentId) -> Decimal`
-  - Method L192: `_price_increment(self, instrument_id: InstrumentId) -> float`
-  - Method L199: `_depth_sum(self, levels: list[object]) -> float`
-  - Method L207: `_best_bid_state(self, instrument_id: InstrumentId) -> tuple[float, float, float, float, float]`
-  - Method L221: `_passive_price(self, instrument_id: InstrumentId, *, bid: float, ask: float) -> float | None`
-  - Method L231: `_active_pair_orders(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
-  - Method L234: `_pair_positions(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[Decimal, Decimal]`
-  - Method L240: `_matched_position_size(self, pair: tuple[InstrumentId, InstrumentId]) -> Decimal`
-  - Method L244: `_has_pair_position(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
-  - Method L248: `_surplus_position_sizes(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[Decimal, Decimal]`
-  - Method L256: `_target_reached(self, pair: tuple[InstrumentId, InstrumentId]) -> bool`
-  - Method L264: `_entry_state(self, pair: tuple[InstrumentId, InstrumentId]) -> tuple[list[float], list[object], float, float, Decimal] | None`
-  - Method L338: `_evaluate_pair(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
-  - Method L388: `_submit_pair_entry(self, *, pair: tuple[InstrumentId, InstrumentId], prices: list[float], quantities: list[object], visible_size: float, edge: float, target_size: Decimal) -> None`
-  - Method L433: `_cancel_pair_orders(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
-  - Method L442: `_submit_surplus_exit(self, pair: tuple[InstrumentId, InstrumentId]) -> None`
-  - Method L469: `_mark_order_closed(self, event) -> None`
-  - Method L483: `_cancel_pair_after_entry_leg_failure(self, event) -> None`
-  - Method L513: `on_order_filled(self, event) -> None`
-  - Method L520: `on_order_rejected(self, event) -> None`
-  - Method L527: `on_order_denied(self, event) -> None`
-  - Method L530: `on_order_canceled(self, event) -> None`
-  - Method L533: `on_order_expired(self, event) -> None`
-  - Method L536: `on_stop(self) -> None`
-  - Method L542: `on_reset(self) -> None`
 
 ### `strategies/rsi_reversion.py`
 - Imports: `__future__, decimal, nautilus_trader, strategies, typing`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Python](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)
 ![Rust](https://img.shields.io/badge/rust-1.93.1-CE422B?logo=rust&logoColor=white)
 ![Rust Edition](https://img.shields.io/badge/edition-2024-CE422B?logo=rust&logoColor=white)
-![NautilusTrader](https://img.shields.io/badge/NautilusTrader-1.225.0-1E3A5F)
+![NautilusTrader](https://img.shields.io/badge/NautilusTrader-1.226.0-1E3A5F)
 ![GitHub last commit](https://img.shields.io/github/last-commit/evan-kolberg/prediction-market-backtesting)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/evan-kolberg/prediction-market-backtesting)
 ![GitHub code size](https://img.shields.io/github/languages/code-size/evan-kolberg/prediction-market-backtesting)
@@ -40,7 +40,7 @@
 - Book replay order book deltas with trade ticks
 
 **New in Version 2:**
-- Nautilus 1.225.0, via PyPI in lieu of a subtree
+- Nautilus via PyPI in lieu of a subtree
 - Better backtest runner classes via EXPERIMENT objects
 - IPython notebook support (.ipynb files)
 - Joint portfolio multi replay runners

--- a/docs/live.md
+++ b/docs/live.md
@@ -61,13 +61,15 @@ Reusable helper code belongs in `prediction_market_extensions/live/`.
 Current helper responsibilities include:
 
 - Polymarket BTC 5m slug and instrument loading
-- Binance BTC trade instrument defaults
+- external BTC trade instrument defaults
 - Nautilus sandbox node config construction
 - sandbox execution client factory registration
 - live BTC trade feature buffering for strategies that need recent BTC
   momentum, volume, or volatility features
 - public Polymarket CLOB settlement polling for sandbox portfolio accounting
 - rolling BTC 5m market discovery and pruning
+- BTC trade-feed freshness checks so live strategies can fail closed when the
+  external reference-price feed is stale
 
 These helpers must remain parameter-free. They can accept strategy configs and
 runtime options from a local runner, but they should not embed private
@@ -88,9 +90,9 @@ The public-safe path is:
    Polymarket event-slug horizon, loads the initial UP/DOWN instrument IDs, and
    exposes an importable slug builder for provider refreshes.
 5. `prediction_market_extensions/live/sandbox.py` builds the Nautilus sandbox
-   node with public Polymarket market data, Binance US BTC trades, and Nautilus
-   sandbox execution.
-6. Strategy code receives live order-book deltas and Binance BTC trade ticks
+   node with public Polymarket market data, an external BTC trade feed, and
+   Nautilus sandbox execution.
+6. Strategy code receives live order-book deltas and external BTC trade ticks
    through Nautilus, then emits sandbox orders through Nautilus risk/execution.
 
 The BTC 5m hooks are rolling, not fixed. On each Polymarket instrument refresh,
@@ -119,6 +121,13 @@ model evaluation points. This makes it clear whether the node is merely
 connected, actively receiving BTC ticks, and actually evaluating the current 5m
 market.
 
+Strategies should also guard against stale reference data. A connected reference
+websocket is not enough proof that BTC features are fresh; the runner can pass a
+maximum BTC feature age so private strategy code skips entries when recent BTC
+trade ticks are missing. The example runner defaults this to 30 seconds, which
+keeps the guard meaningful while avoiding false blocks from normal public-feed
+cadence.
+
 ## Example BTC Snapshot Runner
 
 `live/btc_snapshot_model_sandbox.py` is an example of how a local live runner
@@ -129,8 +138,9 @@ complete public trading package:
 - it sets environment values used by the importable BTC 5m slug builder;
 - it resolves the private model path from `LIVE_BTC_SNAPSHOT_MODEL_PATH` or a
   default under `live/models/`;
-- it builds a strategy config that injects instrument IDs, the Binance BTC
-  trade instrument, local runtime options, and the private model path;
+- it builds a strategy config that injects instrument IDs, the external BTC
+  trade instrument, optional extra spot feature instruments, local runtime
+  options, and the private model path;
 - it calls `build_polymarket_binance_sandbox_config()` and
   `build_polymarket_binance_sandbox_node()`;
 - it supports dry-run/build-only validation and a `--run` path for starting the
@@ -140,6 +150,35 @@ By default, the example runner sets `heartbeat_log_seconds` from
 `LIVE_BTC_HEARTBEAT_LOG_SECONDS`, defaulting to five minutes. Set that
 environment variable lower while debugging startup, or higher if a production
 sandbox log is too chatty.
+
+The example runner also exposes operational switches for the live data path:
+
+- `LIVE_BTC_MAX_FEATURE_AGE_SECONDS` controls how stale BTC trade-derived
+  features may be before the private strategy should skip an entry; the default
+  is 30 seconds.
+- `LIVE_BTC_DAILY_STOP_LOSS` passes a sandbox daily loss limit into strategies
+  that support one.
+- `LIVE_BTC_DATA_SOURCE` or `--btc-data-source` selects the Binance BTC feed.
+  Supported values are `binance-us` and `binance-global`; the example runner
+  defaults to `binance-global` so live BTC features match the Telonex Binance
+  data used for the private model.
+- `LIVE_BTC_BINANCE_GLOBAL=1` or `--binance-global` remains as a compatibility
+  alias for `--btc-data-source binance-global`.
+- `LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS` or `--extra-spot-instrument-ids` can
+  provide comma-separated Binance spot instruments such as
+  `ETHUSDT.BINANCE,SOLUSDT.BINANCE`. If unset, the runner inspects the private
+  model columns and auto-subscribes matching spot instruments for prefixes such
+  as `eth_` and `sol_`.
+
+`live/btc_eth_sol_snapshot_model_sandbox.py` is a local convenience wrapper for
+the current private BTC 5m ETH/SOL profile. It points the base runner at the
+ignored ETH/SOL model artifact, sets `LIVE_BTC_SNAPSHOT_EDGE=0.08`, and
+subscribes `ETHUSDT.BINANCE` and `SOLUSDT.BINANCE` alongside BTC. Run it
+directly the same way as the generic runner:
+
+```bash
+uv run python live/btc_eth_sol_snapshot_model_sandbox.py --run
+```
 
 That runner is useful as a public example of the sandbox wiring. It references
 private strategy and model paths to show where local artifacts plug in, but
@@ -153,7 +192,7 @@ Do not open-source the private strategy or model artifacts.
 
 The BTC snapshot model depends on private research code and private Telonex
 backtesting data. The public repository can show how Nautilus sandbox plumbing,
-Polymarket BTC 5m market discovery, Binance BTC trade features, heartbeat and
+Polymarket BTC 5m market discovery, external BTC trade features, heartbeat and
 evaluation logging, settlement polling, and local runner injection fit together.
 It should not include:
 

--- a/live/btc_eth_sol_snapshot_model_sandbox.py
+++ b/live/btc_eth_sol_snapshot_model_sandbox.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+if __package__ in {None, ""}:
+    import importlib.util
+
+    helper_path = Path(__file__).resolve().parents[1] / "backtests" / "_script_helpers.py"
+    spec = importlib.util.spec_from_file_location("_script_helpers", helper_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script helper from {helper_path}")
+    helpers = importlib.util.module_from_spec(spec)
+    sys.modules["_script_helpers"] = helpers
+    spec.loader.exec_module(helpers)
+    helpers.ensure_repo_root(__file__)
+
+from live import btc_snapshot_model_sandbox
+
+DEFAULT_ETH_SOL_MODEL_PATH = (
+    "live/models/btc_snapshot_model_s223_btc_eth_sol_l2_full_feb12_may9.json"
+)
+DEFAULT_ETH_SOL_EDGE = "0.08"
+DEFAULT_ETH_SOL_EXTRA_SPOT_INSTRUMENT_IDS = "ETHUSDT.BINANCE,SOLUSDT.BINANCE"
+
+
+def _configure_env_defaults() -> None:
+    os.environ.setdefault("LIVE_BTC_SNAPSHOT_MODEL_PATH", DEFAULT_ETH_SOL_MODEL_PATH)
+    os.environ.setdefault("LIVE_BTC_SNAPSHOT_EDGE", DEFAULT_ETH_SOL_EDGE)
+    os.environ.setdefault(
+        "LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS",
+        DEFAULT_ETH_SOL_EXTRA_SPOT_INSTRUMENT_IDS,
+    )
+
+
+async def _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -> None:
+    _configure_env_defaults()
+    await btc_snapshot_model_sandbox._main(argv, force_run=force_run)
+
+
+def run() -> None:
+    asyncio.run(_main((), force_run=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main(sys.argv[1:]))

--- a/live/btc_snapshot_model_sandbox.py
+++ b/live/btc_snapshot_model_sandbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import sys
 from decimal import Decimal
@@ -41,9 +42,15 @@ from prediction_market_extensions.live.sandbox import (
 )
 
 EVENT_SLUG_BUILDER = "prediction_market_extensions.live.btc_5m:configured_btc_5m_event_slugs"
-DEFAULT_MODEL_PATH = "live/models/btc_snapshot_model_s199_cost101_daily_stop120_profile.json"
+DEFAULT_MODEL_PATH = "live/models/btc_snapshot_model_s204_btc_l2_full_mar1_may9.json"
 STRATEGY_PATH = "strategies.private.btc_snapshot_model:BookBtcSnapshotModelStrategy"
 CONFIG_PATH = "strategies.private.btc_snapshot_model:BookBtcSnapshotModelConfig"
+BTC_DATA_SOURCE_BINANCE_GLOBAL = "binance-global"
+BTC_DATA_SOURCE_BINANCE_US = "binance-us"
+BTC_DATA_SOURCE_CHOICES = (
+    BTC_DATA_SOURCE_BINANCE_GLOBAL,
+    BTC_DATA_SOURCE_BINANCE_US,
+)
 
 
 def _model_path() -> str:
@@ -52,6 +59,17 @@ def _model_path() -> str:
 
 def _trade_size() -> Decimal:
     return Decimal(os.getenv("LIVE_BTC_SNAPSHOT_TRADE_SIZE", "2"))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.getenv(name, str(default)))
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _diagnostics_path() -> str | None:
@@ -71,35 +89,92 @@ def _settlement_path() -> str | None:
     return path or None
 
 
+def _split_csv(raw: str | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _instrument_id_for_spot_prefix(prefix: str) -> InstrumentId:
+    symbol = f"{prefix.strip().upper()}USDT"
+    return InstrumentId.from_str(f"{symbol}.BINANCE")
+
+
+def _model_extra_spot_prefixes(model_path: str) -> tuple[str, ...]:
+    path = Path(model_path)
+    if not path.exists():
+        return ()
+    payload = json.loads(path.read_text())
+    columns = tuple(str(column) for column in payload.get("model", {}).get("columns", ()))
+    prefixes: list[str] = []
+    suffix = "_return_since_start"
+    for column in columns:
+        if not column.endswith(suffix):
+            continue
+        prefix = column[: -len(suffix)]
+        if prefix and prefix != "btc" and prefix not in prefixes:
+            prefixes.append(prefix)
+    return tuple(prefixes)
+
+
+def _extra_spot_instrument_ids(model_path: str) -> tuple[InstrumentId, ...]:
+    raw = os.getenv("LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS")
+    if raw is not None:
+        return tuple(InstrumentId.from_str(value) for value in _split_csv(raw))
+    return tuple(
+        _instrument_id_for_spot_prefix(prefix) for prefix in _model_extra_spot_prefixes(model_path)
+    )
+
+
 def _strategy_parameters() -> dict[str, object]:
     return {
         "model_path": _model_path(),
         "trade_size": _trade_size(),
-        "edge": 0.06,
+        "edge": _env_float("LIVE_BTC_SNAPSHOT_EDGE", 0.12),
         "snapshot_seconds": (60,),
-        "min_ask_price": 0.10,
-        "max_ask_price": 0.75,
-        "max_spread": 0.20,
+        "min_ask_price": _env_float("LIVE_BTC_MIN_ASK_PRICE", 0.0),
+        "max_ask_price": _env_float("LIVE_BTC_MAX_ASK_PRICE", 0.75),
+        "max_spread": _env_float("LIVE_BTC_MAX_SPREAD", 0.20),
         "max_book_age_seconds": 8.0,
         "depth_levels": 5,
         "max_expected_slippage": 0.02,
-        "min_visible_size": 1.0,
-        "min_selected_probability": 0.65,
-        "expensive_ask_floor": 0.70,
-        "expensive_min_selected_probability": 0.80,
-        "expensive_min_signed_momentum_30s": 0.0,
-        "adverse_price_diff_floor": 5.0,
-        "adverse_min_signed_momentum_30s": 2.0,
-        "exhausted_price_diff_floor": 30.0,
-        "exhausted_min_selected_probability": 0.80,
-        "volatile_price_diff_floor": 2.5,
-        "volatile_min_selected_probability": 0.72,
-        "max_yes_no_ask_cost": 1.01,
+        "min_visible_size": _env_float("LIVE_BTC_MIN_VISIBLE_SIZE", 1.0),
+        "min_selected_probability": _env_float("LIVE_BTC_MIN_SELECTED_PROBABILITY", 0.0),
+        "expensive_ask_floor": _env_float("LIVE_BTC_EXPENSIVE_ASK_FLOOR", 1.0),
+        "expensive_min_selected_probability": _env_float(
+            "LIVE_BTC_EXPENSIVE_MIN_SELECTED_PROBABILITY",
+            0.0,
+        ),
+        "expensive_min_signed_momentum_30s": _env_float(
+            "LIVE_BTC_EXPENSIVE_MIN_SIGNED_MOMENTUM_30S",
+            0.0,
+        ),
+        "adverse_price_diff_floor": _env_float("LIVE_BTC_ADVERSE_PRICE_DIFF_FLOOR", 0.0),
+        "adverse_min_signed_momentum_30s": _env_float(
+            "LIVE_BTC_ADVERSE_MIN_SIGNED_MOMENTUM_30S",
+            0.0,
+        ),
+        "exhausted_price_diff_floor": _env_float("LIVE_BTC_EXHAUSTED_PRICE_DIFF_FLOOR", 0.0),
+        "exhausted_min_selected_probability": _env_float(
+            "LIVE_BTC_EXHAUSTED_MIN_SELECTED_PROBABILITY",
+            0.0,
+        ),
+        "volatile_price_diff_floor": _env_float("LIVE_BTC_VOLATILE_PRICE_DIFF_FLOOR", 0.0),
+        "volatile_min_selected_probability": _env_float(
+            "LIVE_BTC_VOLATILE_MIN_SELECTED_PROBABILITY",
+            0.0,
+        ),
+        "max_yes_no_ask_cost": _env_float("LIVE_BTC_MAX_YES_NO_ASK_COST", 0.0),
         "diagnostics_path": _diagnostics_path(),
-        "momentum_alignment": "m15_m30",
+        "momentum_alignment": os.getenv(
+            "LIVE_BTC_SNAPSHOT_MOMENTUM_ALIGNMENT",
+            "none",
+        ),
         "live_btc_buffer_seconds": 900,
+        "max_btc_feature_age_seconds": _env_float("LIVE_BTC_MAX_FEATURE_AGE_SECONDS", 30.0),
         "market_buy_quote_quantity": True,
         "min_market_buy_quote_amount": Decimal("1"),
+        "daily_stop_loss": _env_float("LIVE_BTC_DAILY_STOP_LOSS", 1.2),
         "settlement_path": _settlement_path(),
         "settlement_poll_seconds": float(os.getenv("LIVE_BTC_SETTLEMENT_POLL_SECONDS", "10")),
         "settlement_grace_seconds": float(os.getenv("LIVE_BTC_SETTLEMENT_GRACE_SECONDS", "5")),
@@ -115,10 +190,14 @@ def _build_strategy_config(
     *,
     instrument_ids: tuple[InstrumentId, ...],
     btc_instrument_id: InstrumentId,
+    extra_spot_instrument_ids: tuple[InstrumentId, ...] = (),
 ) -> ImportableStrategyConfig:
     config = _strategy_parameters()
     config["instrument_ids"] = [str(instrument_id) for instrument_id in instrument_ids]
     config["btc_instrument_id"] = str(btc_instrument_id)
+    config["extra_spot_instrument_ids"] = [
+        str(instrument_id) for instrument_id in extra_spot_instrument_ids
+    ]
     return ImportableStrategyConfig(
         strategy_path=STRATEGY_PATH,
         config_path=CONFIG_PATH,
@@ -157,8 +236,22 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--btc-instrument-id",
-        default=os.getenv("LIVE_BTC_INSTRUMENT_ID", str(DEFAULT_BTC_INSTRUMENT_ID)),
+        default=os.getenv("LIVE_BTC_INSTRUMENT_ID"),
         help="External BTC trade instrument ID.",
+    )
+    parser.add_argument(
+        "--btc-data-source",
+        choices=BTC_DATA_SOURCE_CHOICES,
+        default=os.getenv("LIVE_BTC_DATA_SOURCE", BTC_DATA_SOURCE_BINANCE_GLOBAL),
+        help="External BTC trade feed used for live features.",
+    )
+    parser.add_argument(
+        "--extra-spot-instrument-ids",
+        default=os.getenv("LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS"),
+        help=(
+            "Comma-separated extra Binance spot instruments for model features. "
+            "Defaults to auto-detecting ETH/SOL/XRP-style prefixes from the model columns."
+        ),
     )
     parser.add_argument(
         "--trader-id",
@@ -176,7 +269,43 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=int(os.getenv("LIVE_POLYMARKET_REFRESH_MINS", "5")),
         help="Minutes between Polymarket instrument refreshes; <=0 disables refresh.",
     )
+    parser.add_argument(
+        "--binance-global",
+        action="store_true",
+        default=_env_bool("LIVE_BTC_BINANCE_GLOBAL", False),
+        help="Deprecated alias for --btc-data-source binance-global.",
+    )
     return parser.parse_args(argv)
+
+
+def _resolve_btc_data_source(args: argparse.Namespace) -> str:
+    if args.binance_global:
+        return BTC_DATA_SOURCE_BINANCE_GLOBAL
+    return str(args.btc_data_source).lower().replace("_", "-")
+
+
+def _default_btc_instrument_id(btc_data_source: str) -> InstrumentId:
+    return DEFAULT_BTC_INSTRUMENT_ID
+
+
+def _btc_data_source_label(btc_data_source: str) -> str:
+    if btc_data_source == BTC_DATA_SOURCE_BINANCE_GLOBAL:
+        return "Binance global"
+    return "Binance US"
+
+
+def _policy_label(config: dict[str, object]) -> str:
+    snapshot_seconds = tuple(config.get("snapshot_seconds", ()))
+    if len(snapshot_seconds) == 1:
+        snapshot_label = f"{snapshot_seconds[0]}s snapshot"
+    elif snapshot_seconds:
+        snapshot_label = f"{','.join(str(value) for value in snapshot_seconds)}s snapshots"
+    else:
+        snapshot_label = "configured snapshots"
+    return (
+        f"Policy: model profile, {snapshot_label}, "
+        f"edge>={config['edge']}, max ask<={config['max_ask_price']}"
+    )
 
 
 async def _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -> None:
@@ -188,7 +317,21 @@ async def _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -
     model_exists = Path(model_path).exists()
     if (args.run or args.build_only) and not model_exists:
         raise FileNotFoundError(model_path)
-    btc_instrument_id = InstrumentId.from_str(args.btc_instrument_id)
+    btc_data_source = _resolve_btc_data_source(args)
+    btc_instrument_id = InstrumentId.from_str(
+        args.btc_instrument_id or str(_default_btc_instrument_id(btc_data_source)),
+    )
+    if args.extra_spot_instrument_ids:
+        extra_spot_instrument_ids = tuple(
+            InstrumentId.from_str(value) for value in _split_csv(args.extra_spot_instrument_ids)
+        )
+    else:
+        extra_spot_instrument_ids = _extra_spot_instrument_ids(model_path)
+    extra_spot_instrument_ids = tuple(
+        instrument_id
+        for instrument_id in dict.fromkeys(extra_spot_instrument_ids)
+        if instrument_id != btc_instrument_id
+    )
     event_slugs = upcoming_btc_5m_event_slugs(
         market_count=args.markets,
         include_current=args.include_current,
@@ -204,17 +347,20 @@ async def _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -
     strategy_config = _build_strategy_config(
         instrument_ids=instrument_ids,
         btc_instrument_id=btc_instrument_id,
+        extra_spot_instrument_ids=extra_spot_instrument_ids,
     )
+    binance_instrument_ids = frozenset({btc_instrument_id, *extra_spot_instrument_ids})
     node_config = build_polymarket_binance_sandbox_config(
         strategies=[strategy_config],
         event_slug_builder=EVENT_SLUG_BUILDER,
-        binance_instrument_ids=frozenset({btc_instrument_id}),
+        btc_instrument_ids=binance_instrument_ids,
         starting_balance=Decimal(str(args.starting_balance)),
         trader_id=args.trader_id,
         log_level=args.log_level,
         polymarket_update_interval_mins=(
             args.polymarket_refresh_mins if args.polymarket_refresh_mins > 0 else None
         ),
+        binance_us=btc_data_source == BTC_DATA_SOURCE_BINANCE_US,
     )
 
     coverage_minutes = len(event_slugs) * 5
@@ -227,8 +373,16 @@ async def _main(argv: Sequence[str] | None = None, *, force_run: bool = False) -
     print(f"Next event slugs: {', '.join(event_slugs[:3])}")
     model_suffix = "" if model_exists else " (missing; dry-run only)"
     print(f"Model profile: {model_path}{model_suffix}")
-    print("Policy: S199 profile, 60s snapshot, edge>=0.06, ask-cost<=1.01")
+    print(_policy_label(strategy_config.config))
     print(f"Trade size: target {_trade_size()} contracts; market buys sent as quote quantity")
+    print(f"BTC trade source: {_btc_data_source_label(btc_data_source)}")
+    if extra_spot_instrument_ids:
+        print(
+            "Extra spot feature instruments: "
+            + ", ".join(str(instrument_id) for instrument_id in extra_spot_instrument_ids)
+        )
+    else:
+        print("Extra spot feature instruments: none")
     print(f"Diagnostics: {_diagnostics_path() or 'disabled'}")
     print(f"Settlement ledger: {_settlement_path() or 'disabled'}")
     print(

--- a/prediction_market_extensions/live/btc_features.py
+++ b/prediction_market_extensions/live/btc_features.py
@@ -7,13 +7,16 @@ NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
 class LiveBtcFeatureStore:
-    """Rolling one-second BTC trade feature store for live snapshot models."""
+    """Rolling one-second spot trade/book feature store for live snapshot models."""
 
-    def __init__(self, *, buffer_seconds: int) -> None:
+    def __init__(self, *, buffer_seconds: int, book_prefix: str = "btc") -> None:
         self._buffer_seconds = int(buffer_seconds)
+        self._book_prefix = book_prefix.strip().lower() or "btc"
         self._prices_by_second: dict[int, float] = {}
         self._volumes_by_second: dict[int, float] = {}
         self._seconds: list[int] = []
+        self._book_features_by_second: dict[int, dict[str, float]] = {}
+        self._book_seconds: list[int] = []
 
     def record_trade(self, *, ts_ns: int, price: float, size: float) -> None:
         if not math.isfinite(price) or price <= 0.0:
@@ -29,16 +32,72 @@ class LiveBtcFeatureStore:
         )
         self._prune(current_second=second)
 
+    def record_book(
+        self,
+        *,
+        ts_ns: int,
+        mid: float,
+        spread: float,
+        bid_size: float,
+        ask_size: float,
+        bid_depth: float,
+        ask_depth: float,
+        book_imbalance: float,
+        microprice: float,
+    ) -> None:
+        if not all(
+            math.isfinite(value)
+            for value in (
+                mid,
+                spread,
+                bid_size,
+                ask_size,
+                bid_depth,
+                ask_depth,
+                book_imbalance,
+                microprice,
+            )
+        ):
+            return
+        if mid <= 0.0 or spread < 0.0 or bid_size <= 0.0 or ask_size <= 0.0:
+            return
+        if bid_depth <= 0.0 or ask_depth <= 0.0:
+            return
+        second = int(ts_ns // NANOSECONDS_PER_SECOND)
+        if second not in self._book_features_by_second:
+            self._book_seconds.append(second)
+            self._book_seconds.sort()
+        prefix = self._book_prefix
+        self._book_features_by_second[second] = {
+            f"{prefix}_book_mid": mid,
+            f"{prefix}_book_spread": spread,
+            f"{prefix}_book_spread_bps": (spread / mid) * 10_000.0,
+            f"{prefix}_book_bid_size": bid_size,
+            f"{prefix}_book_ask_size": ask_size,
+            f"{prefix}_book_bid_depth": bid_depth,
+            f"{prefix}_book_ask_depth": ask_depth,
+            f"{prefix}_book_imbalance": book_imbalance,
+            f"{prefix}_book_microprice": microprice,
+            f"{prefix}_book_microprice_diff": microprice - mid,
+        }
+        self._prune(current_second=second)
+
     def _prune(self, *, current_second: int) -> None:
         cutoff = current_second - self._buffer_seconds
-        if not self._seconds or self._seconds[0] >= cutoff:
-            return
-        retained = [second for second in self._seconds if second >= cutoff]
-        removed = set(self._seconds) - set(retained)
-        for second in removed:
-            self._prices_by_second.pop(second, None)
-            self._volumes_by_second.pop(second, None)
-        self._seconds = retained
+        if self._seconds and self._seconds[0] < cutoff:
+            retained = [second for second in self._seconds if second >= cutoff]
+            removed = set(self._seconds) - set(retained)
+            for second in removed:
+                self._prices_by_second.pop(second, None)
+                self._volumes_by_second.pop(second, None)
+            self._seconds = retained
+
+        if self._book_seconds and self._book_seconds[0] < cutoff:
+            retained_books = [second for second in self._book_seconds if second >= cutoff]
+            removed_books = set(self._book_seconds) - set(retained_books)
+            for second in removed_books:
+                self._book_features_by_second.pop(second, None)
+            self._book_seconds = retained_books
 
     def price_at(self, ts: int) -> float:
         if not self._seconds:
@@ -47,6 +106,46 @@ class LiveBtcFeatureStore:
         if index < 0:
             return math.nan
         return self._prices_by_second.get(self._seconds[index], math.nan)
+
+    def observation_second_at(self, ts: int) -> int | None:
+        if not self._seconds:
+            return None
+        index = bisect_right(self._seconds, int(ts)) - 1
+        if index < 0:
+            return None
+        return self._seconds[index]
+
+    def observation_age_seconds(self, ts: int) -> float:
+        observed_second = self.observation_second_at(ts)
+        if observed_second is None:
+            return math.inf
+        return float(int(ts) - observed_second)
+
+    def book_observation_second_at(self, ts: int) -> int | None:
+        if not self._book_seconds:
+            return None
+        index = bisect_right(self._book_seconds, int(ts)) - 1
+        if index < 0:
+            return None
+        return self._book_seconds[index]
+
+    def book_observation_age_seconds(self, ts: int) -> float:
+        observed_second = self.book_observation_second_at(ts)
+        if observed_second is None:
+            return math.inf
+        return float(int(ts) - observed_second)
+
+    def book_features_at(self, ts: int) -> dict[str, float] | None:
+        observed_second = self.book_observation_second_at(ts)
+        if observed_second is None:
+            return None
+        features = self._book_features_by_second.get(observed_second)
+        if features is None:
+            return None
+        return {
+            **features,
+            f"{self._book_prefix}_book_age_seconds": float(int(ts) - observed_second),
+        }
 
     def momentum(self, ts: int, seconds: int) -> float:
         current = self.price_at(ts)

--- a/prediction_market_extensions/live/sandbox.py
+++ b/prediction_market_extensions/live/sandbox.py
@@ -329,37 +329,40 @@ def build_polymarket_binance_sandbox_config(
     strategies: Sequence[ImportableStrategyConfig],
     event_slug_builder: str,
     binance_instrument_ids: frozenset[InstrumentId] | None = None,
+    btc_instrument_ids: frozenset[InstrumentId] | None = None,
     starting_balance: Decimal | str = Decimal("20"),
     trader_id: str = "SANDBOX-001",
     log_level: str = "INFO",
     polymarket_update_interval_mins: int | None = None,
+    binance_us: bool = True,
     risk_submit_rate: str = "20/00:00:01",
 ) -> TradingNodeConfig:
     """Build a Nautilus sandbox node config."""
 
     polymarket_venues = frozenset({"POLYMARKET"})
     binance_venues = frozenset({"BINANCE"})
-    btc_ids = binance_instrument_ids or frozenset({DEFAULT_BTC_INSTRUMENT_ID})
+    btc_ids = btc_instrument_ids or binance_instrument_ids or frozenset({DEFAULT_BTC_INSTRUMENT_ID})
     balance = Decimal(str(starting_balance))
+    data_clients = {
+        "POLYMARKET": PolymarketDataClientConfig(
+            instrument_config=PolymarketInstrumentProviderConfig(
+                event_slug_builder=event_slug_builder,
+            ),
+            routing=RoutingConfig(venues=polymarket_venues),
+            update_instruments_interval_mins=polymarket_update_interval_mins,
+            compute_effective_deltas=False,
+        ),
+        "BINANCE": BinanceDataClientConfig(
+            instrument_provider=BinanceInstrumentProviderConfig(load_ids=btc_ids),
+            routing=RoutingConfig(venues=binance_venues),
+            us=binance_us,
+        ),
+    }
 
     return TradingNodeConfig(
         environment=Environment.SANDBOX,
         trader_id=TraderId(trader_id),
-        data_clients={
-            "POLYMARKET": PolymarketDataClientConfig(
-                instrument_config=PolymarketInstrumentProviderConfig(
-                    event_slug_builder=event_slug_builder,
-                ),
-                routing=RoutingConfig(venues=polymarket_venues),
-                update_instruments_interval_mins=polymarket_update_interval_mins,
-                compute_effective_deltas=False,
-            ),
-            "BINANCE": BinanceDataClientConfig(
-                instrument_provider=BinanceInstrumentProviderConfig(load_ids=btc_ids),
-                routing=RoutingConfig(venues=binance_venues),
-                us=True,
-            ),
-        },
+        data_clients=data_clients,
         exec_clients={
             "POLYMARKET": SandboxExecutionClientConfig(
                 routing=RoutingConfig(venues=polymarket_venues),

--- a/scripts/generate_codebase_uml.py
+++ b/scripts/generate_codebase_uml.py
@@ -17,6 +17,10 @@ EXCLUDED_DIRS = {
     "__pycache__",
     "tests",
 }
+EXCLUDED_RELATIVE_PREFIXES = {
+    ("backtests", "private"),
+    ("strategies", "private"),
+}
 
 
 @dataclass
@@ -48,7 +52,9 @@ def _is_included_python_file(path: Path) -> bool:
     if path.suffix != ".py":
         return False
     rel_parts = path.relative_to(REPO_ROOT).parts
-    return not any(part in EXCLUDED_DIRS or part.startswith(".") for part in rel_parts)
+    if any(part in EXCLUDED_DIRS or part.startswith(".") for part in rel_parts):
+        return False
+    return not any(rel_parts[: len(prefix)] == prefix for prefix in EXCLUDED_RELATIVE_PREFIXES)
 
 
 def _unparse(node: ast.AST | None) -> str:
@@ -180,7 +186,8 @@ def build_document() -> str:
     lines = [
         "# Codebase UML Inventory",
         "",
-        "This file is generated from Python AST metadata and excludes `tests/`.",
+        "This file is generated from Python AST metadata and excludes `tests/` plus "
+        "git-ignored private strategy/research directories.",
         f"Generated: {datetime.now(UTC).isoformat(timespec='seconds')}",
         f"Modules: {len(modules)} | Classes: {class_count} | Functions/methods: {callable_count}",
         "",

--- a/tests/test_live_sandbox.py
+++ b/tests/test_live_sandbox.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 import importlib
+import json
 import math
+import os
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -13,7 +15,7 @@ from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.trading.config import ImportableStrategyConfig
 
-from live import btc_snapshot_model_sandbox
+from live import btc_eth_sol_snapshot_model_sandbox, btc_snapshot_model_sandbox
 from prediction_market_extensions.live import btc_5m
 from prediction_market_extensions.live.btc_features import (
     NANOSECONDS_PER_SECOND,
@@ -234,9 +236,37 @@ def test_live_btc_feature_store_records_features_and_prunes_old_seconds() -> Non
     store.record_trade(ts_ns=12 * NANOSECONDS_PER_SECOND, price=103.0, size=3.0)
     store.record_trade(ts_ns=12 * NANOSECONDS_PER_SECOND, price=103.5, size=0.5)
     store.record_trade(ts_ns=13 * NANOSECONDS_PER_SECOND, price=float("nan"), size=99.0)
+    store.record_book(
+        ts_ns=12 * NANOSECONDS_PER_SECOND,
+        mid=103.0,
+        spread=0.5,
+        bid_size=2.0,
+        ask_size=1.0,
+        bid_depth=5.0,
+        ask_depth=3.0,
+        book_imbalance=0.25,
+        microprice=103.1,
+    )
 
     assert store.price_at(12) == 103.5
     assert store.price_at(11) == 101.0
+    assert store.observation_second_at(12) == 12
+    assert store.observation_age_seconds(13) == 1.0
+    assert store.book_observation_second_at(13) == 12
+    assert store.book_observation_age_seconds(13) == 1.0
+    assert store.book_features_at(13) == {
+        "btc_book_age_seconds": 1.0,
+        "btc_book_ask_depth": 3.0,
+        "btc_book_ask_size": 1.0,
+        "btc_book_bid_depth": 5.0,
+        "btc_book_bid_size": 2.0,
+        "btc_book_imbalance": 0.25,
+        "btc_book_microprice": 103.1,
+        "btc_book_microprice_diff": pytest.approx(0.1),
+        "btc_book_mid": 103.0,
+        "btc_book_spread": 0.5,
+        "btc_book_spread_bps": pytest.approx(48.543689),
+    }
     assert store.momentum(12, 2) == 3.5
     assert store.volume(12, 2) == 5.5
     assert store.volatility(12, 2) == pytest.approx(0.75)
@@ -244,8 +274,70 @@ def test_live_btc_feature_store_records_features_and_prunes_old_seconds() -> Non
     store.record_trade(ts_ns=14 * NANOSECONDS_PER_SECOND, price=104.0, size=4.0)
 
     assert math.isnan(store.price_at(10))
+    assert store.observation_second_at(10) is None
+    assert math.isinf(store.observation_age_seconds(10))
+    assert store.book_features_at(10) is None
     assert store.price_at(11) == 101.0
     assert store.price_at(14) == 104.0
+
+
+def test_live_btc_feature_store_can_prefix_book_features() -> None:
+    store = LiveBtcFeatureStore(buffer_seconds=3, book_prefix="eth")
+    store.record_trade(ts_ns=12 * NANOSECONDS_PER_SECOND, price=200.0, size=1.0)
+    store.record_book(
+        ts_ns=12 * NANOSECONDS_PER_SECOND,
+        mid=200.0,
+        spread=0.2,
+        bid_size=3.0,
+        ask_size=2.0,
+        bid_depth=9.0,
+        ask_depth=7.0,
+        book_imbalance=0.125,
+        microprice=200.05,
+    )
+
+    assert store.book_features_at(13) == {
+        "eth_book_age_seconds": 1.0,
+        "eth_book_ask_depth": 7.0,
+        "eth_book_ask_size": 2.0,
+        "eth_book_bid_depth": 9.0,
+        "eth_book_bid_size": 3.0,
+        "eth_book_imbalance": 0.125,
+        "eth_book_microprice": 200.05,
+        "eth_book_microprice_diff": pytest.approx(0.05),
+        "eth_book_mid": 200.0,
+        "eth_book_spread": 0.2,
+        "eth_book_spread_bps": pytest.approx(10.0),
+    }
+
+
+def test_live_btc_feature_store_prunes_book_only_features() -> None:
+    store = LiveBtcFeatureStore(buffer_seconds=3, book_prefix="sol")
+    store.record_book(
+        ts_ns=12 * NANOSECONDS_PER_SECOND,
+        mid=100.0,
+        spread=0.1,
+        bid_size=1.0,
+        ask_size=1.0,
+        bid_depth=2.0,
+        ask_depth=2.0,
+        book_imbalance=0.0,
+        microprice=100.0,
+    )
+    store.record_book(
+        ts_ns=16 * NANOSECONDS_PER_SECOND,
+        mid=101.0,
+        spread=0.1,
+        bid_size=1.0,
+        ask_size=1.0,
+        bid_depth=2.0,
+        ask_depth=2.0,
+        book_imbalance=0.0,
+        microprice=101.0,
+    )
+
+    assert store.book_features_at(12) is None
+    assert store.book_features_at(16)["sol_book_mid"] == 101.0
 
 
 def test_split_polymarket_instrument_id_extracts_condition_and_token() -> None:
@@ -317,8 +409,16 @@ def test_btc_snapshot_sandbox_runner_is_example_wiring_with_private_artifacts(
     monkeypatch.delenv("LIVE_BTC_SNAPSHOT_MODEL_PATH", raising=False)
     monkeypatch.delenv("LIVE_BTC_SNAPSHOT_DIAGNOSTICS_PATH", raising=False)
     monkeypatch.delenv("LIVE_BTC_HEARTBEAT_LOG_SECONDS", raising=False)
+    monkeypatch.delenv("LIVE_BTC_MAX_FEATURE_AGE_SECONDS", raising=False)
+    monkeypatch.delenv("LIVE_BTC_DAILY_STOP_LOSS", raising=False)
+    monkeypatch.delenv("LIVE_BTC_DATA_SOURCE", raising=False)
+    monkeypatch.delenv("LIVE_BTC_BINANCE_GLOBAL", raising=False)
+    monkeypatch.delenv("LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS", raising=False)
+    monkeypatch.delenv("LIVE_BTC_SNAPSHOT_MOMENTUM_ALIGNMENT", raising=False)
+    monkeypatch.delenv("LIVE_BTC_EXPENSIVE_MIN_SIGNED_MOMENTUM_30S", raising=False)
 
     params = btc_snapshot_model_sandbox._strategy_parameters()
+    args = btc_snapshot_model_sandbox._parse_args([])
 
     assert btc_snapshot_model_sandbox.STRATEGY_PATH.startswith("strategies.private.")
     assert btc_snapshot_model_sandbox.CONFIG_PATH.startswith("strategies.private.")
@@ -326,6 +426,17 @@ def test_btc_snapshot_sandbox_runner_is_example_wiring_with_private_artifacts(
     assert str(params["model_path"]).startswith("live/models/")
     assert params["diagnostics_path"] is None
     assert params["heartbeat_log_seconds"] == 300.0
+    assert params["edge"] == 0.12
+    assert params["momentum_alignment"] == "none"
+    assert params["min_selected_probability"] == 0.0
+    assert params["max_yes_no_ask_cost"] == 0.0
+    assert params["max_btc_feature_age_seconds"] == 30.0
+    assert params["daily_stop_loss"] == 1.2
+    assert params["expensive_min_signed_momentum_30s"] == 0.0
+    assert btc_snapshot_model_sandbox._resolve_btc_data_source(args) == "binance-global"
+    assert btc_snapshot_model_sandbox._default_btc_instrument_id("binance-global") == (
+        DEFAULT_BTC_INSTRUMENT_ID
+    )
 
 
 def test_btc_snapshot_sandbox_runner_config_injects_live_runtime_options(
@@ -333,20 +444,90 @@ def test_btc_snapshot_sandbox_runner_config_injects_live_runtime_options(
 ) -> None:
     monkeypatch.setenv("LIVE_BTC_SNAPSHOT_MODEL_PATH", "live/models/local-private-model.json")
     monkeypatch.setenv("LIVE_BTC_HEARTBEAT_LOG_SECONDS", "17")
+    monkeypatch.setenv("LIVE_BTC_MAX_FEATURE_AGE_SECONDS", "4.5")
+    monkeypatch.setenv("LIVE_BTC_DAILY_STOP_LOSS", "0.8")
+    monkeypatch.setenv("LIVE_BTC_SNAPSHOT_MOMENTUM_ALIGNMENT", "momentum_vote")
+    monkeypatch.setenv("LIVE_BTC_EXPENSIVE_MIN_SIGNED_MOMENTUM_30S", "1.5")
     up = InstrumentId.from_str("UP.POLYMARKET")
     down = InstrumentId.from_str("DOWN.POLYMARKET")
 
     config = btc_snapshot_model_sandbox._build_strategy_config(
         instrument_ids=(up, down),
         btc_instrument_id=DEFAULT_BTC_INSTRUMENT_ID,
+        extra_spot_instrument_ids=(InstrumentId.from_str("ETHUSDT.BINANCE"),),
     )
 
     assert config.strategy_path == btc_snapshot_model_sandbox.STRATEGY_PATH
     assert config.config_path == btc_snapshot_model_sandbox.CONFIG_PATH
     assert config.config["instrument_ids"] == [str(up), str(down)]
     assert config.config["btc_instrument_id"] == str(DEFAULT_BTC_INSTRUMENT_ID)
+    assert config.config["extra_spot_instrument_ids"] == ["ETHUSDT.BINANCE"]
     assert config.config["model_path"] == "live/models/local-private-model.json"
     assert config.config["heartbeat_log_seconds"] == 17.0
+    assert config.config["momentum_alignment"] == "momentum_vote"
+    assert config.config["max_btc_feature_age_seconds"] == 4.5
+    assert config.config["daily_stop_loss"] == 0.8
+    assert config.config["expensive_min_signed_momentum_30s"] == 1.5
+
+
+def test_btc_snapshot_sandbox_runner_policy_label_uses_configured_thresholds() -> None:
+    assert (
+        btc_snapshot_model_sandbox._policy_label(
+            {
+                "snapshot_seconds": (60,),
+                "edge": 0.08,
+                "max_ask_price": 0.75,
+            }
+        )
+        == "Policy: model profile, 60s snapshot, edge>=0.08, max ask<=0.75"
+    )
+
+
+def test_btc_eth_sol_sandbox_runner_sets_private_champion_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("LIVE_BTC_SNAPSHOT_MODEL_PATH", raising=False)
+    monkeypatch.delenv("LIVE_BTC_SNAPSHOT_EDGE", raising=False)
+    monkeypatch.delenv("LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS", raising=False)
+
+    btc_eth_sol_snapshot_model_sandbox._configure_env_defaults()
+
+    assert os.environ["LIVE_BTC_SNAPSHOT_MODEL_PATH"] == (
+        btc_eth_sol_snapshot_model_sandbox.DEFAULT_ETH_SOL_MODEL_PATH
+    )
+    assert os.environ["LIVE_BTC_SNAPSHOT_EDGE"] == "0.08"
+    assert os.environ["LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS"] == ("ETHUSDT.BINANCE,SOLUSDT.BINANCE")
+
+
+def test_btc_snapshot_sandbox_runner_detects_extra_spot_instruments(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("LIVE_BTC_EXTRA_SPOT_INSTRUMENT_IDS", raising=False)
+    model_path = tmp_path / "model.json"
+    model_path.write_text(
+        json.dumps(
+            {
+                "model": {
+                    "columns": [
+                        "seconds_left",
+                        "eth_return_since_start",
+                        "sol_return_since_start",
+                        "xrp_return_since_start",
+                    ],
+                },
+            },
+        ),
+    )
+
+    assert btc_snapshot_model_sandbox._model_extra_spot_prefixes(str(model_path)) == (
+        "eth",
+        "sol",
+        "xrp",
+    )
+    assert btc_snapshot_model_sandbox._extra_spot_instrument_ids(str(model_path)) == (
+        InstrumentId.from_str("ETHUSDT.BINANCE"),
+        InstrumentId.from_str("SOLUSDT.BINANCE"),
+        InstrumentId.from_str("XRPUSDT.BINANCE"),
+    )
 
 
 def test_btc_snapshot_sandbox_runner_dry_run_allows_missing_private_model(
@@ -449,6 +630,22 @@ def test_build_polymarket_binance_sandbox_config_disables_polymarket_refresh_by_
     )
 
     assert config.data_clients["POLYMARKET"].update_instruments_interval_mins is None
+
+
+def test_build_polymarket_binance_sandbox_config_can_use_global_binance() -> None:
+    strategy = ImportableStrategyConfig(
+        strategy_path="strategies:DemoStrategy",
+        config_path="strategies:DemoConfig",
+        config={"parameter_name": 1},
+    )
+
+    config = build_polymarket_binance_sandbox_config(
+        strategies=[strategy],
+        event_slug_builder="tests.fake:slugs",
+        binance_us=False,
+    )
+
+    assert config.data_clients["BINANCE"].us is False
 
 
 def test_public_polymarket_data_factory_does_not_require_credentials(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- update README Nautilus badge to 1.226.0 and remove the stale 1.225.0 README mention
- add public live sandbox runner wiring for the private BTC/ETH/SOL model profile
- add Binance global/live feature controls, extra spot instrument auto-detection, book feature freshness plumbing, and tests
- regenerate CODEBASE_UML with ignored private strategy/research directories excluded

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q`
- `uv run mkdocs build --strict`
