### PR TITLE
[codex] Fix summary table metrics

### DIFF
--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/` plus git-ignored private strategy/research directories.
-Generated: 2026-05-11T03:41:57+00:00
-Modules: 119 | Classes: 171 | Functions/methods: 1572
+Generated: 2026-05-14T16:02:58+00:00
+Modules: 119 | Classes: 171 | Functions/methods: 1581
 
 ## Backtesting Data Flow
 
@@ -732,18 +732,27 @@ flowchart TD
 - Function L1105: `save_joint_portfolio_backtest_report(*, results: Sequence[dict[str, Any]], output_path: str | Path, title: str, market_key: str, pnl_label: str, max_points_per_market: int = 400, plot_panels: Sequence[str] | None = None) -> str | None`
 - Function L1347: `print_backtest_summary(*, results: list[dict[str, Any]], market_key: str, count_key: str, count_label: str, pnl_label: str, empty_message: str = 'No markets had sufficient data.') -> None`
 - Function L1410: `_summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]`
-- Function L1428: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
-- Function L1454: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
-- Function L1472: `_summary_returns_from_pairs(pairs: object) -> dict[int, float]`
-- Function L1493: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
-- Function L1510: `_summary_total_return_pct(pairs: object) -> float | None`
-- Function L1526: `_safe_stat(func, returns: dict[int, float]) -> float | None`
-- Function L1534: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
-- Function L1539: `_coerce_float(value: object) -> float | None`
-- Function L1547: `_format_summary_float(value: object, decimals: int) -> str`
-- Function L1554: `_format_summary_pct(value: object) -> str`
-- Function L1561: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
-- Function L1624: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
+- Function L1432: `_summary_stats_total(*, rows: Sequence[Mapping[str, float | None]], results: Sequence[Mapping[str, Any]]) -> dict[str, float | None]`
+- Function L1485: `_summary_fill_stats(fill_events: object) -> tuple[float, float, float | None]`
+- Function L1503: `_summary_returns_from_pairs(pairs: object) -> dict[int, float]`
+- Function L1508: `_summary_returns_from_series(series: pd.Series) -> dict[int, float]`
+- Function L1528: `_summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]`
+- Function L1545: `_summary_total_return_pct(pairs: object) -> float | None`
+- Function L1550: `_summary_total_return_pct_from_series(series: pd.Series) -> float | None`
+- Function L1565: `_summary_reconciled_equity_series(pairs: object, *, final_pnl: object) -> pd.Series`
+- Function L1595: `_summary_total_return_pct_for_portfolio(*, equity_series: object, total_pnl: float, portfolio_pnls: Mapping[str, Any], use_portfolio_stats: bool) -> float | None`
+- Function L1627: `_summary_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]`
+- Function L1634: `_summary_portfolio_return_stats(portfolio_stats: Mapping[str, Any]) -> Mapping[str, Any]`
+- Function L1639: `_summary_portfolio_pnl_stats(portfolio_stats: Mapping[str, Any]) -> Mapping[str, Any]`
+- Function L1651: `_summary_portfolio_pnl_matches(*, portfolio_pnls: Mapping[str, Any], total_pnl: float) -> bool`
+- Function L1659: `_summary_prefer_stat(primary: object, fallback: float | None) -> float | None`
+- Function L1664: `_safe_stat(func, returns: dict[int, float]) -> float | None`
+- Function L1672: `_safe_stat_percent(func, returns: dict[int, float]) -> float | None`
+- Function L1677: `_coerce_float(value: object) -> float | None`
+- Function L1685: `_format_summary_float(value: object, decimals: int) -> str`
+- Function L1692: `_format_summary_pct(value: object) -> str`
+- Function L1699: `_print_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> None`
+- Function L1762: `_selected_named_stats(stats: Mapping[str, Any], names: Sequence[str]) -> list[str]`
 
 ### `prediction_market_extensions/analysis/__init__.py`
 - Imports: none

--- a/prediction_market_extensions/adapters/prediction_market/research.py
+++ b/prediction_market_extensions/adapters/prediction_market/research.py
@@ -1409,14 +1409,18 @@ def print_backtest_summary(
 
 def _summary_stats_for_result(result: Mapping[str, Any]) -> dict[str, float | None]:
     fill_qty, fill_notional, avg_fill_price = _summary_fill_stats(result.get("fill_events") or ())
-    returns = _summary_returns_from_pairs(result.get("equity_series"))
+    equity_series = _summary_reconciled_equity_series(
+        result.get("equity_series"),
+        final_pnl=result.get("pnl"),
+    )
+    returns = _summary_returns_from_series(equity_series)
     stats = _summary_return_stats(returns)
     coverage = _coerce_float(result.get("requested_coverage_ratio"))
     return {
         "fill_qty": fill_qty,
         "fill_notional": fill_notional,
         "avg_fill_price": avg_fill_price,
-        "return_pct": _summary_total_return_pct(result.get("equity_series")),
+        "return_pct": _summary_total_return_pct_from_series(equity_series),
         "max_drawdown_pct": stats["max_drawdown_pct"],
         "sharpe": stats["sharpe"],
         "sortino": stats["sortino"],
@@ -1431,8 +1435,19 @@ def _summary_stats_total(
     fill_qty = sum(float(row.get("fill_qty") or 0.0) for row in rows)
     fill_notional = sum(float(row.get("fill_notional") or 0.0) for row in rows)
     avg_fill_price = fill_notional / fill_qty if fill_qty > 0.0 else None
-    equity_series = results[0].get("joint_portfolio_equity_series") if results else None
-    stats = _summary_return_stats(_summary_returns_from_pairs(equity_series))
+    portfolio_stats = _summary_portfolio_stats(results)
+    portfolio_pnls = _summary_portfolio_pnl_stats(portfolio_stats)
+    portfolio_returns = _summary_portfolio_return_stats(portfolio_stats)
+    total_pnl = sum(float(result.get("pnl") or 0.0) for result in results)
+    portfolio_stats_match_pnl = _summary_portfolio_pnl_matches(
+        portfolio_pnls=portfolio_pnls,
+        total_pnl=total_pnl,
+    )
+    equity_series = _summary_reconciled_equity_series(
+        results[0].get("joint_portfolio_equity_series") if results else None,
+        final_pnl=total_pnl,
+    )
+    stats = _summary_return_stats(_summary_returns_from_series(equity_series))
     coverage_values = [
         float(row["coverage_pct"])
         for row in rows
@@ -1442,11 +1457,27 @@ def _summary_stats_total(
         "fill_qty": fill_qty,
         "fill_notional": fill_notional,
         "avg_fill_price": avg_fill_price,
-        "return_pct": _summary_total_return_pct(equity_series),
+        "return_pct": _summary_total_return_pct_for_portfolio(
+            equity_series=equity_series,
+            total_pnl=total_pnl,
+            portfolio_pnls=portfolio_pnls,
+            use_portfolio_stats=portfolio_stats_match_pnl,
+        ),
         "max_drawdown_pct": stats["max_drawdown_pct"],
-        "sharpe": stats["sharpe"],
-        "sortino": stats["sortino"],
-        "profit_factor": stats["profit_factor"],
+        "sharpe": _summary_prefer_stat(
+            portfolio_returns.get("Sharpe Ratio (252 days)") if portfolio_stats_match_pnl else None,
+            stats["sharpe"],
+        ),
+        "sortino": _summary_prefer_stat(
+            portfolio_returns.get("Sortino Ratio (252 days)")
+            if portfolio_stats_match_pnl
+            else None,
+            stats["sortino"],
+        ),
+        "profit_factor": _summary_prefer_stat(
+            portfolio_returns.get("Profit Factor") if portfolio_stats_match_pnl else None,
+            stats["profit_factor"],
+        ),
         "coverage_pct": sum(coverage_values) / len(coverage_values) if coverage_values else None,
     }
 
@@ -1471,6 +1502,10 @@ def _summary_fill_stats(fill_events: object) -> tuple[float, float, float | None
 
 def _summary_returns_from_pairs(pairs: object) -> dict[int, float]:
     series = _pairs_to_series(pairs if isinstance(pairs, Sequence) else [])
+    return _summary_returns_from_series(series)
+
+
+def _summary_returns_from_series(series: pd.Series) -> dict[int, float]:
     if series.empty:
         return {}
 
@@ -1509,6 +1544,10 @@ def _summary_return_stats(returns: dict[int, float]) -> dict[str, float | None]:
 
 def _summary_total_return_pct(pairs: object) -> float | None:
     series = _pairs_to_series(pairs if isinstance(pairs, Sequence) else [])
+    return _summary_total_return_pct_from_series(series)
+
+
+def _summary_total_return_pct_from_series(series: pd.Series) -> float | None:
     if series.empty:
         return None
 
@@ -1521,6 +1560,105 @@ def _summary_total_return_pct(pairs: object) -> float | None:
     if abs(first) < 1e-12:
         return None
     return (last / first - 1.0) * 100.0
+
+
+def _summary_reconciled_equity_series(pairs: object, *, final_pnl: object) -> pd.Series:
+    series = _pairs_to_series(pairs if isinstance(pairs, Sequence) else [])
+    if series.empty:
+        return series
+
+    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric.empty:
+        return pd.Series(dtype=float)
+
+    pnl = _coerce_float(final_pnl)
+    if pnl is None:
+        return numeric.astype(float)
+
+    first = float(numeric.iloc[0])
+    expected_final = first + pnl
+    current_final = float(numeric.iloc[-1])
+    tolerance = max(
+        1e-9,
+        abs(expected_final) * 1e-9,
+        abs(current_final - first) * 1e-6,
+        abs(float(pnl)) * 1e-6,
+    )
+    if abs(current_final - expected_final) <= tolerance:
+        return numeric.astype(float)
+
+    reconciled = numeric.astype(float).copy()
+    reconciled.iloc[-1] = expected_final
+    return reconciled
+
+
+def _summary_total_return_pct_for_portfolio(
+    *,
+    equity_series: object,
+    total_pnl: float,
+    portfolio_pnls: Mapping[str, Any],
+    use_portfolio_stats: bool,
+) -> float | None:
+    engine_return = _coerce_float(portfolio_pnls.get("PnL% (total)"))
+    if use_portfolio_stats and engine_return is not None:
+        return engine_return
+
+    if not isinstance(equity_series, pd.Series):
+        equity_series = _summary_reconciled_equity_series(equity_series, final_pnl=total_pnl)
+    if equity_series.empty:
+        return None
+
+    numeric = pd.to_numeric(equity_series, errors="coerce").dropna()
+    if len(numeric) < 2:
+        return None
+
+    first = float(numeric.iloc[0])
+    if abs(first) < 1e-12:
+        return None
+
+    series_pnl = float(numeric.iloc[-1]) - first
+    pnl_return = (total_pnl / first) * 100.0
+    tolerance = max(1e-9, abs(total_pnl) * 1e-6, abs(series_pnl) * 1e-6)
+    if abs(series_pnl - total_pnl) > tolerance:
+        return pnl_return
+    return (series_pnl / first) * 100.0
+
+
+def _summary_portfolio_stats(results: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    if not results:
+        return {}
+    raw_stats = results[0].get("portfolio_stats")
+    return raw_stats if isinstance(raw_stats, Mapping) else {}
+
+
+def _summary_portfolio_return_stats(portfolio_stats: Mapping[str, Any]) -> Mapping[str, Any]:
+    stats_returns = portfolio_stats.get("stats_returns")
+    return stats_returns if isinstance(stats_returns, Mapping) else {}
+
+
+def _summary_portfolio_pnl_stats(portfolio_stats: Mapping[str, Any]) -> Mapping[str, Any]:
+    stats_pnls = portfolio_stats.get("stats_pnls")
+    if not isinstance(stats_pnls, Mapping):
+        return {}
+    if "PnL% (total)" in stats_pnls or "PnL (total)" in stats_pnls:
+        return stats_pnls
+    for value in stats_pnls.values():
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _summary_portfolio_pnl_matches(*, portfolio_pnls: Mapping[str, Any], total_pnl: float) -> bool:
+    portfolio_pnl = _coerce_float(portfolio_pnls.get("PnL (total)"))
+    if portfolio_pnl is None:
+        return False
+    tolerance = max(1e-9, abs(portfolio_pnl) * 1e-6, abs(total_pnl) * 1e-6)
+    return abs(portfolio_pnl - total_pnl) <= tolerance
+
+
+def _summary_prefer_stat(primary: object, fallback: float | None) -> float | None:
+    value = _coerce_float(primary)
+    return value if value is not None else fallback
 
 
 def _safe_stat(func: Any, returns: dict[int, float]) -> float | None:

--- a/tests/test_prediction_market_summary_stats.py
+++ b/tests/test_prediction_market_summary_stats.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from prediction_market_extensions.adapters.prediction_market import research
 from prediction_market_extensions.adapters.prediction_market.research import print_backtest_summary
 
 
@@ -112,3 +115,142 @@ def test_print_backtest_summary_aligns_count_header_with_values(capsys) -> None:
 
     assert count_value_end == count_header_end
     assert fills_value_end == fills_header_end
+
+
+def test_total_summary_uses_portfolio_stats_when_plot_series_disagrees(capsys) -> None:
+    print_backtest_summary(
+        results=[
+            {
+                "slug": "alpha",
+                "book_events": 10,
+                "fills": 2,
+                "pnl": -0.5981,
+                "fill_events": [],
+                "joint_portfolio_equity_series": [
+                    ("2026-01-01T00:00:00+00:00", 1000.0),
+                    ("2026-01-01T00:05:00+00:00", 1002.1),
+                ],
+                "portfolio_stats": {
+                    "stats_returns": {
+                        "Sortino Ratio (252 days)": -15.8745,
+                        "Profit Factor": 0.3621,
+                    },
+                    "stats_pnls": {
+                        "pUSD": {
+                            "PnL (total)": -0.5981,
+                            "PnL% (total)": -0.05981,
+                        }
+                    },
+                },
+            }
+        ],
+        market_key="slug",
+        count_key="book_events",
+        count_label="Book Events",
+        pnl_label="PnL (pUSD)",
+    )
+
+    output = capsys.readouterr().out
+    total_row = next(line for line in output.splitlines() if line.startswith("TOTAL"))
+
+    assert "-0.06%" in total_row
+    assert "+0.21%" not in total_row
+    assert "-15.87" in total_row
+    assert "0.36" in total_row
+
+
+def test_market_summary_reconciles_return_stats_to_result_pnl() -> None:
+    row = research._summary_stats_for_result(
+        {
+            "pnl": -5.0,
+            "fill_events": [
+                {"price": 0.40, "quantity": 5.0},
+                {"price": 0.50, "quantity": 3.0},
+            ],
+            "equity_series": [
+                ("2026-01-01T00:00:00+00:00", 100.0),
+                ("2026-01-02T00:00:00+00:00", 102.0),
+                ("2026-01-03T00:00:00+00:00", 103.0),
+            ],
+            "requested_coverage_ratio": 0.5,
+        }
+    )
+
+    assert row["fill_qty"] == pytest.approx(8.0)
+    assert row["fill_notional"] == pytest.approx(3.5)
+    assert row["avg_fill_price"] == pytest.approx(0.4375)
+    assert row["return_pct"] == pytest.approx(-5.0)
+    assert row["max_drawdown_pct"] == pytest.approx(-6.862745098)
+    assert row["profit_factor"] == pytest.approx(0.291428571)
+    assert row["coverage_pct"] == pytest.approx(50.0)
+
+
+def test_total_summary_reconciles_return_stats_to_total_pnl_without_portfolio_stats() -> None:
+    results = [
+        {
+            "slug": "alpha",
+            "book_events": 10,
+            "fills": 1,
+            "pnl": -5.0,
+            "fill_events": [{"price": 0.40, "quantity": 5.0}],
+            "joint_portfolio_equity_series": [
+                ("2026-01-01T00:00:00+00:00", 100.0),
+                ("2026-01-02T00:00:00+00:00", 103.0),
+            ],
+            "requested_coverage_ratio": 0.25,
+        },
+        {
+            "slug": "beta",
+            "book_events": 20,
+            "fills": 1,
+            "pnl": 0.0,
+            "fill_events": [{"price": 0.60, "quantity": 5.0}],
+            "requested_coverage_ratio": 0.75,
+        },
+    ]
+    rows = [research._summary_stats_for_result(result) for result in results]
+    total = research._summary_stats_total(rows=rows, results=results)
+
+    assert total["fill_qty"] == pytest.approx(10.0)
+    assert total["fill_notional"] == pytest.approx(5.0)
+    assert total["avg_fill_price"] == pytest.approx(0.5)
+    assert total["return_pct"] == pytest.approx(-5.0)
+    assert total["max_drawdown_pct"] == pytest.approx(-5.0)
+    assert total["coverage_pct"] == pytest.approx(50.0)
+
+
+def test_total_summary_ignores_portfolio_stats_when_pnl_basis_disagrees() -> None:
+    results = [
+        {
+            "slug": "alpha",
+            "book_events": 10,
+            "fills": 1,
+            "pnl": -20.0,
+            "fill_events": [{"price": 0.40, "quantity": 5.0}],
+            "joint_portfolio_equity_series": [
+                ("2026-01-01T00:00:00+00:00", 1000.0),
+                ("2026-01-02T00:00:00+00:00", 1005.0),
+            ],
+            "portfolio_stats": {
+                "stats_returns": {
+                    "Sharpe Ratio (252 days)": -12.58,
+                    "Sortino Ratio (252 days)": -10.73,
+                    "Profit Factor": 0.1395,
+                },
+                "stats_pnls": {
+                    "pUSD": {
+                        "PnL (total)": -23.59,
+                        "PnL% (total)": -2.359,
+                    }
+                },
+            },
+        }
+    ]
+    rows = [research._summary_stats_for_result(result) for result in results]
+    total = research._summary_stats_total(rows=rows, results=results)
+
+    assert total["return_pct"] == pytest.approx(-2.0)
+    assert total["max_drawdown_pct"] == pytest.approx(-2.0)
+    assert total["sharpe"] != pytest.approx(-12.58)
+    assert total["sortino"] != pytest.approx(-10.73)
+    assert total["profit_factor"] != pytest.approx(0.1395)


### PR DESCRIPTION
## Summary

Refs #142

Fixes the custom backtest analytics summary table so it does not mix accounting bases between repo result PnL, synthetic plotting equity, and raw Nautilus portfolio stats.

- Reconciles row-level and total equity-series metrics to the table's reported PnL before computing return-derived stats.
- Uses Nautilus portfolio `PnL% (total)`, Sharpe, Sortino, and Profit Factor for the `TOTAL` row only when Nautilus portfolio PnL matches the table PnL basis.
- Adds regression coverage for both failure modes: plotting equity implied a positive return while PnL was negative, and Nautilus portfolio PnL disagreed with repo settlement/result PnL.
- Regenerates `CODEBASE_UML.md` for the code-structure change.

## Validation

- `uv run ruff check prediction_market_extensions/adapters/prediction_market/research.py tests/test_prediction_market_summary_stats.py`
- `uv run ruff format --check prediction_market_extensions/adapters/prediction_market/research.py tests/test_prediction_market_summary_stats.py`
- `/Users/evankolberg/prediction-market-backtesting/.venv/bin/python -m pytest tests/test_prediction_market_summary_stats.py tests/test_result_policies.py tests/test_joint_portfolio_artifacts.py -q` (`17 passed`)
- `BACKTEST_REPLAY_LOAD_WORKERS=2 uv run python backtests/polymarket_telonex_book_joint_portfolio_runner.py` returned 0; table PnL matched Nautilus PnL and table return/risk metrics agreed.
- `BACKTEST_REPLAY_LOAD_WORKERS=2 uv run python backtests/polymarket_btc_5m_pair_arbitrage.py` returned 0 with 4 fills; table PnL differed from raw Nautilus PnL, and table return stayed on the table/result-PnL basis.