### PR TITLE
Add DepthFeed L2 snapshot importer

### DIFF
--- a/CODEBASE_UML.md
+++ b/CODEBASE_UML.md
@@ -1,8 +1,8 @@
 # Codebase UML Inventory
 
 This file is generated from Python AST metadata and excludes `tests/` plus cache, virtualenv, and dot directories.
-Generated: 2026-05-16T21:06:08+00:00
-Modules: 136 | Classes: 181 | Functions/methods: 1897
+Generated: 2026-07-26T07:12:57+00:00
+Modules: 137 | Classes: 183 | Functions/methods: 1912
 
 ## Backtesting Data Flow
 
@@ -324,6 +324,7 @@ flowchart TD
 - Function L166: `_stable_policy_rows(validation_chunks: list[list[dict[str, Any]]], validation_chunk_probs: list[Any], grid: list[Any], policy_kwargs: dict[str, Any]) -> list[dict[str, Any]]`
 - Function L219: `_aggregate_selected(rows: list[dict[str, Any]]) -> dict[str, Any]`
 - Function L244: `main() -> None`
+- Function L453: `run() -> None`
 
 ### `backtests/private/telonex_general_market_value_rebound_search.py`
 - Imports: `__future__, backtests, csv, dataclasses, decimal, dotenv, importlib, json, os, pathlib, subprocess, sys, typing, uuid`
@@ -361,6 +362,7 @@ flowchart TD
 - Function L348: `_aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]`
 - Function L363: `async _run_async() -> None`
 - Function L433: `main() -> None`
+- Function L442: `run() -> None`
 
 ### `backtests/sitecustomize.py`
 - Imports: `__future__, importlib, pathlib, sys`
@@ -2054,6 +2056,24 @@ flowchart TD
 - Function L262: `_telonex_trade_frame(items: int) -> pd.DataFrame`
 - Function L275: `_bench_native_mode(*, enabled: bool, items: int, telonex_events: int, repeats: int, pmxt_rows: list[tuple[str, str]], public_trade_rows: list[dict[str, object]], telonex_rows: list[tuple[str, str, str, int, str | None]], merge_inputs: tuple[list[int], list[int], list[int], list[int]], telonex_frame: pd.DataFrame, telonex_nested_frame: pd.DataFrame, telonex_trade_frame: pd.DataFrame, native_extension_path: Path | None) -> dict[str, float | bool]`
 - Function L513: `main() -> None`
+
+### `scripts/depthfeed_download_data.py`
+- Imports: `__future__, argparse, collections, dataclasses, datetime, decimal, json, os, pathlib, pyarrow, typing, urllib`
+- Function L93: `_timestamp_ms(snapshot: dict[str, Any]) -> int`
+- Function L113: `_decimal_text(value: object) -> str`
+- Function L123: `_levels(value: object, *, side: str) -> list[list[str]]`
+- Function L138: `_book_payload(*, snapshot: dict[str, Any], condition_id: str, token_id: str, book_key: str) -> str`
+- Function L162: `snapshot_rows(snapshot: dict[str, Any], *, condition_id: str, token_up: str, token_down: str) -> list[dict[str, str]]`
+- Function L193: `_hour_path(destination: Path, timestamp_ms: int) -> Path`
+- Function L204: `_row_sort_key(row: dict[str, str]) -> tuple[float, str]`
+- Function L209: `_write_hour(path: Path, rows: list[dict[str, str]], *, condition_id: str, overwrite: bool) -> int`
+- Function L248: `download_market(*, client: DepthFeedClient, destination: Path, coin: str, market_id: str, start_time: str | None, end_time: str | None, overwrite: bool, max_pages: int | None) -> DownloadSummary`
+- Function L342: `main() -> int`
+- Class L27: `DownloadSummary`
+  - Method L35: `as_dict(self) -> dict[str, object]`
+- Class L46: `DepthFeedClient`
+  - Method L47: `__init__(self, *, api_key: str, api_base: str, timeout_secs: int) -> None`
+  - Method L57: `get(self, path: str, params: dict[str, object] | None = None) -> dict[str, Any]`
 
 ### `scripts/generate_codebase_uml.py`
 - Imports: `__future__, ast, dataclasses, datetime, pathlib`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: backtest sandbox install update test check native-develop native-debug-develop clear-pmxt-cache clear-telonex-cache clear-polymarket-cache download-pmxt-raws download-telonex-data
+.PHONY: backtest sandbox install update test check native-develop native-debug-develop clear-pmxt-cache clear-telonex-cache clear-polymarket-cache download-pmxt-raws download-telonex-data download-depthfeed-data
 
 PMXT_CACHE_ROOT ?= $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/nautilus_trader/pmxt
 PMXT_LOCAL_DATA_ROOT ?= /Volumes/storage/pmxt_data
@@ -8,6 +8,8 @@ DESTINATION ?=
 PMXT_RAW_DOWNLOAD_FLAGS ?=
 TELONEX_DATA_DESTINATION ?= /Volumes/storage/telonex_data
 TELONEX_DOWNLOAD_FLAGS ?=
+DEPTHFEED_DATA_DESTINATION ?=
+DEPTHFEED_DOWNLOAD_FLAGS ?=
 
 backtest:
 	uv run python main.py
@@ -59,6 +61,12 @@ download-telonex-data:
 	uv run python scripts/telonex_download_data.py \
 		--destination "$(TELONEX_DATA_DESTINATION)" \
 		$(TELONEX_DOWNLOAD_FLAGS)
+
+download-depthfeed-data:
+	@if [ -z "$(DEPTHFEED_DATA_DESTINATION)" ]; then echo "Set DEPTHFEED_DATA_DESTINATION=/path"; exit 2; fi
+	uv run python scripts/depthfeed_download_data.py \
+		--destination "$(DEPTHFEED_DATA_DESTINATION)" \
+		$(DEPTHFEED_DOWNLOAD_FLAGS)
 
 update:
 	@echo "No vendored Nautilus subtree remains in this branch."

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Detailed guides have been filed away in the [docs index](https://evan-kolberg.gi
     - [Lower-Level Loader Env Vars](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#lower-level-loader-env-vars)
     - [What Works Today](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#what-works-today)
     - [Supported Local File Layout](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#supported-local-file-layout)
+    - [Import DepthFeed snapshots](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#import-depthfeed-snapshots)
     - [Required Parquet Columns](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#required-parquet-columns)
     - [Legacy JSON Payload Shape](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#legacy-json-payload-shape)
   - [Telonex](https://evan-kolberg.github.io/prediction-market-backtesting/data-vendors/#telonex)

--- a/docs/data-vendors.md
+++ b/docs/data-vendors.md
@@ -120,6 +120,43 @@ Pin it in a runner with:
 sources=("local:/data/pmxt/raw",)
 ```
 
+### Import DepthFeed snapshots
+
+[DepthFeed](https://depthfeed.com) exposes full Polymarket outcome books through
+its paginated REST API. The repository includes a bounded importer that writes
+those full snapshots into the PMXT legacy parquet layout, so they can be replayed
+through the existing PMXT adapter without introducing a second execution path.
+
+Set a DepthFeed API key and import one exact market and time window:
+
+```bash
+export DEPTHFEED_API_KEY=df_your_key
+make download-depthfeed-data \
+  DEPTHFEED_DATA_DESTINATION=/data/depthfeed-pmxt \
+  DEPTHFEED_DOWNLOAD_FLAGS='\
+    --coin btc \
+    --market-id 3107661 \
+    --start-time 2026-07-26T04:00:00Z \
+    --end-time 2026-07-26T08:00:00Z'
+```
+
+Then point a Polymarket PMXT runner at the generated mirror:
+
+```python
+sources=("local:/data/depthfeed-pmxt",)
+```
+
+The importer requests `include_orderbook=true`, emits both outcome tokens as
+full `book_snapshot` events, follows keyset pagination, deduplicates repeated
+snapshots, and writes atomically. Existing legacy-schema hours are merged.
+Fixed-column PMXT hours are rejected instead of mixing incompatible parquet
+schemas; use a separate destination for the DepthFeed mirror in that case.
+
+This path supplies L2 book state. The replay adapter still sources real trade
+ticks independently for execution matching. Availability and history remain
+bounded by the DepthFeed plan attached to `DEPTHFEED_API_KEY`; use exact market
+ids returned by the API rather than constructing ids.
+
 ### Required Parquet Columns
 
 Raw PMXT archive parquet may use the legacy payload schema:

--- a/scripts/depthfeed_download_data.py
+++ b/scripts/depthfeed_download_data.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+DEPTHFEED_API_KEY_ENV = "DEPTHFEED_API_KEY"
+DEFAULT_API_BASE = "https://api.depthfeed.com"
+USER_AGENT = "prediction-market-backtesting/1.0"
+LEGACY_COLUMNS = ("market_id", "update_type", "data")
+
+
+@dataclass(frozen=True)
+class DownloadSummary:
+    market_id: str
+    condition_id: str
+    snapshots: int
+    rows: int
+    files: tuple[str, ...]
+    pages: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "market_id": self.market_id,
+            "condition_id": self.condition_id,
+            "snapshots": self.snapshots,
+            "rows": self.rows,
+            "files": list(self.files),
+            "pages": self.pages,
+        }
+
+
+class DepthFeedClient:
+    def __init__(self, *, api_key: str, api_base: str, timeout_secs: int) -> None:
+        key = api_key.strip()
+        if not key:
+            raise ValueError(
+                f"Set {DEPTHFEED_API_KEY_ENV} to a DepthFeed API key before downloading."
+            )
+        self.api_key = key
+        self.api_base = api_base.rstrip("/")
+        self.timeout_secs = max(1, timeout_secs)
+
+    def get(self, path: str, params: dict[str, object] | None = None) -> dict[str, Any]:
+        query = urlencode(
+            {
+                key: str(value).lower() if isinstance(value, bool) else value
+                for key, value in (params or {}).items()
+            }
+        )
+        url = f"{self.api_base}{path}"
+        if query:
+            url = f"{url}?{query}"
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        try:
+            with urlopen(request, timeout=self.timeout_secs) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"DepthFeed returned HTTP {exc.code} for {path}: {body}") from exc
+        except (URLError, TimeoutError) as exc:
+            raise RuntimeError(f"DepthFeed request failed for {path}: {exc}") from exc
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"DepthFeed returned invalid JSON for {path}.") from exc
+
+        if not isinstance(payload, dict):
+            raise TypeError(f"DepthFeed returned a non-object response for {path}.")
+        if "error" in payload:
+            raise RuntimeError(f"DepthFeed API error for {path}: {payload['error']}")
+        return payload
+
+
+def _timestamp_ms(snapshot: dict[str, Any]) -> int:
+    raw_id = snapshot.get("id")
+    try:
+        timestamp_ms = int(str(raw_id))
+    except (TypeError, ValueError):
+        raw_time = snapshot.get("time")
+        if not isinstance(raw_time, str) or not raw_time.strip():
+            raise ValueError("Snapshot is missing both a millisecond id and time.")
+        normalized = raw_time.strip().replace(" ", "T")
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        timestamp_ms = int(parsed.timestamp() * 1_000)
+    if timestamp_ms <= 0:
+        raise ValueError(f"Invalid snapshot timestamp: {timestamp_ms}")
+    return timestamp_ms
+
+
+def _decimal_text(value: object) -> str:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"Invalid order-book number: {value!r}") from exc
+    if not parsed.is_finite():
+        raise ValueError(f"Non-finite order-book number: {value!r}")
+    return format(parsed, "f")
+
+
+def _levels(value: object, *, side: str) -> list[list[str]]:
+    if not isinstance(value, list):
+        raise TypeError(f"Snapshot {side} levels must be a list.")
+    levels: list[list[str]] = []
+    for level in value:
+        if not isinstance(level, list | tuple) or len(level) != 2:
+            raise ValueError(f"Invalid {side} level: {level!r}")
+        price = _decimal_text(level[0])
+        size = _decimal_text(level[1])
+        if Decimal(price) <= 0 or Decimal(size) <= 0:
+            continue
+        levels.append([price, size])
+    return levels
+
+
+def _book_payload(
+    *,
+    snapshot: dict[str, Any],
+    condition_id: str,
+    token_id: str,
+    book_key: str,
+) -> str:
+    book = snapshot.get(book_key)
+    if not isinstance(book, dict):
+        raise TypeError(
+            f"Snapshot is missing {book_key}; request include_orderbook=true and verify plan access."
+        )
+    timestamp_ms = _timestamp_ms(snapshot)
+    payload = {
+        "asks": _levels(book.get("asks"), side=f"{book_key}.asks"),
+        "bids": _levels(book.get("bids"), side=f"{book_key}.bids"),
+        "market_id": condition_id,
+        "timestamp": timestamp_ms / 1_000,
+        "token_id": token_id,
+        "update_type": "book_snapshot",
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def snapshot_rows(
+    snapshot: dict[str, Any],
+    *,
+    condition_id: str,
+    token_up: str,
+    token_down: str,
+) -> list[dict[str, str]]:
+    return [
+        {
+            "market_id": condition_id,
+            "update_type": "book_snapshot",
+            "data": _book_payload(
+                snapshot=snapshot,
+                condition_id=condition_id,
+                token_id=token_up,
+                book_key="orderbook_up",
+            ),
+        },
+        {
+            "market_id": condition_id,
+            "update_type": "book_snapshot",
+            "data": _book_payload(
+                snapshot=snapshot,
+                condition_id=condition_id,
+                token_id=token_down,
+                book_key="orderbook_down",
+            ),
+        },
+    ]
+
+
+def _hour_path(destination: Path, timestamp_ms: int) -> Path:
+    stamp = datetime.fromtimestamp(timestamp_ms / 1_000, tz=UTC)
+    return (
+        destination
+        / f"{stamp.year:04d}"
+        / f"{stamp.month:02d}"
+        / f"{stamp.day:02d}"
+        / f"polymarket_orderbook_{stamp:%Y-%m-%dT%H}.parquet"
+    )
+
+
+def _row_sort_key(row: dict[str, str]) -> tuple[float, str]:
+    payload = json.loads(row["data"])
+    return float(payload["timestamp"]), str(payload["token_id"])
+
+
+def _write_hour(
+    path: Path,
+    rows: list[dict[str, str]],
+    *,
+    condition_id: str,
+    overwrite: bool,
+) -> int:
+    existing_rows: list[dict[str, str]] = []
+    if path.exists():
+        existing = pq.read_table(path)
+        if not set(LEGACY_COLUMNS).issubset(existing.schema.names):
+            raise ValueError(
+                f"{path} uses the PMXT fixed-column schema. Use a separate destination "
+                "for DepthFeed legacy rows instead of mixing schemas."
+            )
+        if overwrite:
+            existing = existing.filter(pc.not_equal(existing["market_id"], condition_id))
+        existing_rows = [
+            {name: str(row[name]) for name in LEGACY_COLUMNS}
+            for row in existing.select(LEGACY_COLUMNS).to_pylist()
+        ]
+
+    unique: dict[tuple[str, str, str], dict[str, str]] = {}
+    for row in [*existing_rows, *rows]:
+        unique[(row["market_id"], row["update_type"], row["data"])] = row
+    merged = sorted(unique.values(), key=_row_sort_key)
+    table = pa.Table.from_pylist(
+        merged, schema=pa.schema([(name, pa.string()) for name in LEGACY_COLUMNS])
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        pq.write_table(table, temporary, compression="zstd")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return len({(row["market_id"], row["update_type"], row["data"]) for row in rows})
+
+
+def download_market(
+    *,
+    client: DepthFeedClient,
+    destination: Path,
+    coin: str,
+    market_id: str,
+    start_time: str | None,
+    end_time: str | None,
+    overwrite: bool,
+    max_pages: int | None,
+) -> DownloadSummary:
+    market_path = f"/v3/{quote(coin, safe='')}/markets/{quote(market_id, safe='')}"
+    market_response = client.get(market_path)
+    market = market_response.get("data")
+    if not isinstance(market, dict):
+        raise TypeError("DepthFeed market response is missing data.")
+
+    condition_id = str(market.get("condition_id") or "").strip()
+    token_up = str(market.get("clob_token_up") or "").strip()
+    token_down = str(market.get("clob_token_down") or "").strip()
+    if not condition_id or not token_up or not token_down:
+        raise RuntimeError(
+            "DepthFeed market metadata is missing condition_id or CLOB outcome token ids."
+        )
+
+    snapshot_path = f"{market_path}/snapshots"
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    seen_snapshots: set[tuple[int, str]] = set()
+    rows_by_hour: dict[Path, list[dict[str, str]]] = defaultdict(list)
+    pages = 0
+
+    while True:
+        params: dict[str, object] = {"include_orderbook": True, "limit": 1_000}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
+        if cursor:
+            params["cursor"] = cursor
+        response = client.get(snapshot_path, params)
+        pages += 1
+        data = response.get("data")
+        if not isinstance(data, list):
+            raise TypeError("DepthFeed snapshots response is missing a data array.")
+        for raw_snapshot in data:
+            if not isinstance(raw_snapshot, dict):
+                continue
+            timestamp_ms = _timestamp_ms(raw_snapshot)
+            snapshot_key = (timestamp_ms, json.dumps(raw_snapshot, sort_keys=True))
+            if snapshot_key in seen_snapshots:
+                continue
+            seen_snapshots.add(snapshot_key)
+            rows_by_hour[_hour_path(destination, timestamp_ms)].extend(
+                snapshot_rows(
+                    raw_snapshot,
+                    condition_id=condition_id,
+                    token_up=token_up,
+                    token_down=token_down,
+                )
+            )
+
+        pagination = response.get("pagination")
+        if not isinstance(pagination, dict) or not pagination.get("has_more"):
+            break
+        next_cursor = str(pagination.get("next_cursor") or "").strip()
+        if not next_cursor or next_cursor in seen_cursors:
+            raise RuntimeError("DepthFeed pagination repeated or omitted next_cursor.")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+        if max_pages is not None and pages >= max_pages:
+            break
+
+    files: list[str] = []
+    rows_written = 0
+    for path, rows in sorted(rows_by_hour.items()):
+        rows_written += _write_hour(
+            path,
+            rows,
+            condition_id=condition_id,
+            overwrite=overwrite,
+        )
+        files.append(str(path))
+
+    return DownloadSummary(
+        market_id=market_id,
+        condition_id=condition_id,
+        snapshots=len(seen_snapshots),
+        rows=rows_written,
+        files=tuple(files),
+        pages=pages,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download one DepthFeed Polymarket L2 snapshot window into the local "
+            "PMXT legacy parquet layout used by this repository."
+        )
+    )
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument(
+        "--coin", required=True, choices=("btc", "eth", "sol", "xrp", "doge", "bnb", "hype")
+    )
+    parser.add_argument("--market-id", required=True)
+    parser.add_argument("--start-time", default=None)
+    parser.add_argument("--end-time", default=None)
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    parser.add_argument("--timeout-secs", type=int, default=60)
+    parser.add_argument("--max-pages", type=int, default=None)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    api_key = os.getenv(DEPTHFEED_API_KEY_ENV, "")
+    client = DepthFeedClient(
+        api_key=api_key,
+        api_base=args.api_base,
+        timeout_secs=args.timeout_secs,
+    )
+    summary = download_market(
+        client=client,
+        destination=args.destination,
+        coin=args.coin,
+        market_id=args.market_id,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        overwrite=args.overwrite,
+        max_pages=args.max_pages,
+    )
+    print(json.dumps(summary.as_dict(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_depthfeed_data_download.py
+++ b/tests/test_depthfeed_data_download.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from scripts.depthfeed_download_data import (
+    DepthFeedClient,
+    _hour_path,
+    _write_hour,
+    download_market,
+    snapshot_rows,
+)
+
+
+def _snapshot(timestamp_ms: int = 1_768_780_800_123) -> dict[str, object]:
+    return {
+        "id": str(timestamp_ms),
+        "time": "2026-01-19 00:00:00.123",
+        "orderbook_up": {
+            "bids": [[0.42, 10], [0, 5]],
+            "asks": [[0.44, 11]],
+        },
+        "orderbook_down": {
+            "bids": [[0.56, 11]],
+            "asks": [[0.58, 10]],
+        },
+    }
+
+
+def test_snapshot_rows_emit_both_outcomes_in_pmxt_legacy_shape() -> None:
+    rows = snapshot_rows(
+        _snapshot(),
+        condition_id="0xcondition",
+        token_up="up-token",
+        token_down="down-token",
+    )
+
+    assert [row["update_type"] for row in rows] == ["book_snapshot", "book_snapshot"]
+    payloads = [json.loads(row["data"]) for row in rows]
+    assert [payload["token_id"] for payload in payloads] == ["up-token", "down-token"]
+    assert payloads[0]["market_id"] == "0xcondition"
+    assert payloads[0]["timestamp"] == 1_768_780_800.123
+    assert payloads[0]["bids"] == [["0.42", "10"]]
+    assert payloads[0]["asks"] == [["0.44", "11"]]
+
+
+def test_hour_path_matches_pmxt_local_raw_layout(tmp_path: Path) -> None:
+    assert _hour_path(tmp_path, 1_768_780_800_123) == (
+        tmp_path / "2026" / "01" / "19" / "polymarket_orderbook_2026-01-19T00.parquet"
+    )
+
+
+def test_write_hour_merges_and_deduplicates_legacy_rows(tmp_path: Path) -> None:
+    path = _hour_path(tmp_path, 1_768_780_800_123)
+    rows = snapshot_rows(
+        _snapshot(),
+        condition_id="0xcondition",
+        token_up="up-token",
+        token_down="down-token",
+    )
+
+    assert _write_hour(path, rows, condition_id="0xcondition", overwrite=False) == 2
+    assert _write_hour(path, rows, condition_id="0xcondition", overwrite=False) == 2
+    table = pq.read_table(path)
+    assert table.schema.names == ["market_id", "update_type", "data"]
+    assert table.num_rows == 2
+
+
+def test_write_hour_refuses_to_mix_fixed_and_legacy_schemas(tmp_path: Path) -> None:
+    path = _hour_path(tmp_path, 1_768_780_800_123)
+    path.parent.mkdir(parents=True)
+    pq.write_table(pa.table({"timestamp": [1], "market": ["0xcondition"]}), path)
+
+    with pytest.raises(ValueError, match="fixed-column schema"):
+        _write_hour(
+            path,
+            snapshot_rows(
+                _snapshot(),
+                condition_id="0xcondition",
+                token_up="up-token",
+                token_down="down-token",
+            ),
+            condition_id="0xcondition",
+            overwrite=False,
+        )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the existing Telonex module imports resource")
+def test_generated_file_is_readable_by_pmxt_loader(tmp_path: Path) -> None:
+    from prediction_market_extensions.backtesting.data_sources.pmxt import (
+        RunnerPolymarketPMXTDataLoader,
+    )
+
+    path = _hour_path(tmp_path, 1_768_780_800_123)
+    rows = snapshot_rows(
+        _snapshot(),
+        condition_id="0xcondition",
+        token_up="up-token",
+        token_down="down-token",
+    )
+    _write_hour(path, rows, condition_id="0xcondition", overwrite=False)
+
+    loader = object.__new__(RunnerPolymarketPMXTDataLoader)
+    loader._pmxt_raw_root = tmp_path
+    loader._pmxt_cache_dir = None
+    loader._pmxt_progress_size_cache = {}
+    loader._pmxt_scan_progress_callback = None
+    loader._condition_id = "0xcondition"
+    loader._token_id = "up-token"
+
+    batches = loader._load_local_raw_market_batches(
+        pd.Timestamp("2026-01-19T00:00:00Z"),
+        batch_size=1_000,
+    )
+
+    assert batches is not None
+    assert sum(batch.num_rows for batch in batches) == 1
+    assert json.loads(batches[0].column("data")[0].as_py())["token_id"] == "up-token"
+
+
+def test_download_market_pages_deduplicates_snapshots_and_writes_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, dict[str, object] | None]] = []
+
+    def fake_get(
+        self: DepthFeedClient,
+        path: str,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        del self
+        calls.append((path, params))
+        if path.endswith("/markets/123"):
+            return {
+                "data": {
+                    "condition_id": "0xcondition",
+                    "clob_token_up": "up-token",
+                    "clob_token_down": "down-token",
+                }
+            }
+        if params and params.get("cursor") == "next":
+            return {
+                "data": [_snapshot(1_768_780_801_000)],
+                "pagination": {"has_more": False, "next_cursor": None},
+            }
+        return {
+            "data": [_snapshot(), _snapshot()],
+            "pagination": {"has_more": True, "next_cursor": "next"},
+        }
+
+    monkeypatch.setattr(DepthFeedClient, "get", fake_get)
+    client = DepthFeedClient(api_key="df_test", api_base="https://api.test", timeout_secs=1)
+    summary = download_market(
+        client=client,
+        destination=tmp_path,
+        coin="btc",
+        market_id="123",
+        start_time="2026-01-19T00:00:00Z",
+        end_time="2026-01-19T01:00:00Z",
+        overwrite=False,
+        max_pages=None,
+    )
+
+    assert summary.snapshots == 2
+    assert summary.rows == 4
+    assert summary.pages == 2
+    assert len(summary.files) == 1
+    assert pq.read_table(summary.files[0]).num_rows == 4
+    assert calls[1][1] == {
+        "include_orderbook": True,
+        "limit": 1_000,
+        "start_time": "2026-01-19T00:00:00Z",
+        "end_time": "2026-01-19T01:00:00Z",
+    }
+    assert calls[2][1] == {
+        "include_orderbook": True,
+        "limit": 1_000,
+        "start_time": "2026-01-19T00:00:00Z",
+        "end_time": "2026-01-19T01:00:00Z",
+        "cursor": "next",
+    }


### PR DESCRIPTION
## Summary

Add a bounded importer that converts DepthFeed Polymarket full-book snapshots into this repository's existing PMXT legacy parquet layout.

The importer:
- discovers the condition and both outcome token ids from one exact market id
- requests full order books with `include_orderbook=true`
- follows cursor pagination and deduplicates repeated snapshots
- emits both outcome tokens as full `book_snapshot` events
- merges legacy-schema hours atomically and refuses to mix with fixed-column PMXT files
- exposes a Make target and documents the local replay workflow

This keeps replay on the existing PMXT adapter and leaves trade-tick sourcing unchanged.

## Validation

- `ruff format --check` on the new script/test: passed
- `ruff check` on the new script/test: passed
- focused pytest: 5 passed, 1 Windows-only skip
- generated parquet compatibility test is enabled on Linux CI and skipped on Windows because the existing Telonex module imports the POSIX-only `resource` module
- `mkdocs build --strict`: passed with the versions pinned by the docs workflow
- `scripts/generate_codebase_uml.py`: refreshed `CODEBASE_UML.md`
- CLI `--help` smoke: passed

I did not run an authenticated live download because no DepthFeed API key was available in this environment; HTTP behavior is isolated behind `DepthFeedClient` and pagination/conversion/writes are covered with deterministic tests.

Disclosure: I maintain DepthFeed.